### PR TITLE
feat: create eslint-plugin base on lint-md API to get reliable IDE support

### DIFF
--- a/src/helper/eslint-plugin-lint-md/.gitignore
+++ b/src/helper/eslint-plugin-lint-md/.gitignore
@@ -1,0 +1,1 @@
+src/rules/noArgsRules

--- a/src/helper/eslint-plugin-lint-md/README.md
+++ b/src/helper/eslint-plugin-lint-md/README.md
@@ -1,0 +1,55 @@
+# eslint-plugin-lint-md
+
+依靠各个 IDE 对 eslint 不错的支持，让 lint-md 玩家也能得到愉悦的文档编写体验。
+
+![](https://user-images.githubusercontent.com/56540811/110348136-48bb7480-806c-11eb-89ec-ad9ee2ab42f1.png)
+
+## 安装
+
+> **npm i eslint eslint-plugin-lint-md**
+
+
+## 使用
+
+为你的 `.eslintrc.js` 追加以下配置，其中 `rules` 请参考 [lint-md](https://github.com/lint-md/lint-md#%E6%A3%80%E6%9F%A5%E7%B1%BB%E5%9E%8B)
+
+```javascript
+module.exports = {
+  plugins: [
+    'lint-md'
+  ],
+  overrides: [
+    {
+      files: ['*.md'],
+      parser: 'eslint-plugin-lint-md/src/parser',
+      rules: {
+        // rules 在这里自定义
+        'lint-md/space-round-alphabet': ["warn"],
+        'lint-md/no-empty-list': ["warn"],
+        'lint-md/no-long-code': [2, {
+          "length": 10,
+          "exclude": []
+        }]
+      }
+    },
+  ]
+}
+```
+
+如果你喜欢 `vscode`，那么请安装 `eslint` 插件，然后为 `settings.json` 添加以下配置：
+
+```json
+{
+    "eslint.validate": ["markdown"]
+}
+```
+
+
+如果你喜欢 `webstorm`，请按下图配置以支持 `.md` 后缀文件：
+
+![](http://cdn.yuzzl.top/blog/20210309004301.png)
+
+> TIP：webstorm 2021.1 版本开始支持非 js 的扩展名文件（用户可自行配置），现在这个版本处于测试阶段，应该离 release 不远了。
+
+
+**hope you enjoy it！**

--- a/src/helper/eslint-plugin-lint-md/package.json
+++ b/src/helper/eslint-plugin-lint-md/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-lint-md",
-  "version": "1.0.0",
+  "version": "0.0.2",
   "description": "",
   "main": "./src/index.js",
   "scripts": {
@@ -12,5 +12,8 @@
   "license": "ISC",
   "dependencies": {
     "lint-md": "^0.2.0"
-  }
+  },
+  "files": [
+    "src"
+  ]
 }

--- a/src/helper/eslint-plugin-lint-md/package.json
+++ b/src/helper/eslint-plugin-lint-md/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "eslint-plugin-lint-md",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "sync-rules": "node ./src/ruleGenerator.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "lint-md": "^0.2.0"
+  }
+}

--- a/src/helper/eslint-plugin-lint-md/package.json
+++ b/src/helper/eslint-plugin-lint-md/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-plugin-lint-md",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "./src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "sync-rules": "node ./src/ruleGenerator.js"

--- a/src/helper/eslint-plugin-lint-md/src/constants.js
+++ b/src/helper/eslint-plugin-lint-md/src/constants.js
@@ -1,0 +1,20 @@
+/*
+ * File: constants.ts
+ * Description: 保存常量
+ * Created: 2021-3-8 21:28:22
+ * Author: yuzhanglong
+ * Email: yuzl1123@163.com
+ */
+
+
+// 不可以 fix 的 rule
+const NOT_SUPPORTED_FIX = ['no-long-code']
+
+// 带参 rules，此类 rules 单独处理，不通过模板写入
+const ARGS_RULES = ['no-long-code']
+
+
+module.exports = {
+  NOT_SUPPORTED_FIX,
+  ARGS_RULES
+}

--- a/src/helper/eslint-plugin-lint-md/src/index.js
+++ b/src/helper/eslint-plugin-lint-md/src/index.js
@@ -1,0 +1,14 @@
+const rules = require('./rules/index')
+module.exports = {
+  processors: {
+    ".md": {
+      preprocess: function (text) {
+        return [text];
+      },
+      postprocess: function (messages) {
+        return messages[0];
+      }
+    }
+  },
+  rules: rules
+}

--- a/src/helper/eslint-plugin-lint-md/src/index.js
+++ b/src/helper/eslint-plugin-lint-md/src/index.js
@@ -6,8 +6,9 @@ module.exports = {
         return [text];
       },
       postprocess: function (messages) {
-        return messages[0];
-      }
+        return messages.flat();
+      },
+      supportsAutofix: true
     }
   },
   rules: rules

--- a/src/helper/eslint-plugin-lint-md/src/parser.js
+++ b/src/helper/eslint-plugin-lint-md/src/parser.js
@@ -1,5 +1,15 @@
+/*
+ * File: constants.ts
+ * Description: 面向 md 文件的 eslint 自定义 parser
+ * Created: 2021-3-8 21:40:24
+ * Author: yuzhanglong
+ * Email: yuzl1123@163.com
+ */
+
 module.exports = {
-  parseForESLint(code, config) {
+  // md parser，使用一个定死的 ast，将 code 传给 Literal 的 value，
+  // 这样，我们可以在 自定义的 eslint-rule 中的 Literal() 拿到它，然后查错 / fix it
+  parseForESLint(code) {
     return {
       ast: {
         type: 'Program',

--- a/src/helper/eslint-plugin-lint-md/src/parser.js
+++ b/src/helper/eslint-plugin-lint-md/src/parser.js
@@ -1,0 +1,46 @@
+module.exports = {
+  parseForESLint(code, config) {
+    return {
+      ast: {
+        type: 'Program',
+        start: 0,
+        end: 0,
+        loc: {
+          start: {
+            line: 1,
+            column: 0
+          },
+          end: {
+            line: 1,
+            column: 0
+          }
+        },
+        range: [0, 0],
+        body: [
+          {
+            "type": "ExpressionStatement",
+            "start": 0,
+            "end": 1,
+            "range": [
+              0,
+              1
+            ],
+            "expression": {
+              "type": "Literal",
+              "start": 0,
+              "end": 1,
+              "range": [
+                0,
+                1
+              ],
+              "value": code,
+              "raw": "1"
+            }
+          }
+        ],
+        tokens: [],
+        comments: []
+      }
+    }
+  },
+}

--- a/src/helper/eslint-plugin-lint-md/src/ruleGenerator.js
+++ b/src/helper/eslint-plugin-lint-md/src/ruleGenerator.js
@@ -1,3 +1,16 @@
+/*
+ * File: constants.ts
+ * Description: rules 生成器
+ *
+ * 对于一些无参 rules(几乎所有)
+ * 我们直接基于 lint-md 生成相应的模板，
+ * 这样无需再去花费大量时间单独写 rules
+ *
+ * Created: 2021-3-8 23:38:56
+ * Author: yuzhanglong
+ * Email: yuzl1123@163.com
+ */
+
 const path = require('path')
 const fs = require("fs");
 const {getTotalRuleNames} = require("./utils");

--- a/src/helper/eslint-plugin-lint-md/src/ruleGenerator.js
+++ b/src/helper/eslint-plugin-lint-md/src/ruleGenerator.js
@@ -1,20 +1,12 @@
-const fs = require('fs')
 const path = require('path')
+const fs = require("fs");
+const {getTotalRuleNames} = require("./utils");
 const {getTemplateHeaderComment} = require("./utils");
 const {NOT_SUPPORTED_FIX} = require("./constants");
 
 // paths
-const ruleDir = path.resolve(__dirname, '../../../lint-rules')
 const templatePath = path.resolve(__dirname, './ruleTemplate.js')
-const eslintRuleDir = path.resolve(__dirname, './rules')
-
-// 获取 lint-md 下的所有 rules
-const getTotalRuleNames = () => {
-  const ruleFiles = fs.readdirSync(ruleDir)
-  return ruleFiles
-    .filter(res => (res !== 'index.js' && res.endsWith('.js')))
-    .map(data => data.slice(0, -3))
-}
+const eslintRuleDir = path.resolve(__dirname, './rules/noArgsRules')
 
 // 生成 eslint rules 文件
 const generateRuleCode = () => {
@@ -31,11 +23,11 @@ const generateRuleCode = () => {
       .replace(/\$FIXABLE\$/g, NOT_SUPPORTED_FIX.indexOf(name) >= 0 ? false : '"code"')
 
     fs.writeFileSync(path.resolve(eslintRuleDir, `${name}.js`), `${comment}${result}`)
-    data += `  '${name}': require('./${name}'),\n`
+    data += `  '${name}': require('./noArgsRules/${name}'),\n`
   })
   data += '}'
 
-  fs.writeFileSync(path.resolve(eslintRuleDir, 'index.js'), `${getTemplateHeaderComment()}${data}`)
+  fs.writeFileSync(path.resolve(path.resolve(eslintRuleDir, '../'), 'index.js'), `${getTemplateHeaderComment()}${data}`)
 }
 
 generateRuleCode()

--- a/src/helper/eslint-plugin-lint-md/src/ruleGenerator.js
+++ b/src/helper/eslint-plugin-lint-md/src/ruleGenerator.js
@@ -5,6 +5,8 @@ const ruleDir = path.resolve(__dirname, '../../../lint-rules')
 const templatePath = path.resolve(__dirname, './ruleTemplate.js')
 const eslintRuleDir = path.resolve(__dirname, './rules')
 
+const NOT_SUPPORTED_FIX = ['no-long-code']
+
 const HEADERS = `/*
  * IMPORTANT!
  * This file has been automatically generated,
@@ -27,7 +29,10 @@ const generateRuleCode = () => {
 
   // 生成 rules && index.js
   rules.forEach(name => {
-    const result = template.toString().replace('$MD_LINT_RULE_NAME$', name)
+    const result = template.toString()
+      .replace(/\$MD_LINT_RULE_NAME\$/g, name)
+      .replace(/\$FIXABLE\$/g, NOT_SUPPORTED_FIX.indexOf(name) >= 0 ? false : '"code"')
+
     fs.writeFileSync(path.resolve(eslintRuleDir, `${name}.js`), `${HEADERS}${result}`)
     data += `  '${name}': require('./${name}'),\n`
   })

--- a/src/helper/eslint-plugin-lint-md/src/ruleGenerator.js
+++ b/src/helper/eslint-plugin-lint-md/src/ruleGenerator.js
@@ -12,7 +12,7 @@ const eslintRuleDir = path.resolve(__dirname, './rules/noArgsRules')
 const generateRuleCode = () => {
   const template = fs.readFileSync(templatePath)
   const rules = getTotalRuleNames()
-  let data = 'module.exports = {\n'
+  let data = `module.exports = {\n  'no-long-code': require('./no-long-code'),\n`
 
   // 生成 rules && index.js
   rules.forEach(name => {

--- a/src/helper/eslint-plugin-lint-md/src/ruleGenerator.js
+++ b/src/helper/eslint-plugin-lint-md/src/ruleGenerator.js
@@ -1,19 +1,14 @@
 const fs = require('fs')
 const path = require('path')
+const {getTemplateHeaderComment} = require("./utils");
+const {NOT_SUPPORTED_FIX} = require("./constants");
 
+// paths
 const ruleDir = path.resolve(__dirname, '../../../lint-rules')
 const templatePath = path.resolve(__dirname, './ruleTemplate.js')
 const eslintRuleDir = path.resolve(__dirname, './rules')
 
-const NOT_SUPPORTED_FIX = ['no-long-code']
-
-const HEADERS = `/*
- * IMPORTANT!
- * This file has been automatically generated,
- * in order to update it's content execute "npm run sync-rules"
- */\n\n`
-
-
+// 获取 lint-md 下的所有 rules
 const getTotalRuleNames = () => {
   const ruleFiles = fs.readdirSync(ruleDir)
   return ruleFiles
@@ -21,7 +16,7 @@ const getTotalRuleNames = () => {
     .map(data => data.slice(0, -3))
 }
 
-
+// 生成 eslint rules 文件
 const generateRuleCode = () => {
   const template = fs.readFileSync(templatePath)
   const rules = getTotalRuleNames()
@@ -29,15 +24,18 @@ const generateRuleCode = () => {
 
   // 生成 rules && index.js
   rules.forEach(name => {
+    const comment = getTemplateHeaderComment(name)
+
     const result = template.toString()
       .replace(/\$MD_LINT_RULE_NAME\$/g, name)
       .replace(/\$FIXABLE\$/g, NOT_SUPPORTED_FIX.indexOf(name) >= 0 ? false : '"code"')
 
-    fs.writeFileSync(path.resolve(eslintRuleDir, `${name}.js`), `${HEADERS}${result}`)
+    fs.writeFileSync(path.resolve(eslintRuleDir, `${name}.js`), `${comment}${result}`)
     data += `  '${name}': require('./${name}'),\n`
   })
   data += '}'
-  fs.writeFileSync(path.resolve(eslintRuleDir, 'index.js'), `${HEADERS}${data}`)
+
+  fs.writeFileSync(path.resolve(eslintRuleDir, 'index.js'), `${getTemplateHeaderComment()}${data}`)
 }
 
 generateRuleCode()

--- a/src/helper/eslint-plugin-lint-md/src/ruleGenerator.js
+++ b/src/helper/eslint-plugin-lint-md/src/ruleGenerator.js
@@ -1,0 +1,39 @@
+const fs = require('fs')
+const path = require('path')
+
+const ruleDir = path.resolve(__dirname, '../../../lint-rules')
+const templatePath = path.resolve(__dirname, './ruleTemplate.js')
+const eslintRuleDir = path.resolve(__dirname, './rules')
+
+const HEADERS = `/*
+ * IMPORTANT!
+ * This file has been automatically generated,
+ * in order to update it's content execute "npm run sync-rules"
+ */\n\n`
+
+
+const getTotalRuleNames = () => {
+  const ruleFiles = fs.readdirSync(ruleDir)
+  return ruleFiles
+    .filter(res => (res !== 'index.js' && res.endsWith('.js')))
+    .map(data => data.slice(0, -3))
+}
+
+
+const generateRuleCode = () => {
+  const template = fs.readFileSync(templatePath)
+  const rules = getTotalRuleNames()
+  let data = 'module.exports = {\n'
+
+  // 生成 rules && index.js
+  rules.forEach(name => {
+    const result = template.toString().replace('$MD_LINT_RULE_NAME$', name)
+    fs.writeFileSync(path.resolve(eslintRuleDir, `${name}.js`), `${HEADERS}${result}`)
+    data += `  '${name}': require('./${name}'),\n`
+  })
+  data += '}'
+  fs.writeFileSync(path.resolve(eslintRuleDir, 'index.js'), `${HEADERS}${data}`)
+}
+
+generateRuleCode()
+

--- a/src/helper/eslint-plugin-lint-md/src/ruleTemplate.js
+++ b/src/helper/eslint-plugin-lint-md/src/ruleTemplate.js
@@ -1,15 +1,32 @@
 const {lint, getDescription} = require('lint-md')
 const baseFixer = require('lint-md/lib/fix').fix
 
+// 该 rule 是否可以 fix
+const FIXABLE = $FIXABLE$
+
 module.exports = {
   meta: {
     type: 'suggestion',
-    fixable: $FIXABLE$
+    fixable: FIXABLE
   },
   create(context) {
+    // 获取 fixer
+    const getFixer = (node) => {
+      return FIXABLE ? {
+        fix: (fixer) => {
+          const newMarkdown = baseFixer(node.value)
+          return fixer.replaceTextRange(
+            [0, node.value.length - 1],
+            newMarkdown
+          );
+        }
+      } : {}
+    }
+
     return {
       Literal(node) {
         if (node.value) {
+          // 调用 lint 函数
           const errors = lint(node.value);
           const resultErr = errors.filter(e => e.type === '$MD_LINT_RULE_NAME$')
           for (let err of resultErr) {
@@ -20,13 +37,7 @@ module.exports = {
                 start: err.start,
                 end: err.end
               },
-              fix: function (fixer) {
-                const newMarkdown = baseFixer(node.value)
-                return fixer.replaceTextRange(
-                  [0, node.value.length - 1],
-                  newMarkdown
-                );
-              }
+              ...getFixer(node)
             })
           }
         }

--- a/src/helper/eslint-plugin-lint-md/src/ruleTemplate.js
+++ b/src/helper/eslint-plugin-lint-md/src/ruleTemplate.js
@@ -1,0 +1,28 @@
+const {lint, getDescription} = require('lint-md')
+
+module.exports = {
+  meta: {
+    messages: {
+      invalidName: 'TODO'
+    }
+  },
+  create(context) {
+    return {
+      Literal(node) {
+        if (node.value) {
+          const errors = lint(node.value, ['$MD_LINT_RULE_NAME$']);
+          for (let err of errors) {
+            const describe = getDescription(err.type)
+            context.report({
+              message: describe.message,
+              loc: {
+                start: err.start,
+                end: err.end
+              },
+            })
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/helper/eslint-plugin-lint-md/src/ruleTemplate.js
+++ b/src/helper/eslint-plugin-lint-md/src/ruleTemplate.js
@@ -1,17 +1,18 @@
 const {lint, getDescription} = require('lint-md')
+const baseFixer = require('lint-md/lib/fix').fix
 
 module.exports = {
   meta: {
-    messages: {
-      invalidName: 'TODO'
-    }
+    type: 'suggestion',
+    fixable: $FIXABLE$
   },
   create(context) {
     return {
       Literal(node) {
         if (node.value) {
-          const errors = lint(node.value, ['$MD_LINT_RULE_NAME$']);
-          for (let err of errors) {
+          const errors = lint(node.value);
+          const resultErr = errors.filter(e => e.type === '$MD_LINT_RULE_NAME$')
+          for (let err of resultErr) {
             const describe = getDescription(err.type)
             context.report({
               message: describe.message,
@@ -19,6 +20,13 @@ module.exports = {
                 start: err.start,
                 end: err.end
               },
+              fix: function (fixer) {
+                const newMarkdown = baseFixer(node.value)
+                return fixer.replaceTextRange(
+                  [0, node.value.length - 1],
+                  newMarkdown
+                );
+              }
             })
           }
         }

--- a/src/helper/eslint-plugin-lint-md/src/rules/index.js
+++ b/src/helper/eslint-plugin-lint-md/src/rules/index.js
@@ -1,0 +1,28 @@
+/*
+ * IMPORTANT!
+ * This file has been automatically generated,
+ * in order to update it's content execute "npm run sync-rules"
+ *
+ * @created: Mon Mar 08 2021 
+ */
+
+module.exports = {
+  'no-long-code': require('./no-long-code'),
+  'no-empty-blockquote': require('./noArgsRules/no-empty-blockquote'),
+  'no-empty-code-lang': require('./noArgsRules/no-empty-code-lang'),
+  'no-empty-code': require('./noArgsRules/no-empty-code'),
+  'no-empty-delete': require('./noArgsRules/no-empty-delete'),
+  'no-empty-inlinecode': require('./noArgsRules/no-empty-inlinecode'),
+  'no-empty-list': require('./noArgsRules/no-empty-list'),
+  'no-empty-url': require('./noArgsRules/no-empty-url'),
+  'no-fullwidth-number': require('./noArgsRules/no-fullwidth-number'),
+  'no-multiple-space-blockquote': require('./noArgsRules/no-multiple-space-blockquote'),
+  'no-space-in-emphasis': require('./noArgsRules/no-space-in-emphasis'),
+  'no-space-in-inlinecode': require('./noArgsRules/no-space-in-inlinecode'),
+  'no-space-in-link': require('./noArgsRules/no-space-in-link'),
+  'no-special-characters': require('./noArgsRules/no-special-characters'),
+  'no-trailing-punctuation': require('./noArgsRules/no-trailing-punctuation'),
+  'space-round-alphabet': require('./noArgsRules/space-round-alphabet'),
+  'space-round-number': require('./noArgsRules/space-round-number'),
+  'use-standard-ellipsis': require('./noArgsRules/use-standard-ellipsis'),
+}

--- a/src/helper/eslint-plugin-lint-md/src/rules/no-long-code.js
+++ b/src/helper/eslint-plugin-lint-md/src/rules/no-long-code.js
@@ -1,0 +1,61 @@
+/*
+ * IMPORTANT!
+ * This file has been automatically generated,
+ * in order to update it's content execute "npm run sync-rules"
+ *
+ * @created: Mon Mar 08 2021 
+ * @rule: no-long-code
+ */
+
+const {lint, getDescription} = require('lint-md')
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    fixable: false,
+    schema: [
+      {
+        "type": "object",
+        "properties": {
+          "length": {
+            "type": "number"
+          },
+          "exclude": {
+            "type": "Array"
+          },
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  create(context) {
+    return {
+      Literal(node) {
+        if (node.value) {
+          // 调用 lint 函数
+          const opt = Array.isArray(context.options) && context.options.length ? context.options[0] : {}
+          const errors = lint(node.value, {
+            // 将第一个参数设为 null 我们可以通过 .eslintrc.js 决定之
+            "no-long-code": [
+              null, {
+                "length": opt.length,
+                "exclude": opt.exclude || []
+              }
+            ]
+          });
+          const resultErr = errors.filter(e => e.type === 'no-long-code')
+          for (let err of resultErr) {
+            const describe = getDescription(err.type)
+            context.report({
+              message: describe.message,
+              loc: {
+                start: err.start,
+                end: err.end
+              }
+            })
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/helper/eslint-plugin-lint-md/src/utils.js
+++ b/src/helper/eslint-plugin-lint-md/src/utils.js
@@ -1,0 +1,36 @@
+/*
+ * File: utils.ts
+ * Description: 工具函数模块
+ * Created: 2021-3-8 21:29:46
+ * Author: yuzhanglong
+ * Email: yuzl1123@163.com
+ */
+const fs = require('fs')
+const path = require("path");
+const {ARGS_RULES} = require("./constants");
+
+// 模板导出文件头部注释信息输出
+const getTemplateHeaderComment = (rule, time, command = "npm run sync-rules") => {
+  return `/*
+ * IMPORTANT!
+ * This file has been automatically generated,
+ * in order to update it's content execute "${command}"
+ *
+ * @created: ${time || new Date().toDateString()} ${!rule ? '' : `\n * @rule: ${rule || 'undefined'}`}
+ */\n\n`
+}
+
+// 获取 lint-md 下的所有 rules
+const getTotalRuleNames = () => {
+  const ruleDir = path.resolve(__dirname, '../../../lint-rules')
+  const ruleFiles = fs.readdirSync(ruleDir)
+  return ruleFiles
+    .filter(res => (res !== 'index.js' && res.endsWith('.js')))
+    .map(data => data.slice(0, -3))
+    .filter(data => ARGS_RULES.indexOf(data) < 0)
+}
+
+module.exports = {
+  getTemplateHeaderComment,
+  getTotalRuleNames
+}


### PR DESCRIPTION
前辈您好！

前几天发现了这个宝藏项目，对中文 Markdown 代码检查非常友好，非常感谢您的帮助。

但每次写文章只能通过命令行调用来进行 lint && fix，写文时笔误在所难免，如果我们能通过 IDE，得到即时的反馈就更好了。

不过基于 lint-md 额外开发 vscode、jetbrains 等其它 IDE 的相关插件，工作量大，学习成本高。

于是今天花了点时间补充了一个 eslint 插件，依靠各个 IDE 对 eslint 不错的支持，让 lint-md 玩家也能得到愉悦的文档编写体验。

lint-md 原本的核心源码**没有任何改变**，所有的内容都是基于它提供的 API 实现，支持 fix。

下图是 vscode 和 webstorm 的效果：

![](https://user-images.githubusercontent.com/56540811/110348136-48bb7480-806c-11eb-89ec-ad9ee2ab42f1.png)


> vscode 需要 eslint 插件并在 settings.json 中配置 `"eslint.validate": ["markdown"]`，webstorm 2021.1 版本开始支持用户自定义检测文件扩展名，现在这个版本处于测试阶段，应该离 release 不远了。

查看插件根目录下的 README 以获取更多信息。