### PR TITLE
feat: add rule for 'space-round-inlinecode'

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ const fixed = fix(markdown);
 | ------ | ------ | ------ | ----- | ----- |
 | space-round-alphabet | 中文与英文之间需要增加空格 | 对应提示的位置增加空格 | | √ |
 | space-round-number | 中文与数字之间需要增加空格 | 对应提示的位置增加空格 | | √ |
+| space-round-inlinecode | 行内代码块之间需要增加空格 | 对应提示的位置增加空格 | | √ |
 | no-empty-code-lang | 代码语言不能为空 | 在代码块语法上增加语言 | | √ |
 | no-empty-delete | delete 块内容不能为空 | 删除空的 delete 文本块 | | √ |
 | no-empty-url | 链接和图片地址不能为空 | 填写完整的 url，或者不使用链接和图片语法 | | √ |

--- a/__tests__/fix-rules/no-trailing-punctuation.spec.ts
+++ b/__tests__/fix-rules/no-trailing-punctuation.spec.ts
@@ -7,7 +7,7 @@ describe('no-trailing-punctuation', () => {
   });
 
   test('fail', () => {
-    const md = `### header 3~~!~~**.**\`。\``;
+    const md = `### header 3~~!~~**.**\`。`;
     // expect(lint(md)).toEqual([]);
     expect(fix(md)).toBe('### header 3');
   });

--- a/__tests__/fix-rules/space-round-inlinecode.spec.ts
+++ b/__tests__/fix-rules/space-round-inlinecode.spec.ts
@@ -1,0 +1,33 @@
+import { fix } from '../../src';
+
+describe('space-round-inlinecode', () => {
+  test('no fix', () => {
+    const cases = [
+      '你好 `world` 世界',
+      '你好 `world`',
+      '`world` 世界',
+      '`world`',
+      '``world``',
+      '![img](img) `code`'
+    ];
+    cases.forEach(c => {
+      expect(fix(c)).toStrictEqual(c);
+    });
+  });
+
+  test('fix', () => {
+    const dataToFix = [
+      '你好 `world`世界',
+      '你好`world`世界',
+      '你好 `world`世界',
+      '![img](img)`code`'
+    ];
+    expect(dataToFix.map(data => fix(data)))
+      .toStrictEqual([
+        '你好 `world` 世界',
+        '你好 `world` 世界',
+        '你好 `world` 世界',
+        '![img](img) `code`'
+      ]);
+  });
+});

--- a/__tests__/lint-rules/space-round-inlinecode.spec.ts
+++ b/__tests__/lint-rules/space-round-inlinecode.spec.ts
@@ -28,7 +28,7 @@ describe('space-round-inlinecode', () => {
           column: 4,
           line: 1
         },
-        text: ' `world`',
+        text: '`world` ',
         type: 'space-round-inlinecode'
       }
     ]);
@@ -47,7 +47,7 @@ describe('space-round-inlinecode', () => {
           column: 3,
           line: 1
         },
-        text: '`world` ',
+        text: ' `world`',
         type: 'space-round-inlinecode'
       }
     ]);
@@ -66,7 +66,7 @@ describe('space-round-inlinecode', () => {
           column: 12,
           line: 1
         },
-        text: '`code` ',
+        text: ' `code`',
         type: 'space-round-inlinecode'
       }
     ]);

--- a/__tests__/lint-rules/space-round-inlinecode.spec.ts
+++ b/__tests__/lint-rules/space-round-inlinecode.spec.ts
@@ -1,0 +1,75 @@
+import { lint } from '../../src';
+
+describe('space-round-inlinecode', () => {
+  test('lint success when space around inline code', () => {
+    const cases = [
+      '你好 `world` 世界',
+      '你好 `world`',
+      '`world` 世界',
+      '`world`',
+      '``world``',
+      '![img](img) `code`'
+    ];
+    cases.forEach(c => {
+      expect(lint(c)).toStrictEqual([]);
+    });
+  });
+
+  test('lint fail when no space around for right error', () => {
+    const md = '你好 `world`世界';
+    expect(lint(md)).toEqual([
+      {
+        end: {
+          column: 11,
+          line: 1
+        },
+        level: 'error',
+        start: {
+          column: 4,
+          line: 1
+        },
+        text: '`world`',
+        type: 'space-round-inlinecode'
+      }
+    ]);
+  });
+
+  test('lint fail when no space around for left error', () => {
+    const md = '你好`world` 世界';
+    expect(lint(md)).toEqual([
+      {
+        end: {
+          column: 10,
+          line: 1
+        },
+        level: 'error',
+        start: {
+          column: 3,
+          line: 1
+        },
+        text: '`world`',
+        type: 'space-round-inlinecode'
+      }
+    ]);
+  });
+
+  test('lint fail when no space around with no-text node like image', () => {
+    const md = '![img](img)`code`';
+    expect(lint(md)).toEqual([
+      {
+        end: {
+          column: 18,
+          line: 1
+        },
+        level: 'error',
+        start: {
+          column: 12,
+          line: 1
+        },
+        text: '`code`',
+        type: 'space-round-inlinecode'
+      }
+    ]);
+  });
+
+});

--- a/__tests__/lint-rules/space-round-inlinecode.spec.ts
+++ b/__tests__/lint-rules/space-round-inlinecode.spec.ts
@@ -28,7 +28,7 @@ describe('space-round-inlinecode', () => {
           column: 4,
           line: 1
         },
-        text: '`world`',
+        text: ' `world`',
         type: 'space-round-inlinecode'
       }
     ]);
@@ -47,7 +47,7 @@ describe('space-round-inlinecode', () => {
           column: 3,
           line: 1
         },
-        text: '`world`',
+        text: '`world` ',
         type: 'space-round-inlinecode'
       }
     ]);
@@ -66,7 +66,7 @@ describe('space-round-inlinecode', () => {
           column: 12,
           line: 1
         },
-        text: '`code`',
+        text: '`code` ',
         type: 'space-round-inlinecode'
       }
     ]);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ast-plugin"
   ],
   "dependencies": {
-    "@lint-md/ast-plugin": "^1.0.0",
+    "@lint-md/ast-plugin": "^1.0.1",
     "lodash": "^4.17.11",
     "remark-parse": "^6.0.2",
     "unified": "^7.0.1"

--- a/src/description/en_US.ts
+++ b/src/description/en_US.ts
@@ -5,6 +5,9 @@ export default {
   'space-round-number': {
     message: 'No space between Chinese and number.'
   },
+  'space-round-inlinecode': {
+    message: 'No space between inline code.'
+  },
   'no-empty-code-lang': {
     message: 'Language of code can not be empty.'
   },
@@ -51,6 +54,6 @@ export default {
     message: 'Inline code content can not start / end with space.'
   },
   'no-long-code': {
-    message: 'Code Block cannot have too long line.',
-  },
-}
+    message: 'Code Block cannot have too long line.'
+  }
+};

--- a/src/fix-rules/index.ts
+++ b/src/fix-rules/index.ts
@@ -19,6 +19,7 @@ import no_empty_list from './no-empty-list';
 import no_empty_url from './no-empty-url';
 import no_empty_inlinecode from './no-empty-inlinecode';
 import no_empty_delete from './no-empty-delete';
+import space_round_inlinecode from './space-round-inlinecode';
 
 // 规则集合
 const Rules: PlainObject<LintMdFixer> = {
@@ -38,7 +39,8 @@ const Rules: PlainObject<LintMdFixer> = {
   'no-trailing-punctuation': no_trailing_punctuation,
   'space-round-alphabet': space_round_alphabet,
   'space-round-number': space_round_number,
-  'use-standard-ellipsis': use_standard_ellipsis
+  'use-standard-ellipsis': use_standard_ellipsis,
+  'space-round-inlinecode': space_round_inlinecode
 };
 
 /**

--- a/src/fix-rules/space-round-inlinecode.ts
+++ b/src/fix-rules/space-round-inlinecode.ts
@@ -7,7 +7,6 @@ export default (markdown, error) => {
   const { start, end } = position;
 
   const text = error.text as string;
-  // 插入空格
 
   return new Text(markdown)
     .removeBlock(start, end)

--- a/src/fix-rules/space-round-inlinecode.ts
+++ b/src/fix-rules/space-round-inlinecode.ts
@@ -1,0 +1,16 @@
+import Text from '../helper/Text';
+
+// 中文和英文直接，增加空格
+export default (markdown, error) => {
+  const { ast } = error;
+  const { position } = ast.node;
+  const { start, end } = position;
+
+  const text = error.text as string;
+  // 插入空格
+
+  return new Text(markdown)
+    .removeBlock(start, end)
+    .insertBlock(start.line, start.column, text)
+    .result();
+};

--- a/src/lint-rules/index.ts
+++ b/src/lint-rules/index.ts
@@ -22,7 +22,8 @@ const PluginClasses: Plugin[] = [
   require('./no-multiple-space-blockquote'),
   require('./no-space-in-inlinecode'),
   require('./no-trailing-punctuation'),
-  require('./no-long-code')
+  require('./no-long-code'),
+  require('./space-round-inlinecode')
 ];
 
 

--- a/src/lint-rules/index.ts
+++ b/src/lint-rules/index.ts
@@ -2,28 +2,46 @@ import * as _ from 'lodash';
 import { Plugin } from '@lint-md/ast-plugin';
 import { LintMdRulesConfig, PlainObject, LintMdError, RuleLevel } from '../type';
 import { ruleToLevel } from './helper/rule';
+import space_round_alphabet from './space-round-alphabet';
+import space_round_number from './space-round-number';
+import no_empty_code_lang from './no-empty-code-lang';
+import no_empty_delete from './no-empty-delete';
+import no_empty_url from './no-empty-url';
+import no_empty_list from './no-empty-list';
+import no_empty_code from './no-empty-code';
+import no_empty_inlinecode from './no-empty-inlinecode';
+import no_empty_blockquote from './no-empty-blockquote';
+import no_special_characters from './no-special-characters';
+import use_standard_ellipsis from './use-standard-ellipsis';
+import no_fullwidth_number from './no-fullwidth-number';
+import no_space_in_emphasis from './no-space-in-emphasis';
+import no_space_in_link from './no-space-in-link';
+import no_multiple_space_blockquote from './no-multiple-space-blockquote';
+import no_space_in_inlinecode from './no-space-in-inlinecode';
+import no_trailing_punctuation from './no-trailing-punctuation';
+import no_long_code from './no-long-code';
+import space_round_inlinecode from './space-round-inlinecode';
 
-
-const PluginClasses: Plugin[] = [
-  require('./space-round-alphabet'),
-  require('./space-round-number'),
-  require('./no-empty-code-lang'),
-  require('./no-empty-delete'),
-  require('./no-empty-url'),
-  require('./no-empty-list'),
-  require('./no-empty-code'),
-  require('./no-empty-inlinecode'),
-  require('./no-empty-blockquote'),
-  require('./no-special-characters'),
-  require('./use-standard-ellipsis'),
-  require('./no-fullwidth-number'),
-  require('./no-space-in-emphasis'),
-  require('./no-space-in-link'),
-  require('./no-multiple-space-blockquote'),
-  require('./no-space-in-inlinecode'),
-  require('./no-trailing-punctuation'),
-  require('./no-long-code'),
-  require('./space-round-inlinecode')
+const PluginClasses = [
+  space_round_alphabet,
+  space_round_number,
+  no_empty_code_lang,
+  no_empty_delete,
+  no_empty_url,
+  no_empty_list,
+  no_empty_code,
+  no_empty_inlinecode,
+  no_empty_blockquote,
+  no_special_characters,
+  use_standard_ellipsis,
+  no_fullwidth_number,
+  no_space_in_emphasis,
+  no_space_in_link,
+  no_multiple_space_blockquote,
+  no_space_in_inlinecode,
+  no_trailing_punctuation,
+  no_long_code,
+  space_round_inlinecode
 ];
 
 

--- a/src/lint-rules/no-empty-blockquote.ts
+++ b/src/lint-rules/no-empty-blockquote.ts
@@ -6,7 +6,7 @@ import { getChildrenPosition } from '../helper/ast';
  * blockquote 块内容不能为空
  * no-empty-blockquote
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
   static get type() {
     return 'no-empty-blockquote';
   }
@@ -34,4 +34,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/no-empty-code-lang.ts
+++ b/src/lint-rules/no-empty-code-lang.ts
@@ -4,7 +4,7 @@ import { Plugin } from '@lint-md/ast-plugin';
  * 中文和英文、数字之间需要有空格
  * no-empty-code-lang
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
 
   static get type() {
     return 'no-empty-code-lang';
@@ -41,4 +41,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/no-empty-code.ts
+++ b/src/lint-rules/no-empty-code.ts
@@ -6,7 +6,7 @@ import { getChildrenPosition } from '../helper/ast';
  * code 代码块内容不能为空
  * no-empty-code
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
 
   static get type() {
     return 'no-empty-code';
@@ -39,4 +39,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/no-empty-delete.ts
+++ b/src/lint-rules/no-empty-delete.ts
@@ -6,7 +6,7 @@ import { getChildrenPosition } from '../helper/ast';
  * delete 代码块内容不能为空
  * no-empty-delete
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
 
   static get type() {
     return 'no-empty-delete';
@@ -33,4 +33,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/no-empty-inlinecode.ts
+++ b/src/lint-rules/no-empty-inlinecode.ts
@@ -6,7 +6,7 @@ import { getChildrenPosition } from '../helper/ast';
  * code 代码块内容不能为空
  * no-empty-inlinecode
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
 
   static get type() {
     return 'no-empty-inlinecode';
@@ -39,4 +39,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/no-empty-list.ts
+++ b/src/lint-rules/no-empty-list.ts
@@ -6,7 +6,7 @@ import { getChildrenPosition } from '../helper/ast';
  * list 内容不能为空
  * no-empty-list
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
 
   static get type() {
     return 'no-empty-list';
@@ -35,4 +35,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/no-empty-url.ts
+++ b/src/lint-rules/no-empty-url.ts
@@ -4,7 +4,7 @@ import { Plugin } from '@lint-md/ast-plugin';
  * link image 中地址不能为空
  * no-empty-url
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
 
   static get type() {
     return 'no-empty-url';
@@ -43,4 +43,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/no-fullwidth-number.ts
+++ b/src/lint-rules/no-fullwidth-number.ts
@@ -38,7 +38,7 @@ const isFullWidthNumber = s => {
  * 无全角数字
  * no-fullwidth-number
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
 
   static get type() {
     return 'no-fullwidth-number';
@@ -78,4 +78,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/no-long-code.ts
+++ b/src/lint-rules/no-long-code.ts
@@ -9,7 +9,7 @@ const defaultConfig = {
  * 代码长度有限制
  * no-long-code
  */
-module.exports = class extends Plugin {
+export default  class extends Plugin {
   static get type() {
     return 'no-long-code';
   }
@@ -48,4 +48,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/no-multiple-space-blockquote.ts
+++ b/src/lint-rules/no-multiple-space-blockquote.ts
@@ -8,7 +8,7 @@ import { startSpaceLen, substr } from './helper/string';
  * blockquote 后面不能有多个空格
  * no-multiple-space-blockquote
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
 
   static get type() {
     return 'no-multiple-space-blockquote';
@@ -44,4 +44,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/no-space-in-emphasis.ts
+++ b/src/lint-rules/no-space-in-emphasis.ts
@@ -7,7 +7,7 @@ import { astToText, getChildrenPosition } from '../helper/ast';
  * emphasis 内容前后不能有空格
  * no-space-in-emphasis
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
 
   static get type() {
     return 'no-space-in-emphasis';
@@ -36,4 +36,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/no-space-in-inlinecode.ts
+++ b/src/lint-rules/no-space-in-inlinecode.ts
@@ -7,7 +7,7 @@ import { astPositionTrans } from '../helper/ast';
  * inlineCode 内容前后不能有空格
  * no-space-in-inlinecode
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
 
   static get type() {
     return 'no-space-in-inlinecode';
@@ -39,4 +39,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/no-space-in-link.ts
+++ b/src/lint-rules/no-space-in-link.ts
@@ -7,7 +7,7 @@ import { astToText, getChildrenPosition } from '../helper/ast';
  * Link 内容前后不能有空格
  * no-space-in-link
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
 
   static get type() {
     return 'no-space-in-link';
@@ -35,4 +35,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/no-special-characters.ts
+++ b/src/lint-rules/no-special-characters.ts
@@ -9,7 +9,7 @@ const showLength = 12;
  * 无特殊字符
  * no-special-characters
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
 
   static get type() {
     return 'no-special-characters';
@@ -52,4 +52,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/no-trailing-punctuation.ts
+++ b/src/lint-rules/no-trailing-punctuation.ts
@@ -9,7 +9,7 @@ const Symbols = '.,;:!?。，；：！？…~*`';
  * Header 内容不能以标点符号结尾
  * no-trailing-punctuation
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
 
   static get type() {
     return 'no-trailing-punctuation';
@@ -46,4 +46,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/space-round-alphabet.ts
+++ b/src/lint-rules/space-round-alphabet.ts
@@ -8,7 +8,7 @@ const matches = ['ZA', 'AZ'];
  * 中文和英文之间需要有空格
  * space-round-alphabet
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
   static get type() {
     return 'space-round-alphabet';
   }
@@ -26,4 +26,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/space-round-inlinecode.ts
+++ b/src/lint-rules/space-round-inlinecode.ts
@@ -1,7 +1,25 @@
 import { Ast, Plugin } from '@lint-md/ast-plugin';
 import * as Unist from 'unist';
 
-const checkHasSpace = (node: Unist.Node, position: 'left' | 'right'): boolean => {
+
+/**
+ * 判断 inline code 左侧/右侧节点是否合法
+ *
+ * 判断方法：
+ *
+ * 1. 如果节点不是文字节点，直接返回 false，因为两侧的空格必然是 text 节点
+ *
+ * 2. 节点是文字节点
+ *
+ * 2-1. 如果节点位于 inline-code 左侧，如果节点 value 最右端有空格，返回 true
+ *
+ * 2-2. 如果节点位于 inline-code 右侧，如果节点 value 最左端有空格，返回 true
+ *
+ * @param node 节点
+ * @param position 该节点位于 inline code 的左侧还是右侧
+ * @return boolean 节点是否合法
+ */
+const isNodeAccepted = (node: Unist.Node, position: 'left' | 'right'): boolean => {
   // 左右两边是空格，那么必须存在文字节点
   if (node.type !== 'text') {
     return false;
@@ -39,9 +57,9 @@ module.exports = class extends Plugin {
           const rightIndex = nodeIndex + 1;
 
           // 1. 节点存在 -- 节点在合法的下标范围内
-          // 2.checkHasSpace 不通过，则 lint 异常
-          const isLeftLintError = isNodePositionAccepted(leftIndex) && !checkHasSpace(parentNodeChildren[leftIndex], 'left');
-          const isRightLintError = isNodePositionAccepted(rightIndex) && !checkHasSpace(parentNodeChildren[rightIndex], 'right');
+          // 2. isNodeAccepted 不通过，则 lint 异常
+          const isLeftLintError = isNodePositionAccepted(leftIndex) && !isNodeAccepted(parentNodeChildren[leftIndex], 'left');
+          const isRightLintError = isNodePositionAccepted(rightIndex) && !isNodeAccepted(parentNodeChildren[rightIndex], 'right');
 
           if (isLeftLintError || isRightLintError) {
             this.cfg.throwError(({

--- a/src/lint-rules/space-round-inlinecode.ts
+++ b/src/lint-rules/space-round-inlinecode.ts
@@ -54,7 +54,7 @@ module.exports = class extends Plugin {
                 line: ast.node.position.end.line,
                 column: ast.node.position.end.column
               },
-              text: `\`${currentNode.value}\``
+              text: `${isLeftLintError ? ' ' : ''}\`${currentNode.value}\`${isRightLintError ? ' ' : ''}`
             }));
           }
         }

--- a/src/lint-rules/space-round-inlinecode.ts
+++ b/src/lint-rules/space-round-inlinecode.ts
@@ -34,7 +34,7 @@ const isNodeAccepted = (node: Unist.Node, position: 'left' | 'right'): boolean =
  * code 代码块之间要加空格
  * space-round-inlinecode
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
   static get type() {
     return 'space-round-inlinecode';
   }
@@ -85,4 +85,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/space-round-inlinecode.ts
+++ b/src/lint-rules/space-round-inlinecode.ts
@@ -1,0 +1,70 @@
+import { Ast, Plugin } from '@lint-md/ast-plugin';
+import * as Unist from 'unist';
+
+const checkHasSpace = (node: Unist.Node, position: 'left' | 'right'): boolean => {
+  // 左右两边是空格，那么必须存在文字节点
+  if (node.type !== 'text') {
+    return false;
+  } else {
+    const val = node.value as string;
+    // 是 text 节点，并且以 ' ' 结尾 / 开头
+    return position === 'left' ? val.endsWith(' ') : val.startsWith(' ');
+  }
+};
+
+/**
+ * code 代码块之间要加空格
+ * space-round-inlinecode
+ */
+module.exports = class extends Plugin {
+  static get type() {
+    return 'space-round-inlinecode';
+  }
+
+  visitor() {
+    return {
+      inlineCode: (ast: Ast) => {
+        // 当前节点
+        const currentNode = ast.node;
+
+        // 父亲节点
+        const parentNodeChildren = ast.parent.node.children as any[];
+
+        // 所有孩子，理应包含当前节点
+        const nodeIndex = parentNodeChildren.indexOf(currentNode);
+        if (nodeIndex >= 0) {
+          const isNodePositionAccepted = (index: number) => index >= 0 && index <= parentNodeChildren.length - 1;
+
+          const leftIndex = nodeIndex - 1;
+          const rightIndex = nodeIndex + 1;
+
+          // 1. 节点存在 -- 节点在合法的下标范围内
+          // 2.checkHasSpace 不通过，则 lint 异常
+          const isLeftLintError = isNodePositionAccepted(leftIndex) && !checkHasSpace(parentNodeChildren[leftIndex], 'left');
+          const isRightLintError = isNodePositionAccepted(rightIndex) && !checkHasSpace(parentNodeChildren[rightIndex], 'right');
+
+          if (isLeftLintError || isRightLintError) {
+            this.cfg.throwError(({
+              ast: ast,
+              start: {
+                line: ast.node.position.start.line,
+                column: ast.node.position.start.column
+              },
+              end: {
+                line: ast.node.position.end.line,
+                column: ast.node.position.end.column
+              },
+              text: `\`${currentNode.value}\``
+            }));
+          }
+        }
+      }
+    };
+  }
+
+  pre() {
+  }
+
+  post() {
+  }
+};

--- a/src/lint-rules/space-round-number.ts
+++ b/src/lint-rules/space-round-number.ts
@@ -8,7 +8,7 @@ const matches = ['ZN', 'NZ'];
  * 中文和数字之间需要有空格
  * space-round-number
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
 
   static get type() {
     return 'space-round-number';
@@ -26,4 +26,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}

--- a/src/lint-rules/use-standard-ellipsis.ts
+++ b/src/lint-rules/use-standard-ellipsis.ts
@@ -51,7 +51,7 @@ const findAllDotEllipsis = s => {
  * 要判断准确，还是必须一个一个处理
  * use-standard-ellipsis
  */
-module.exports = class extends Plugin {
+export default class extends Plugin {
 
   static get type() {
     return 'use-standard-ellipsis';
@@ -88,4 +88,4 @@ module.exports = class extends Plugin {
 
   post() {
   }
-};
+}


### PR DESCRIPTION
**规则名称**

行内代码之间需要增加空格

**正确**

> 你好 `hello`  世界
> using a `<script>` tag

**错误**

> 你好`hello`世界
> using a`<script>`tag

**实现方案**

找到 `inlineCode`，判断是否存在左右节点。

如果存在，判断该节点是否为 text 节点，如果是，继续判断是否为 ' ' 结尾（左节点）或者是否为 ' ' 开头（右节点）
如果不是 text 节点，则不通过（因为空格必然是 text 节点产生的）

**有待商榷的地方**

对于如下的案例：

![image](https://user-images.githubusercontent.com/56540811/112176979-8656fa80-8c33-11eb-8869-7ad93623988e.png)

fix 的结果有一定概率多一个空格，导致这个 test case 有概率失败。

应该是您当初写 fix 是采用了**随机处理的方案**，上面的案例如果先处理 inline code，会在左侧加一个空格，从而使最后的结果后面多一个空格，如果先删最后的标点，那么一切符合预期。