### PR TITLE
feat: finish rules about code block

### DIFF
--- a/__tests__/benchmark/lint-md.spec.ts
+++ b/__tests__/benchmark/lint-md.spec.ts
@@ -16,7 +16,9 @@ Some **importance**, and \`code\`.
 
     const newLintMd = () => {
       lintAndFix(NO_EMPTY_CODE_DEMO, [
-        noEmptyCode
+        {
+          rule: noEmptyCode
+        }
       ], true);
     };
 
@@ -30,7 +32,7 @@ Some **importance**, and \`code\`.
     };
 
     await benchMarkBetween({
-      magnification: 90,
+      magnification: 85,
       cb1: newLintMd,
       cb2: oldLintMd,
       check: true

--- a/__tests__/unit/core.spec.ts
+++ b/__tests__/unit/core.spec.ts
@@ -12,11 +12,13 @@ Some **importance**, and \`code\`.
 \`\`\`javascript
 
 \`\`\``, [
-      noEmptyCode
+      {
+        rule: noEmptyCode
+      }
     ]);
 
-    expect(lintResult.ruleContext.getReportData().length).toStrictEqual(1);
-    const res = lintResult.ruleContext.getReportData().pop();
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    const res = lintResult.ruleManager.getReportData().pop();
     expect(isFunction(res.fix)).toBeTruthy();
     expect(res.message).toStrictEqual('[lint-md] 代码块内容不能为空，请删除空的代码块，或者填充代码内容');
   });
@@ -29,7 +31,9 @@ Some **importance**, and \`code\`.
 \`\`\`javascript
 
 \`\`\``, [
-      noEmptyCode
+      {
+        rule: noEmptyCode
+      }
     ], true);
 
     expect(res.fixedResult.notAppliedFixes).toStrictEqual([]);

--- a/__tests__/unit/rule-context.spec.ts
+++ b/__tests__/unit/rule-context.spec.ts
@@ -1,15 +1,15 @@
-import { createRuleContext } from '../../src/utils/rule-context';
+import { createRuleManager } from '../../src/utils/rule-manager';
 
 describe('test rule context', () => {
   test('test rule context creation', () => {
-    const ctx = createRuleContext();
+    const ctx = createRuleManager();
     expect(ctx).toBeTruthy();
-    expect(typeof ctx.report).toStrictEqual('function');
+    expect(typeof ctx.createRuleContext().report).toStrictEqual('function');
   });
 
   test('test rule context report() call', () => {
-    const ctx = createRuleContext();
-    ctx.report({
+    const manager = createRuleManager();
+    manager.createRuleContext().report({
       message: 'message 1',
       loc: {
         start: {
@@ -22,7 +22,7 @@ describe('test rule context', () => {
         }
       }
     });
-    ctx.report({
+    manager.createRuleContext().report({
       message: 'message 2',
       loc: {
         start: {
@@ -35,8 +35,8 @@ describe('test rule context', () => {
         }
       }
     });
-    expect(ctx.getReportData().length).toStrictEqual(2);
-    expect(ctx.getReportData().map(item => item.message))
+    expect(manager.getReportData().length).toStrictEqual(2);
+    expect(manager.getReportData().map(item => item.message))
       .toStrictEqual(['message 1', 'message 2']);
   });
 });

--- a/__tests__/unit/rules/no-empty-code-lang.spec.ts
+++ b/__tests__/unit/rules/no-empty-code-lang.spec.ts
@@ -1,7 +1,9 @@
 import { createFixer } from '../../utils/test-utils';
 import noEmptyCodeLang from '../../../src/rules/no-empty-code-lang';
 
-const fixer = createFixer([noEmptyCodeLang]);
+const fixer = createFixer([{
+  rule: noEmptyCodeLang
+}]);
 
 describe('test no-empty-code-lang', () => {
   test('no fix applied', () => {
@@ -12,7 +14,7 @@ describe('test no-empty-code-lang', () => {
     const { fixedResult, lintResult } = fixer(md);
 
     expect(fixedResult.result).toBe(md);
-    expect(lintResult.ruleContext.getReportData().length).toStrictEqual(0);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
   });
 
   test('fix applied', () => {
@@ -25,7 +27,6 @@ describe('test no-empty-code-lang', () => {
     expect(fixedResult.result).toBe('```plain\n' +
       'const b = 2;\n' +
       '```');
-    expect(lintResult.ruleContext.getReportData().length).toStrictEqual(1);
-
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
   });
 });

--- a/__tests__/unit/rules/no-empty-code-lang.spec.ts
+++ b/__tests__/unit/rules/no-empty-code-lang.spec.ts
@@ -1,0 +1,31 @@
+import { createFixer } from '../../utils/test-utils';
+import noEmptyCodeLang from '../../../src/rules/no-empty-code-lang';
+
+const fixer = createFixer([noEmptyCodeLang]);
+
+describe('test no-empty-code-lang', () => {
+  test('no fix applied', () => {
+    const md = '```js\n' +
+      'const a = 1;\n' +
+      '```';
+
+    const { fixedResult, lintResult } = fixer(md);
+
+    expect(fixedResult.result).toBe(md);
+    expect(lintResult.ruleContext.getReportData().length).toStrictEqual(0);
+  });
+
+  test('fix applied', () => {
+    const md = '```\n' +
+      'const b = 2;\n' +
+      '```';
+
+    const { fixedResult, lintResult } = fixer(md);
+
+    expect(fixedResult.result).toBe('```plain\n' +
+      'const b = 2;\n' +
+      '```');
+    expect(lintResult.ruleContext.getReportData().length).toStrictEqual(1);
+
+  });
+});

--- a/__tests__/unit/rules/no-empty-code.spec.ts
+++ b/__tests__/unit/rules/no-empty-code.spec.ts
@@ -1,0 +1,20 @@
+import noEmptyCode from '../../../src/rules/no-empty-code';
+import { createFixer } from '../../utils/test-utils';
+
+const fixer = createFixer([noEmptyCode]);
+
+describe('test no-empty-code', () => {
+  test('no fix applied', () => {
+    const md = ' - right\n```js\n const a = 1;\n```\n你好\n';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(fixedResult.result).toBe(md);
+    expect(lintResult.ruleContext.getReportData().length).toStrictEqual(0);
+  });
+
+  test('fix applied', () => {
+    const md = ' - right\n```js\n\n```\n你好\n';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(fixedResult.result).toBe(' - right\n\n你好\n');
+    expect(lintResult.ruleContext.getReportData().length).toStrictEqual(1);
+  });
+});

--- a/__tests__/unit/rules/no-empty-code.spec.ts
+++ b/__tests__/unit/rules/no-empty-code.spec.ts
@@ -1,20 +1,22 @@
 import noEmptyCode from '../../../src/rules/no-empty-code';
 import { createFixer } from '../../utils/test-utils';
 
-const fixer = createFixer([noEmptyCode]);
+const fixer = createFixer([{
+  rule: noEmptyCode
+}]);
 
 describe('test no-empty-code', () => {
   test('no fix applied', () => {
     const md = ' - right\n```js\n const a = 1;\n```\n你好\n';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult.result).toBe(md);
-    expect(lintResult.ruleContext.getReportData().length).toStrictEqual(0);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
   });
 
   test('fix applied', () => {
     const md = ' - right\n```js\n\n```\n你好\n';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult.result).toBe(' - right\n\n你好\n');
-    expect(lintResult.ruleContext.getReportData().length).toStrictEqual(1);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
   });
 });

--- a/__tests__/unit/rules/no-long-code.spec.ts
+++ b/__tests__/unit/rules/no-long-code.spec.ts
@@ -1,0 +1,99 @@
+import { createFixer } from '../../utils/test-utils';
+import noLongCode from '../../../src/rules/no-long-code';
+
+
+describe('test no-long-code', () => {
+  const fixer = createFixer([{
+    rule: noLongCode,
+    options: {
+      length: 50,
+      exclude: ['plain']
+    }
+  }]);
+
+  test('test no fix applied', () => {
+    const md = [
+      '```js',
+      'console.log("this is a short line");',
+      'console.log("with multiple lines");',
+      '```'
+    ].join('\n');
+
+    const { fixedResult, lintResult } = fixer(md);
+
+    expect(fixedResult.result).toBe(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+  });
+
+  test('test fix applied', () => {
+    const longCode = 'console.log("very long long long long long long long long long long long long long long long long long sentence");';
+    const md = [
+      '```js',
+      longCode,
+      '```'
+    ].join('\n');
+
+    const { lintResult } = fixer(md);
+    const { loc } = lintResult.ruleManager.getReportData().pop();
+
+    expect(loc).toStrictEqual({
+      'end': {
+        'column': 114,
+        'line': 1
+      },
+      'start': {
+        'column': 1,
+        'line': 1
+      }
+    });
+  });
+
+  test('test exclude option', () => {
+    const longCode = 'console.log("very long long long long long long long long long long long long long long long long long sentence");';
+    const md = [
+      '```plain',
+      longCode,
+      '```'
+    ].join('\n');
+    const { lintResult } = fixer(md);
+
+    const data = lintResult.ruleManager.getReportData();
+    expect(data.length).toStrictEqual(0);
+  });
+
+  test('test lint error in lines more than one', () => {
+    const md = [
+      '```js',
+      'console.log("this is a short line");',
+      'console.log("code code code code code code code code");',
+      'console.log("this is a short line");',
+      'console.log("code code code code code code code code");',
+      '```'
+    ].join('\n');
+
+    const { fixedResult, lintResult } = fixer(md);
+
+    expect(fixedResult.result).toBe(md);
+    const [r1, r2] = lintResult.ruleManager.getReportData();
+    expect(r1.loc).toStrictEqual({
+      'end': {
+        'column': 55,
+        'line': 2
+      },
+      'start': {
+        'column': 1,
+        'line': 2
+      }
+    });
+    expect(r2.loc).toStrictEqual({
+      'end': {
+        'column': 55,
+        'line': 4
+      },
+      'start': {
+        'column': 1,
+        'line': 4
+      }
+    });
+  });
+});

--- a/__tests__/utils/test-utils.ts
+++ b/__tests__/utils/test-utils.ts
@@ -1,4 +1,6 @@
 import * as Benchmark from 'benchmark';
+import { LintMdRule } from '../../src/types';
+import { lintAndFix } from '../../src/core/lint-and-fix';
 
 interface BenchMarkBetweenOptions {
   // 回调函数 1
@@ -50,4 +52,10 @@ export const benchMarkBetween = async (opt: BenchMarkBetweenOptions) => {
       });
     suite.run();
   });
+};
+
+export const createFixer = (rules: LintMdRule[]) => {
+  return (md: string) => {
+    return lintAndFix(md, rules, true);
+  };
 };

--- a/__tests__/utils/test-utils.ts
+++ b/__tests__/utils/test-utils.ts
@@ -1,5 +1,5 @@
 import * as Benchmark from 'benchmark';
-import { LintMdRule } from '../../src/types';
+import { LintMdRule, LintMdRuleConfig } from '../../src/types';
 import { lintAndFix } from '../../src/core/lint-and-fix';
 
 interface BenchMarkBetweenOptions {
@@ -54,8 +54,8 @@ export const benchMarkBetween = async (opt: BenchMarkBetweenOptions) => {
   });
 };
 
-export const createFixer = (rules: LintMdRule[]) => {
+export const createFixer = (ruleConfigs: LintMdRuleConfig[]) => {
   return (md: string) => {
-    return lintAndFix(md, rules, true);
+    return lintAndFix(md, ruleConfigs, true);
   };
 };

--- a/src/core/lint-and-fix.ts
+++ b/src/core/lint-and-fix.ts
@@ -1,4 +1,4 @@
-import { Fix, LintMdRule } from '../types';
+import { Fix, LintMdRuleConfig } from '../types';
 import { applyFix } from '../utils/apply-fix';
 import { MAX_LINT_AND_FIX_CALL_TIMES } from '../common/constant';
 import { lintMarkdown } from './lint-markdown';
@@ -8,7 +8,7 @@ import { lintMarkdown } from './lint-markdown';
  *
  * @date 2021-12-14 17:16:12
  */
-export const lintAndFix = (markdown: string, rules: LintMdRule[], isFixMode: boolean) => {
+export const lintAndFix = (markdown: string, rules: LintMdRuleConfig[], isFixMode: boolean) => {
   let lintTimes = 0;
   let lintResult = lintMarkdown(markdown, rules);
 
@@ -16,7 +16,7 @@ export const lintAndFix = (markdown: string, rules: LintMdRule[], isFixMode: boo
 
   while (isFixMode && lintTimes <= MAX_LINT_AND_FIX_CALL_TIMES) {
     lintTimes += 1;
-    fixedResult = applyFix(markdown, lintResult.ruleContext.getAllFixes());
+    fixedResult = applyFix(markdown, lintResult.ruleManager.getAllFixes());
     if (!fixedResult.notAppliedFixes.length) {
       break;
     }

--- a/src/rules/no-empty-code-lang.ts
+++ b/src/rules/no-empty-code-lang.ts
@@ -1,0 +1,36 @@
+import { LintMdRule, MarkdownNode } from '../types';
+
+type MarkdownCodeNode = MarkdownNode & {
+  value: string
+  lang: string
+}
+
+/**
+ * 代码语言不能为空
+ * no-empty-code-lang
+ *
+ * @date 2021-12-24 21:36:12
+ */
+const noEmptyCodeLang: LintMdRule = {
+  create: (context) => {
+    return {
+      code: (node: MarkdownCodeNode) => {
+        if (!node.lang) {
+          context.report({
+            loc: node.position,
+            message: '[lint-md] 代码语言不能为空，请在代码块语法上增加语言',
+            fix: (fixer) => {
+              return fixer.insertTextAfterRange([
+                node.position.start.offset,
+                // + 3 的原因是代码块以 ``` 开头
+                node.position.start.offset + 3
+              ], 'plain');
+            }
+          });
+        }
+      }
+    };
+  }
+};
+
+export default noEmptyCodeLang;

--- a/src/rules/no-long-code.ts
+++ b/src/rules/no-long-code.ts
@@ -1,0 +1,57 @@
+import { LintMdRule, MarkdownNode } from '../types';
+
+type MarkdownCodeNode = MarkdownNode & {
+  value: string
+  lang: string
+}
+
+/**
+ * 代码块不能有过长的代码
+ * no-long-code
+ *
+ * @date 2021-12-24 22:37:04
+ */
+const noLongCode: LintMdRule = {
+  create: (context) => {
+    return {
+      code: (node: MarkdownCodeNode) => {
+        const { length: maxLength, exclude = [] } = context.options;
+        // 选项中设置的排除语言不考虑
+        if (exclude.includes(node.lang)) {
+          return;
+        }
+
+        const codeArray = node.value.split('\n');
+        for (let i = 0; i < codeArray.length; i++) {
+          // 第 i 行超出限制
+          if (codeArray[i].length > maxLength) {
+            const firstLineInCodeArea = node.position.start.line;
+            // code 代码块包括开头的三个点，所以三点处为第 firstLineInCodeArea 行，则 lint 问题出现在第 1 + i 行
+            // 列数则从第一列开始
+            const start = {
+              line: firstLineInCodeArea + i,
+              column: 1
+            };
+
+            // 很明显，结束处在同一行，列数则是该行的长度
+            const end = {
+              line: firstLineInCodeArea + i,
+              column: codeArray[i].length
+            };
+
+            context.report({
+              loc: {
+                start: start,
+                end: end
+              },
+              message: '[lint-md] 代码块不能有过长的代码'
+            });
+
+          }
+        }
+      }
+    };
+  }
+};
+
+export default noLongCode;

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,4 +60,4 @@ export interface TraverserOptions {
   onLeave?: (node: MarkdownNode, parent: MarkdownNode) => void;
 }
 
-export type TextRange = [number, number]
+export type TextRange = number[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { Parent } from 'unist';
 import type { createFixer } from './utils/fixer';
-import { createRuleContext } from './utils/rule-context';
+import { createRuleManager } from './utils/rule-manager';
 
 export interface MarkdownNodePosition {
   /**
@@ -37,12 +37,18 @@ export interface LintMdRule {
   /**
    * 选择器初始化回调
    */
-  create: (context: ReturnType<typeof createRuleContext>) => Record<string, (node: MarkdownNode) => void>;
+  create: (context: ReturnType<ReturnType<typeof createRuleManager>['createRuleContext']>) => Record<string, (node: MarkdownNode) => void>;
 
   /**
    * rule 的一些基本信息，后续有需要再补充
    */
   meta?: Record<any, any>;
+}
+
+export interface LintMdRuleConfig {
+  rule: LintMdRule,
+  options?: Record<string, any>
+  fileName?: string
 }
 
 // 节点队列

--- a/src/utils/rule-manager.ts
+++ b/src/utils/rule-manager.ts
@@ -3,11 +3,11 @@ import { ReportOption } from '../types';
 import { createFixer } from './fixer';
 
 /**
- * 初始化 rule 上下文实例
+ * 初始化全局 rule 管理器
  *
- * @date 2021-12-14 11:45:09
+ * @date 2021-12-24 22:57:11
  */
-export const createRuleContext = () => {
+export const createRuleManager = () => {
   // 修复器
   const fixer = createFixer();
 
@@ -31,9 +31,17 @@ export const createRuleContext = () => {
       .map(item => item.fix(fixer));
   };
 
+  // 初始化一个 rule context
+  const createRuleContext = (options?: Record<string, any>) => {
+    return {
+      report: report,
+      options: options || {}
+    };
+  };
+
   return {
-    report: report,
     getReportData: getReportData,
-    getAllFixes: getAllFixes
+    getAllFixes: getAllFixes,
+    createRuleContext: createRuleContext
   };
 };


### PR DESCRIPTION
迁移旧版的 rules 到新版，本 pr 更新以下和 code block 有关的 rules:

- [x] no-empty-code-lang
- [x] no-empty-code
- [x] no-long-code



