### PR TITLE
.lintmdrc 配置文件中必须有 rules 字段，否则配置无效

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ lint-md examples/**/* --threads=8
 
 ```json
 {
-  "no-empty-code": 1,
-  "no-long-code": [2, {
-    "length": 100,
-    "exclude": ["dot"]
-  }]
+  "rules":{
+    "no-empty-code": 1,
+    "no-long-code": [2, {
+      "length": 100,
+      "exclude": ["dot"]
+    }]
+  }
 }
 ```
 


### PR DESCRIPTION
无效：
```JSON
{ 
"space-around-number": 0,
"space-around-alphabet": 1 
}
```
有效：

```JSON
{
  "rules": { 
    "space-around-number": 0,
    "space-around-alphabet": 1 
  }
}
```