### PR TITLE
feat: add rule space-around-inline-code

### DIFF
--- a/__tests__/unit/rules/space-around-inline-code.spec.ts
+++ b/__tests__/unit/rules/space-around-inline-code.spec.ts
@@ -1,0 +1,20 @@
+import { createFixer } from '../../utils/test-utils';
+import spaceAroundInlineCode from '../../../src/rules/space-around-inline-code';
+
+const fixer = createFixer([{
+  rule: spaceAroundInlineCode
+}]);
+
+describe('test space-around-inline-code', () => {
+  test('fix applied', () => {
+    const content1 = '有时候`div`元素的 `display`属性会被设置为`inline-block`，这样就可以让 `div` 元素在一行内显示，但是又可以设置宽高`height` 等属性。';
+    const { fixedResult: fixedResult1, lintResult: lintResult1 } = fixer(content1);
+    expect(lintResult1.ruleManager.getReportData().length).toStrictEqual(4);
+    expect(fixedResult1?.result).toStrictEqual('有时候 `div` 元素的 `display` 属性会被设置为 `inline-block`，这样就可以让 `div` 元素在一行内显示，但是又可以设置宽高 `height` 等属性。');
+
+    const content2 = '有时候```div```元素的 ```display```属性会被设置为```inline-block```，这样就可以让 ```div``` 元素在一行内显示，但是又可以设置宽高```height``` 等属性。';
+    const { fixedResult: fixedResult2, lintResult: lintResult2 } = fixer(content2);
+    expect(lintResult2.ruleManager.getReportData().length).toStrictEqual(4);
+    expect(fixedResult2?.result).toStrictEqual('有时候 ```div``` 元素的 ```display``` 属性会被设置为 ```inline-block```，这样就可以让 ```div``` 元素在一行内显示，但是又可以设置宽高 ```height``` 等属性。');
+  });
+});

--- a/src/rules/space-around-inline-code.ts
+++ b/src/rules/space-around-inline-code.ts
@@ -1,0 +1,55 @@
+import type { MarkdownCodeNode } from '@lint-md/parser';
+import type { LintMdRule, LintMdRuleContext } from '../types';
+
+const spaceAroundInlineCode: LintMdRule = {
+  meta: {
+    name: 'space-around-inline-code',
+  },
+  create: (context: LintMdRuleContext) => {
+    return {
+      inlineCode: (node: MarkdownCodeNode) => {
+        const result: string = context.markdown.slice(node.position.start.offset - 1, node.position.end.offset + 1);
+        let newContent;
+
+        if (result.startsWith(' `') && result.endsWith('` ')) {
+          return;
+        }
+
+        if (result.includes('```')) {
+          newContent = `\`\`\`${node.value}\`\`\``;
+        }
+        else {
+          newContent = `\`${node.value}\``;
+        }
+
+        if (!result.startsWith(' `')) {
+          newContent = ` ${newContent}`;
+        }
+        if (!result.endsWith('` ')) {
+          // 最后一个字符是标点符号的情况下，不需要添加空格
+          const lastChar = result[result.length - 1];
+          // 定义标点符号的正则表达式
+          const punctuationRegex = /[.,;:!?。，；：！？]/;
+
+          // 如果最后一个字符不是标点符号，那么添加空格
+          if (!punctuationRegex.test(lastChar)) {
+            newContent = `${newContent} `;
+          }
+        }
+
+        context.report({
+          loc: node.position,
+          message: 'test',
+          fix: (fixer) => {
+            return fixer.replaceTextRange(
+              [node.position.start.offset, node.position.end.offset],
+              newContent
+            );
+          },
+        });
+      },
+    };
+  },
+};
+
+export default spaceAroundInlineCode;


### PR DESCRIPTION
增加规则，行内代码周围没有空格时，添加空格；最后一个字符是标点符号的情况下，不添加空格
效果如下

有时候`div`元素的 `display`属性会被设置为`inline-block`，

lint后

有时候 `div` 元素的 `display` 属性会被设置为 `inline-block`，