### PR TITLE
fix: wrong boolean operator in no-space-in-link guard

### DIFF
--- a/src/rules/no-space-in-link.ts
+++ b/src/rules/no-space-in-link.ts
@@ -3,7 +3,7 @@ import type { LintMdRule, LintMdRuleContext } from '../types';
 import { getTextNodes } from '../utils/get-text-nodes';
 
 const checkAndReportTextNode = (ctx: LintMdRuleContext, node: MarkdownTextNode, pos: 'between' | 'start-only' | 'end-only') => {
-  if (!node && node.type !== 'text') {
+  if (!node || node.type !== 'text') {
     return;
   }
 


### PR DESCRIPTION
Closes #116

`&&` → `||`，修复原本永远为 false 的无效守卫逻辑。

详情见 #116