### PR TITLE
fix: replace while(true) with clean regex exec() loop, fix premature break

### DIFF
--- a/__tests__/unit/rules/use-standard-ellipsis.spec.ts
+++ b/__tests__/unit/rules/use-standard-ellipsis.spec.ts
@@ -20,6 +20,13 @@ describe('test use-standard-ellipsis', () => {
     expect(fixedResult?.result).toStrictEqual('hello world……');
   });
 
+  test('report invalid ellipsis after valid ellipsis', () => {
+    const md = '前言……他说…';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(fixedResult?.result).toStrictEqual('前言……他说……');
+  });
+
   test('fix long md', () => {
     const md = `
 1. hello world....

--- a/src/rules/no-full-width-number.ts
+++ b/src/rules/no-full-width-number.ts
@@ -22,20 +22,14 @@ const FULL_WIDTH_NUMBER_REPLACEMENT_MAP = {
 const findAllFullWidthNumbers = (s: string) => {
   const re = /[０-９]+/g;
   const r: { number: string; index: number }[] = [];
+  let matched: RegExpExecArray | null;
 
   // 循环找出所有的数字
-  while (true) {
-    const matched = re.exec(s);
-
-    if (matched) {
-      r.push({
-        number: matched[0],
-        index: matched.index
-      });
-    }
-    else {
-      break;
-    }
+  while ((matched = re.exec(s)) !== null) {
+    r.push({
+      number: matched[0],
+      index: matched.index
+    });
   }
   return r;
 };
@@ -83,4 +77,3 @@ const noFullWidthNumber: LintMdRule = {
 };
 
 export default noFullWidthNumber;
-

--- a/src/rules/use-standard-ellipsis.ts
+++ b/src/rules/use-standard-ellipsis.ts
@@ -5,22 +5,17 @@ import type { LintMdRule } from '../types';
  * 找到所有的 …
  */
 const findAllSingleEllipsis = (s: string) => {
-  const r = [];
+  const r: { index: number; length: number }[] = [];
   const re = /…+/g; // 使用正则匹配
+  let matched: RegExpExecArray | null;
 
-  while (true) {
-    const matched = re.exec(s);
-
+  while ((matched = re.exec(s)) !== null) {
     // 只要不是两个，都是不规范的
-    if (matched && matched[0].length !== 2) {
-      // @ts-expect-error
+    if (matched[0].length !== 2) {
       r.push({
         index: matched.index,
         length: matched[0].length
       });
-    }
-    else {
-      break;
     }
   }
   return r;
@@ -30,22 +25,15 @@ const findAllSingleEllipsis = (s: string) => {
  * 找到所有的 . 组成的省略号
  */
 const findAllDotEllipsis = (s: string) => {
-  const r = [];
+  const r: { index: number; length: number }[] = [];
   const re = /\.{4,}/g; // 使用正则匹配
+  let matched: RegExpExecArray | null;
 
-  while (true) {
-    const matched = re.exec(s);
-
-    if (matched) {
-      // @ts-expect-error
-      r.push({
-        index: matched.index,
-        length: matched[0].length
-      });
-    }
-    else {
-      break;
-    }
+  while ((matched = re.exec(s)) !== null) {
+    r.push({
+      index: matched.index,
+      length: matched[0].length
+    });
   }
   return r;
 };


### PR DESCRIPTION
Closes #118

## 改动

| 文件 | 改动 |
|---|---|
| `src/rules/use-standard-ellipsis.ts` | 修复 `findAllSingleEllipsis` 提前 break bug，统一 loop 模式 |
| `src/rules/no-full-width-number.ts` | 统一 loop 模式 |
| `__tests__/unit/rules/use-standard-ellipsis.spec.ts` | 新增回归测试 |

## 核心 Bug

`findAllSingleEllipsis` 遇到正确的 `……` 会进入 else 分支 break 退出，导致后续不规范的省略号被跳过。