### PR TITLE
perf: remove lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "chinese"
   ],
   "dependencies": {
-    "@lint-md/parser": "~0.0.14",
-    "lodash": "^4.17.21"
+    "@lint-md/parser": "~0.0.14"
   },
   "devDependencies": {
     "@attachments/eslint-config": "^0.3.3",
@@ -37,7 +36,6 @@
     "@types/benchmark": "^2.1.2",
     "@types/glob": "^8.0.0",
     "@types/jest": "^29.2.0",
-    "@types/lodash": "^4.14.186",
     "@types/node": "^18.11.7",
     "benchmark": "^2.1.4",
     "eslint": "^8.26.0",

--- a/src/utils/rule-manager.ts
+++ b/src/utils/rule-manager.ts
@@ -1,4 +1,3 @@
-import { isFunction } from 'lodash';
 import type { LintMdRuleWithOptions, ReportOption } from '../types';
 import { createFixer } from './fixer';
 
@@ -23,7 +22,7 @@ export const createRuleManager = (appliedMarkdown: string) => {
   const getAllFixes = () => {
     return allReportedData
       .filter((item) => {
-        return isFunction(item.fix);
+        return typeof item.fix === 'function';
       })
       .map((item) => {
         // @ts-expect-error

--- a/src/utils/traverser.ts
+++ b/src/utils/traverser.ts
@@ -1,7 +1,8 @@
-import { noop } from 'lodash';
 import type { MarkdownNode } from '@lint-md/parser';
 import type { TraverserOptions } from '../types';
 import { isNode } from './common';
+
+const noop = () => {};
 
 /**
  * 初始化遍历器


### PR DESCRIPTION
Closes #120

移除 50KB `lodash` 依赖，用原生实现替代仅用到的两个工具函数。