### PR TITLE
perf: hoist regex literals to module-level constants in char-helper

### DIFF
--- a/__tests__/unit/common-utils.spec.ts
+++ b/__tests__/unit/common-utils.spec.ts
@@ -1,9 +1,25 @@
 import { parseMd } from '@lint-md/parser';
+import {
+  isChineseCharacter,
+  isEnglishCharacter,
+  isNumberCharacter
+} from '../../src/utils/char-helper';
 import { getTextNodes } from '../../src/utils/get-text-nodes';
 
 describe('test common utils', () => {
   test('test get text node', () => {
     const res = getTextNodes(parseMd('这就是 ~~删除线~~ ![12312313](213213) **啦啦啦**<div>~~123123~~!<a>测试测试</a></div> [123123123!!](12312313)'));
     expect(res).toMatchSnapshot();
+  });
+
+  test('test char helper', () => {
+    expect(isNumberCharacter('1')).toBe(true);
+    expect(isNumberCharacter('a')).toBe(false);
+
+    expect(isChineseCharacter('中')).toBe(true);
+    expect(isChineseCharacter('1')).toBe(false);
+
+    expect(isEnglishCharacter('a')).toBe(true);
+    expect(isEnglishCharacter('中')).toBe(false);
   });
 });

--- a/src/utils/char-helper.ts
+++ b/src/utils/char-helper.ts
@@ -1,11 +1,7 @@
-export const isNumberCharacter = (value: string) => {
-  return /^[0-9]$/.test(value);
-};
+const NUMBER_RE = /^[0-9]$/;
+const CHINESE_RE = /^[\u4E00-\u9FA5]$/;
+const ENGLISH_RE = /^[a-zA-Z]$/;
 
-export const isChineseCharacter = (value: string) => {
-  return /^[\u4E00-\u9FA5]$/.test(value);
-};
-
-export const isEnglishCharacter = (value: string) => {
-  return /^[a-zA-Z]$/.test(value);
-};
+export const isNumberCharacter = (value: string) => NUMBER_RE.test(value);
+export const isChineseCharacter = (value: string) => CHINESE_RE.test(value);
+export const isEnglishCharacter = (value: string) => ENGLISH_RE.test(value);


### PR DESCRIPTION
Closes #122

将 `char-helper.ts` 中三个热路径正则提取到模块级，避免每次调用重复创建 RegExp 对象。同时新增专项单测。