### PR TITLE
chore: update checkout action to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,14 @@ name: build
 
 on: [ pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6.0.2
 
       - name: Install modules
         run: yarn install


### PR DESCRIPTION
## Summary
- update `.github/workflows/build.yml` to use `actions/checkout@v6`
- add `permissions: contents: read` as the recommended minimal permission

## Testing
- not run locally; workflow-only change

Close #124 