### PR TITLE
fix: no-space-in-inline-code backtick handling & correct-title-trailing-punctuation inlineCode skip

### DIFF
--- a/__tests__/unit/rules/correct-title-trailing-punctuation.spec.ts
+++ b/__tests__/unit/rules/correct-title-trailing-punctuation.spec.ts
@@ -51,4 +51,18 @@ describe('test correct-title-trailing-punctuation', () => {
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
     expect(fixedResult?.result).toStrictEqual('# 这是一个错误标题`code`');
   });
+
+  test('still report trailing punctuation in link text before trailing inline code', () => {
+    const md = '# foo [bar~](x) `code`';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(fixedResult?.result).toStrictEqual('# foo [bar](x) `code`');
+  });
+
+  test('still report trailing punctuation in strong text before trailing inline code', () => {
+    const md = '# foo **bar~** `code`';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(fixedResult?.result).toStrictEqual('# foo **bar** `code`');
+  });
 });

--- a/__tests__/unit/rules/correct-title-trailing-punctuation.spec.ts
+++ b/__tests__/unit/rules/correct-title-trailing-punctuation.spec.ts
@@ -37,4 +37,18 @@ describe('test correct-title-trailing-punctuation', () => {
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
     expect(fixedResult?.result).toStrictEqual('# 这就是 ~~删除线~~ ![12312313](213213) **啦啦啦**<div>~~123123~~!<a>测试测试</a></div> [123123123](12312313)');
   });
+
+  test('do not remove punctuation from trailing inline code', () => {
+    const md = '#### 强调符号 `#` 和 `~`';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+    expect(fixedResult?.result).toStrictEqual(md);
+  });
+
+  test('still report trailing punctuation before trailing inline code', () => {
+    const md = '# 这是一个错误标题。`code`';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(fixedResult?.result).toStrictEqual('# 这是一个错误标题`code`');
+  });
 });

--- a/__tests__/unit/rules/no-space-in-inline-code.spec.ts
+++ b/__tests__/unit/rules/no-space-in-inline-code.spec.ts
@@ -6,7 +6,7 @@ const fixer = createFixer([{
 }]);
 
 describe('test no-space-in-inline-code', () => {
-  test('fix applied (by ``)', () => {
+  test('fix applied (by ` `)', () => {
     const md = '- right `      const a = 1     ` 你好';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toBe('- right `const a = 1` 你好');
@@ -17,6 +17,20 @@ describe('test no-space-in-inline-code', () => {
     const md = '```  test  ```';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toStrictEqual('```test```');
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+  });
+
+  test('do not report markdown padding for inline code containing backticks', () => {
+    const md = '``` `` ` `` ```';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(fixedResult?.result).toStrictEqual(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+  });
+
+  test('fix applied while preserving safe backtick padding', () => {
+    const md = '```  `` ` ``  ```';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(fixedResult?.result).toStrictEqual('``` `` ` `` ```');
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
   });
 });

--- a/__tests__/unit/rules/no-space-in-inline-code.spec.ts
+++ b/__tests__/unit/rules/no-space-in-inline-code.spec.ts
@@ -33,4 +33,18 @@ describe('test no-space-in-inline-code', () => {
     expect(fixedResult?.result).toStrictEqual('``` `` ` `` ```');
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
   });
+
+  test('no report for inline code containing tilde without spaces', () => {
+    const md = '- explain `~` symbol';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(fixedResult?.result).toStrictEqual(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+  });
+
+  test('fix applied for inline code with tilde and spaces', () => {
+    const md = '- explain `  ~  ` symbol';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(fixedResult?.result).toStrictEqual('- explain `~` symbol');
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+  });
 });

--- a/src/rules/correct-title-trailing-punctuation.ts
+++ b/src/rules/correct-title-trailing-punctuation.ts
@@ -12,7 +12,8 @@ const correctTitleTrailingPunctuation: LintMdRule = {
       heading: (node) => {
         const lastTextNode = getTextNodes(node)
           .filter((item) => item.type !== 'inlineCode')
-          .pop();
+          .reverse()
+          .find((item) => item.value.trimEnd().length > 0);
         if (lastTextNode) {
           const val: string = lastTextNode.value.trimEnd();
 

--- a/src/rules/correct-title-trailing-punctuation.ts
+++ b/src/rules/correct-title-trailing-punctuation.ts
@@ -10,7 +10,9 @@ const correctTitleTrailingPunctuation: LintMdRule = {
   create: (context) => {
     return {
       heading: (node) => {
-        const lastTextNode = getTextNodes(node).pop();
+        const lastTextNode = getTextNodes(node)
+          .filter((item) => item.type !== 'inlineCode')
+          .pop();
         if (lastTextNode) {
           const val: string = lastTextNode.value.trimEnd();
 

--- a/src/rules/no-space-in-inline-code.ts
+++ b/src/rules/no-space-in-inline-code.ts
@@ -1,9 +1,17 @@
 import type { MarkdownCodeNode } from '@lint-md/parser';
 import type { LintMdRule, LintMdRuleContext } from '../types';
 
-const getFenceLength = (raw: string) => {
-  const match = raw.match(/^`+/);
-  return match?.[0].length || 1;
+const runReport = (ctx: LintMdRuleContext, node: MarkdownCodeNode, value: string, fenceLength: number) => {
+  ctx.report({
+    loc: node.position,
+    message: '行内代码内容，前后不能有空格，请删除行内代码中的前后空格',
+    fix: (fixer) => {
+      return fixer.replaceTextRange([
+        node.position.start.offset,
+        node.position.end.offset
+      ], getSerializedInlineCode(value, fenceLength));
+    }
+  });
 };
 
 const getSerializedInlineCode = (content: string, preferredFenceLength: number) => {
@@ -20,17 +28,9 @@ const getSerializedInlineCode = (content: string, preferredFenceLength: number) 
   return `${fence}${requiresPadding ? ` ${content} ` : content}${fence}`;
 };
 
-const runReport = (ctx: LintMdRuleContext, node: MarkdownCodeNode, value: string, fenceLength: number) => {
-  ctx.report({
-    loc: node.position,
-    message: '行内代码内容，前后不能有空格，请删除行内代码中的前后空格',
-    fix: (fixer) => {
-      return fixer.replaceTextRange([
-        node.position.start.offset,
-        node.position.end.offset
-      ], getSerializedInlineCode(value, fenceLength));
-    }
-  });
+const getFenceLength = (raw: string) => {
+  const match = raw.match(/^`+/);
+  return match?.[0].length || 1;
 };
 
 const noSpaceInInlineCode: LintMdRule = {

--- a/src/rules/no-space-in-inline-code.ts
+++ b/src/rules/no-space-in-inline-code.ts
@@ -1,7 +1,26 @@
 import type { MarkdownCodeNode } from '@lint-md/parser';
 import type { LintMdRule, LintMdRuleContext } from '../types';
 
-const runReport = (ctx: LintMdRuleContext, node: MarkdownCodeNode, value: string, type: 'long' | 'short') => {
+const getFenceLength = (raw: string) => {
+  const match = raw.match(/^`+/);
+  return match?.[0].length || 1;
+};
+
+const getSerializedInlineCode = (content: string, preferredFenceLength: number) => {
+  const backtickRuns: string[] = content.match(/`+/g) || [];
+  const maxBacktickRunLength = backtickRuns.reduce((max, item) => {
+    return Math.max(max, item.length);
+  }, 0);
+
+  const fenceLength = Math.max(preferredFenceLength, maxBacktickRunLength + 1, 1);
+  const fence = '`'.repeat(fenceLength);
+  const requiresPadding = content.startsWith('`')
+    || content.endsWith('`');
+
+  return `${fence}${requiresPadding ? ` ${content} ` : content}${fence}`;
+};
+
+const runReport = (ctx: LintMdRuleContext, node: MarkdownCodeNode, value: string, fenceLength: number) => {
   ctx.report({
     loc: node.position,
     message: '行内代码内容，前后不能有空格，请删除行内代码中的前后空格',
@@ -9,7 +28,7 @@ const runReport = (ctx: LintMdRuleContext, node: MarkdownCodeNode, value: string
       return fixer.replaceTextRange([
         node.position.start.offset,
         node.position.end.offset
-      ], type === 'long' ? `\`\`\`${value}\`\`\`` : `\`${value}\``);
+      ], getSerializedInlineCode(value, fenceLength));
     }
   });
 };
@@ -23,19 +42,11 @@ const noSpaceInInlineCode: LintMdRule = {
       inlineCode: (node: MarkdownCodeNode) => {
         const { position } = node;
 
-        // 由于 parser 的问题，这里需要从 md 直接获取文本
-        const result = context.markdown.slice(position.start.offset, position.end.offset);
-        if (result.startsWith('```')) {
-          const internalContent = result.slice(3, -3);
-          if (internalContent.trim() !== internalContent) {
-            runReport(context, node, internalContent.trim(), 'long');
-          }
-        }
-        else {
-          const internalContent = result.slice(1, -1);
-          if (internalContent.trim() !== internalContent) {
-            runReport(context, node, internalContent.trim(), 'short');
-          }
+        const raw = context.markdown.slice(position.start.offset, position.end.offset);
+        const trimmedContent = node.value.trim();
+
+        if (trimmedContent !== node.value) {
+          runReport(context, node, trimmedContent, getFenceLength(raw));
         }
       }
     };


### PR DESCRIPTION
Closes #112

## Summary

### Bug 1: `no-space-in-inline-code` mis-deletes content in code blocks (e.g. `~`)
- Replaced manual `result.slice(1, -1)` / `result.slice(3, -3)` slicing with `node.value` from the AST parser
- Added dynamic fence length computation (`getFenceLength` / `getSerializedInlineCode`) to correctly handle content containing backticks

### Bug 2: `correct-title-trailing-punctuation` strips `~` and ```` from inline code in headings
- Filter out `inlineCode` nodes from `getTextNodes` results, preventing forbidden punctuation inside inline code from being removed while still reporting violations in surrounding text

## Changes
- `src/rules/no-space-in-inline-code.ts` — use node.value + dynamic fence length
- `src/rules/correct-title-trailing-punctuation.ts` — skip inlineCode text nodes  
- Corresponding test coverage for backtick and inline code edge cases