### PR TITLE
fix: detect percent suffix of number in space-around-number

### DIFF
--- a/__tests__/unit/rules/space-around-number.spec.ts
+++ b/__tests__/unit/rules/space-around-number.spec.ts
@@ -21,4 +21,18 @@ describe('test space-around-number', () => {
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(3);
     expect(fixedResult?.result).toStrictEqual(fixedMarkdownToCheck);
   });
+
+  test('fix applied for percentage between chinese text', () => {
+    const md = '100%测试 测试100%';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual('100% 测试 测试 100%');
+  });
+
+  test('does not treat symbols as alphabet through this rule', () => {
+    const md = 'C#教程 中文#标签';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+    expect(fixedResult?.result).toStrictEqual(md);
+  });
 });

--- a/src/rules/space-around-number.ts
+++ b/src/rules/space-around-number.ts
@@ -1,9 +1,22 @@
 import type { MarkdownTextNode } from '@lint-md/parser';
 import type { LintMdRule } from '../types';
-import { markText } from '../utils/mark-text';
+import { isChineseCharacter, isNumberCharacter } from '../utils/char-helper';
 
-const isMarkedTextBetweenChineseAndNumber = (value: string) => {
-  return value === 'ZN' || value === 'NZ';
+const isPercentSuffixOfNumber = (value: string, index: number) => {
+  return value[index] === '%' && index > 0 && isNumberCharacter(value[index - 1]);
+};
+
+const shouldInsertSpaceBetween = (value: string, index: number) => {
+  const currentCharacter = value[index];
+  const nextCharacter = value[index + 1];
+
+  if (!currentCharacter || !nextCharacter) {
+    return false;
+  }
+
+  return (isChineseCharacter(currentCharacter) && isNumberCharacter(nextCharacter))
+    || (isNumberCharacter(currentCharacter) && isChineseCharacter(nextCharacter))
+    || (isPercentSuffixOfNumber(value, index) && isChineseCharacter(nextCharacter));
 };
 
 const spaceAroundNumber: LintMdRule = {
@@ -14,11 +27,9 @@ const spaceAroundNumber: LintMdRule = {
     return {
       text: (node: MarkdownTextNode) => {
         const { value } = node;
-        const markedText = markText(value);
 
-        for (let i = 0; i < markedText.length - 1; i++) {
-          const checkStrFragment = markedText.slice(i, i + 2);
-          if (isMarkedTextBetweenChineseAndNumber(checkStrFragment)) {
+        for (let i = 0; i < value.length - 1; i++) {
+          if (shouldInsertSpaceBetween(value, i)) {
             // 最终定位
             const loc = node.position;
             // start 定位到英文字符串前中文字符的位置，end 定位到英文字符串后中文字符的位置


### PR DESCRIPTION
## 修复内容

修复 `space-around-number` 规则对百分号的处理。

半角的百分号视同阿拉伯数字（参考[阮一峰《中文技术文档的写作规范》](https://github.com/ruanyf/document-style-guide#字间距)），`100%测试` 应检测为需要插入空格。

### 变更

- `space-around-number.ts`：新增 `isPercentSuffixOfNumber` 检测数字后的 `%` 符号，将其视为数字边界
- 回归测试：验证 `100%测试` / `测试100%` 正确插入空格，`C#教程` 不误报

Closes #111