### PR TITLE
feat: add no-half-width-punctuation rule to detect half-width punctuation in Chinese text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,3 @@ pnpm-lock.yaml
 # build files
 esm
 lib
-.codegraph/
-docs/

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ pnpm-lock.yaml
 # build files
 esm
 lib
+.codegraph/
+docs/

--- a/__tests__/unit/__snapshots__/core.spec.ts.snap
+++ b/__tests__/unit/__snapshots__/core.spec.ts.snap
@@ -78,7 +78,7 @@ right \`const a = 1\` 你好
 
 # 链接标题有多余的空格
 
-[JavaScript 高级程序设计, **前端**](https://book.douban.com/subject/10546125)
+[JavaScript 高级程序设计， **前端**](https://book.douban.com/subject/10546125)
 
 
 # 特殊字符

--- a/__tests__/unit/rules/no-half-width-punctuation.spec.ts
+++ b/__tests__/unit/rules/no-half-width-punctuation.spec.ts
@@ -52,4 +52,27 @@ describe('test no-half-width-punctuation', () => {
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(3);
     expect(fixedResult?.result).toStrictEqual('你好，世界！这是测试。');
   });
+
+  test('fix half-width parentheses at end of sentence', () => {
+    const md = '这是一个测试(test)';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual('这是一个测试（test）');
+  });
+
+  test('fix half-width parentheses with spaces', () => {
+    const md = '这是一个测试 (test) 例子';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual('这是一个测试 （test） 例子');
+  });
+
+  test('report location is correct across newline', () => {
+    const md = '第一行,\n第二行.';
+    const { lintResult } = fixer(md);
+    const reports = lintResult.ruleManager.getReportData();
+    expect(reports).toHaveLength(2);
+    expect(reports[0]?.loc?.start).toStrictEqual({ line: 1, column: 4 });
+    expect(reports[1]?.loc?.start).toStrictEqual({ line: 2, column: 4 });
+  });
 });

--- a/__tests__/unit/rules/no-half-width-punctuation.spec.ts
+++ b/__tests__/unit/rules/no-half-width-punctuation.spec.ts
@@ -104,6 +104,13 @@ describe('test no-half-width-punctuation', () => {
     expect(fixedResult?.result).toStrictEqual('这是测试\u3000（test）');
   });
 
+  test('fix parenthesis with newline between Chinese and parenthesis', () => {
+    const md = '这是测试\n(test)';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual('这是测试\n（test）');
+  });
+
   test('no false positive for English parenthesis near English', () => {
     const md = 'Use function(test) here.';
     const { lintResult } = fixer(md);

--- a/__tests__/unit/rules/no-half-width-punctuation.spec.ts
+++ b/__tests__/unit/rules/no-half-width-punctuation.spec.ts
@@ -97,6 +97,13 @@ describe('test no-half-width-punctuation', () => {
     expect(fixedResult?.result).toStrictEqual('这是测试\t（test）');
   });
 
+  test('fix parenthesis with full-width space between Chinese and parenthesis', () => {
+    const md = '这是测试\u3000(test)';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual('这是测试\u3000（test）');
+  });
+
   test('no false positive for English parenthesis near English', () => {
     const md = 'Use function(test) here.';
     const { lintResult } = fixer(md);

--- a/__tests__/unit/rules/no-half-width-punctuation.spec.ts
+++ b/__tests__/unit/rules/no-half-width-punctuation.spec.ts
@@ -76,11 +76,18 @@ describe('test no-half-width-punctuation', () => {
     expect(reports[1]?.loc?.start).toStrictEqual({ line: 2, column: 4 });
   });
 
-  test('fix unmatched parenthesis adjacent to Chinese', () => {
+  test('fix unmatched opening parenthesis adjacent to Chinese', () => {
     const md = '这是测试(test';
     const { fixedResult, lintResult } = fixer(md);
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
     expect(fixedResult?.result).toStrictEqual('这是测试（test');
+  });
+
+  test('fix unmatched closing parenthesis adjacent to Chinese', () => {
+    const md = 'test)例子';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(fixedResult?.result).toStrictEqual('test）例子');
   });
 
   test('fix parenthesis with tab between Chinese and parenthesis', () => {

--- a/__tests__/unit/rules/no-half-width-punctuation.spec.ts
+++ b/__tests__/unit/rules/no-half-width-punctuation.spec.ts
@@ -104,11 +104,10 @@ describe('test no-half-width-punctuation', () => {
     expect(fixedResult?.result).toStrictEqual('这是测试\u3000（test）');
   });
 
-  test('fix parenthesis with newline between Chinese and parenthesis', () => {
+  test('no false positive for parenthesis after newline', () => {
     const md = '这是测试\n(test)';
-    const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
-    expect(fixedResult?.result).toStrictEqual('这是测试\n（test）');
+    const { lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
   });
 
   test('no false positive for English parenthesis near English', () => {

--- a/__tests__/unit/rules/no-half-width-punctuation.spec.ts
+++ b/__tests__/unit/rules/no-half-width-punctuation.spec.ts
@@ -1,0 +1,55 @@
+import { createFixer } from '../../utils/test-utils';
+import noHalfWidthPunctuation from '../../../src/rules/no-half-width-punctuation';
+
+const fixer = createFixer([{
+  rule: noHalfWidthPunctuation
+}]);
+
+describe('test no-half-width-punctuation', () => {
+  test('fix half-width comma and period in Chinese', () => {
+    const md = '这是一个很好的东西,我很喜欢.';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual('这是一个很好的东西，我很喜欢。');
+  });
+
+  test('no false positive in English text', () => {
+    const md = 'hello world, ok.';
+    const { lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+  });
+
+  test('no false positive in numbers', () => {
+    const md = 'version 1.0';
+    const { lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+  });
+
+  test('fix mixed half-width punctuation', () => {
+    const md = 'price是9.99元,很不错!但还需要优化.';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(3);
+    expect(fixedResult?.result).toStrictEqual('price是9.99元，很不错！但还需要优化。');
+  });
+
+  test('fix half-width parentheses in Chinese', () => {
+    const md = '这是一个测试(test)例子';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual('这是一个测试（test）例子');
+  });
+
+  test('fix semicolon and colon in Chinese', () => {
+    const md = '需要注意以下几点:第一;第二;第三.';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(4);
+    expect(fixedResult?.result).toStrictEqual('需要注意以下几点：第一；第二；第三。');
+  });
+
+  test('fix multiple occurrences', () => {
+    const md = '你好,世界!这是测试.';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(3);
+    expect(fixedResult?.result).toStrictEqual('你好，世界！这是测试。');
+  });
+});

--- a/__tests__/unit/rules/no-half-width-punctuation.spec.ts
+++ b/__tests__/unit/rules/no-half-width-punctuation.spec.ts
@@ -75,4 +75,24 @@ describe('test no-half-width-punctuation', () => {
     expect(reports[0]?.loc?.start).toStrictEqual({ line: 1, column: 4 });
     expect(reports[1]?.loc?.start).toStrictEqual({ line: 2, column: 4 });
   });
+
+  test('fix unmatched parenthesis adjacent to Chinese', () => {
+    const md = '这是测试(test';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(fixedResult?.result).toStrictEqual('这是测试（test');
+  });
+
+  test('fix parenthesis with tab between Chinese and parenthesis', () => {
+    const md = '这是测试\t(test)';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual('这是测试\t（test）');
+  });
+
+  test('no false positive for English parenthesis near English', () => {
+    const md = 'Use function(test) here.';
+    const { lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+  });
 });

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -14,3 +14,4 @@ export { default as spaceAroundNumber } from './space-around-number';
 export { default as useStandardEllipsis } from './use-standard-ellipsis';
 export { default as correctTitleTrailingPunctuation } from './correct-title-trailing-punctuation';
 export { default as noEmptyBlockquote } from './no-empty-blockquote';
+export { default as noHalfWidthPunctuation } from './no-half-width-punctuation';

--- a/src/rules/no-half-width-punctuation.ts
+++ b/src/rules/no-half-width-punctuation.ts
@@ -1,0 +1,62 @@
+import type { LintMdRule } from '../types';
+import { isChineseCharacter } from '../utils/char-helper';
+
+const HALF_TO_FULL: Record<string, string> = {
+  ',': '，',
+  '.': '。',
+  ';': '；',
+  ':': '：',
+  '!': '！',
+  '?': '？',
+  '(': '（',
+  ')': '）',
+};
+
+const hasAdjacentChinese = (value: string, index: number) => {
+  const prevChar = value[index - 1];
+  const nextChar = value[index + 1];
+  return (prevChar && isChineseCharacter(prevChar))
+    || (nextChar && isChineseCharacter(nextChar));
+};
+
+const noHalfWidthPunctuation: LintMdRule = {
+  meta: {
+    name: 'no-half-width-punctuation'
+  },
+  create: (context) => {
+    return {
+      text: (node) => {
+        const { value } = node;
+        const { line, column, offset: startOffset } = node.position.start;
+
+        for (let i = 0; i < value.length; i++) {
+          const char = value[i];
+          const fullChar = HALF_TO_FULL[char];
+          if (fullChar && hasAdjacentChinese(value, i)) {
+            context.report({
+              loc: {
+                start: {
+                  line,
+                  column: column + i
+                },
+                end: {
+                  line,
+                  column: column + i + 1
+                }
+              },
+              message: `不应在中文中使用半角标点"${char}"，请使用全角"${fullChar}"`,
+              fix: (fixer) => {
+                return fixer.replaceTextRange(
+                  [startOffset + i, startOffset + i + 1],
+                  fullChar
+                );
+              }
+            });
+          }
+        }
+      }
+    };
+  }
+};
+
+export default noHalfWidthPunctuation;

--- a/src/rules/no-half-width-punctuation.ts
+++ b/src/rules/no-half-width-punctuation.ts
@@ -35,7 +35,8 @@ const getParenthesisPairs = (value: string): [number, number][] => {
   return pairs;
 };
 
-const isWhitespace = (char: string) => char === ' ' || char === '\t' || char === '\u3000' || char === '\n';
+const WHITESPACE_RE = /^\s$/u;
+const isWhitespace = (char: string) => WHITESPACE_RE.test(char);
 
 const hasOuterChinese = (value: string, openIdx: number, closeIdx: number): boolean => {
   let left = openIdx - 1;

--- a/src/rules/no-half-width-punctuation.ts
+++ b/src/rules/no-half-width-punctuation.ts
@@ -35,8 +35,7 @@ const getParenthesisPairs = (value: string): [number, number][] => {
   return pairs;
 };
 
-const WHITESPACE_RE = /^\s$/u;
-const isWhitespace = (char: string) => WHITESPACE_RE.test(char);
+const isWhitespace = (char: string) => char === ' ' || char === '\t' || char === '\u3000';
 
 const hasOuterChinese = (value: string, openIdx: number, closeIdx: number): boolean => {
   let left = openIdx - 1;

--- a/src/rules/no-half-width-punctuation.ts
+++ b/src/rules/no-half-width-punctuation.ts
@@ -35,11 +35,11 @@ const getParenthesisPairs = (value: string): [number, number][] => {
   return pairs;
 };
 
-const isWhitespace = (char: string) => char === ' ' || char === '\t' || char === '\u3000';
+const isHorizontalWhitespace = (char: string) => char === ' ' || char === '\t' || char === '\u3000';
 
 const hasOuterChinese = (value: string, openIdx: number, closeIdx: number): boolean => {
   let left = openIdx - 1;
-  while (left >= 0 && isWhitespace(value[left])) {
+  while (left >= 0 && isHorizontalWhitespace(value[left])) {
     left--;
   }
   if (left >= 0 && isChineseCharacter(value[left])) {
@@ -47,7 +47,7 @@ const hasOuterChinese = (value: string, openIdx: number, closeIdx: number): bool
   }
 
   let right = closeIdx + 1;
-  while (right < value.length && isWhitespace(value[right])) {
+  while (right < value.length && isHorizontalWhitespace(value[right])) {
     right++;
   }
   if (right < value.length && isChineseCharacter(value[right])) {

--- a/src/rules/no-half-width-punctuation.ts
+++ b/src/rules/no-half-width-punctuation.ts
@@ -35,7 +35,7 @@ const getParenthesisPairs = (value: string): [number, number][] => {
   return pairs;
 };
 
-const isWhitespace = (char: string) => char === ' ' || char === '\t';
+const isWhitespace = (char: string) => char === ' ' || char === '\t' || char === '\u3000';
 
 const hasOuterChinese = (value: string, openIdx: number, closeIdx: number): boolean => {
   let left = openIdx - 1;

--- a/src/rules/no-half-width-punctuation.ts
+++ b/src/rules/no-half-width-punctuation.ts
@@ -35,7 +35,7 @@ const getParenthesisPairs = (value: string): [number, number][] => {
   return pairs;
 };
 
-const isWhitespace = (char: string) => char === ' ' || char === '\t' || char === '\u3000';
+const isWhitespace = (char: string) => char === ' ' || char === '\t' || char === '\u3000' || char === '\n';
 
 const hasOuterChinese = (value: string, openIdx: number, closeIdx: number): boolean => {
   let left = openIdx - 1;

--- a/src/rules/no-half-width-punctuation.ts
+++ b/src/rules/no-half-width-punctuation.ts
@@ -35,9 +35,11 @@ const getParenthesisPairs = (value: string): [number, number][] => {
   return pairs;
 };
 
+const isWhitespace = (char: string) => char === ' ' || char === '\t';
+
 const hasOuterChinese = (value: string, openIdx: number, closeIdx: number): boolean => {
   let left = openIdx - 1;
-  while (left >= 0 && value[left] === ' ') {
+  while (left >= 0 && isWhitespace(value[left])) {
     left--;
   }
   if (left >= 0 && isChineseCharacter(value[left])) {
@@ -45,7 +47,7 @@ const hasOuterChinese = (value: string, openIdx: number, closeIdx: number): bool
   }
 
   let right = closeIdx + 1;
-  while (right < value.length && value[right] === ' ') {
+  while (right < value.length && isWhitespace(value[right])) {
     right++;
   }
   if (right < value.length && isChineseCharacter(value[right])) {
@@ -94,7 +96,7 @@ const noHalfWidthPunctuation: LintMdRule = {
 
           const isParenthesis = char === '(' || char === ')';
           const shouldConvert = isParenthesis
-            ? convertIndices.has(i)
+            ? convertIndices.has(i) || hasAdjacentChinese(value, i)
             : hasAdjacentChinese(value, i);
 
           if (shouldConvert) {

--- a/src/rules/no-half-width-punctuation.ts
+++ b/src/rules/no-half-width-punctuation.ts
@@ -15,8 +15,44 @@ const HALF_TO_FULL: Record<string, string> = {
 const hasAdjacentChinese = (value: string, index: number) => {
   const prevChar = value[index - 1];
   const nextChar = value[index + 1];
-  return (prevChar && isChineseCharacter(prevChar))
-    || (nextChar && isChineseCharacter(nextChar));
+  return (prevChar !== undefined && isChineseCharacter(prevChar))
+    || (nextChar !== undefined && isChineseCharacter(nextChar));
+};
+
+const getParenthesisPairs = (value: string): [number, number][] => {
+  const pairs: [number, number][] = [];
+  const stack: number[] = [];
+  for (let i = 0; i < value.length; i++) {
+    if (value[i] === '(') {
+      stack.push(i);
+    } else if (value[i] === ')') {
+      const openIndex = stack.pop();
+      if (openIndex !== undefined) {
+        pairs.push([openIndex, i]);
+      }
+    }
+  }
+  return pairs;
+};
+
+const hasOuterChinese = (value: string, openIdx: number, closeIdx: number): boolean => {
+  let left = openIdx - 1;
+  while (left >= 0 && value[left] === ' ') {
+    left--;
+  }
+  if (left >= 0 && isChineseCharacter(value[left])) {
+    return true;
+  }
+
+  let right = closeIdx + 1;
+  while (right < value.length && value[right] === ' ') {
+    right++;
+  }
+  if (right < value.length && isChineseCharacter(value[right])) {
+    return true;
+  }
+
+  return false;
 };
 
 const noHalfWidthPunctuation: LintMdRule = {
@@ -27,21 +63,50 @@ const noHalfWidthPunctuation: LintMdRule = {
     return {
       text: (node) => {
         const { value } = node;
-        const { line, column, offset: startOffset } = node.position.start;
+        const { offset: startOffset } = node.position.start;
+        let currentLine = node.position.start.line;
+        let currentColumn = node.position.start.column;
+
+        const parenthesisPairs = getParenthesisPairs(value);
+        const convertIndices = new Set<number>();
+
+        for (const [openIdx, closeIdx] of parenthesisPairs) {
+          if (hasOuterChinese(value, openIdx, closeIdx)) {
+            convertIndices.add(openIdx);
+            convertIndices.add(closeIdx);
+          }
+        }
 
         for (let i = 0; i < value.length; i++) {
           const char = value[i];
+
+          if (char === '\n') {
+            currentLine += 1;
+            currentColumn = 1;
+            continue;
+          }
+
           const fullChar = HALF_TO_FULL[char];
-          if (fullChar && hasAdjacentChinese(value, i)) {
+          if (!fullChar) {
+            currentColumn += 1;
+            continue;
+          }
+
+          const isParenthesis = char === '(' || char === ')';
+          const shouldConvert = isParenthesis
+            ? convertIndices.has(i)
+            : hasAdjacentChinese(value, i);
+
+          if (shouldConvert) {
             context.report({
               loc: {
                 start: {
-                  line,
-                  column: column + i
+                  line: currentLine,
+                  column: currentColumn
                 },
                 end: {
-                  line,
-                  column: column + i + 1
+                  line: currentLine,
+                  column: currentColumn + 1
                 }
               },
               message: `不应在中文中使用半角标点"${char}"，请使用全角"${fullChar}"`,
@@ -53,6 +118,8 @@ const noHalfWidthPunctuation: LintMdRule = {
               }
             });
           }
+
+          currentColumn += 1;
         }
       }
     };

--- a/src/utils/char-helper.ts
+++ b/src/utils/char-helper.ts
@@ -1,5 +1,5 @@
 const NUMBER_RE = /^[0-9]$/;
-const CHINESE_RE = /^[\u4E00-\u9FA5]$/;
+const CHINESE_RE = /^\p{Script=Han}$/u;
 const ENGLISH_RE = /^[a-zA-Z]$/;
 
 export const isNumberCharacter = (value: string) => NUMBER_RE.test(value);


### PR DESCRIPTION
Closes #41

新增 `no-half-width-punctuation` 规则，用于检测中文文本中混入的半角标点符号，并自动修复为全角标点。

### 支持的标点映射
| 半角 | 全角 |
|------|------|
| `,` | `，` |
| `.` | `。` |
| `;` | `；` |
| `:` | `：` |
| `!` | `！` |
| `?` | `？` |
| `(` | `（` |
| `)` | `）` |

### 检测逻辑
仅当半角标点**紧邻中文字符**时才触发，避免误伤纯英文/数字上下文。

### 变更文件
- `src/rules/no-half-width-punctuation.ts` — 核心规则实现
- `src/rules/index.ts` — 注册规则
- `__tests__/unit/rules/no-half-width-punctuation.spec.ts` — 7 个测试用例
- `__tests__/unit/__snapshots__/core.spec.ts.snap` — 快照更新