### PR TITLE
fix(build): replace yarn with npm and add push trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: build
 
-on: [ pull_request ]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 permissions:
   contents: read
@@ -12,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
 
       - name: Install modules
-        run: yarn install
+        run: npm install
 
       - name: Run tests
-        run: yarn test
+        run: npm test


### PR DESCRIPTION
Closes #133

## 变更

| 行 | Before | After |
|----|--------|-------|
| 3 | `on: [ pull_request ]` | `on: push + pull_request` |
| 15 | `yarn install` | `npm install` |
| 18 | `yarn test` | `npm test` |

## 原因

- 仓库使用 `package-lock.json`（npm），CI 不应该用 `yarn`
- 加 `push` 触发确保 master 合并后也跑 CI