### PR TITLE
refactor(lint-markdown): replace require() with static import for type safety

### DIFF
--- a/src/core/lint-markdown.ts
+++ b/src/core/lint-markdown.ts
@@ -1,9 +1,8 @@
-import * as path from 'path';
 import type {
-  LintMdRule,
   LintMdRuleWithOptions,
   LintMdRulesConfig
 } from '../types';
+import * as internalRuleConfig from '../rules';
 import { overrideDefaultRules } from '../utils/override-default-rules';
 import { RULE_SEVERITY } from '../types';
 import { runLint } from './run-lint';
@@ -28,10 +27,6 @@ export const lintMarkdownInternal = (markdown: string, rules: LintMdRuleWithOpti
  * @date 2021-12-14 17:16:12
  */
 export const lintMarkdown = (markdown: string, rules: LintMdRulesConfig = {}, isFixMode = true) => {
-  // 获取内部 rules
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const internalRuleConfig: Record<string, LintMdRule> = require('../rules');
-
   // 基于用户配置覆盖默认配置
   const registeredRules = overrideDefaultRules(internalRuleConfig, rules);
 


### PR DESCRIPTION
## 变更

`src/core/lint-markdown.ts`: 消除唯一的 `require()` 调用。

```diff
- import * as path from 'path';
- import type { LintMdRule, LintMdRuleWithOptions, LintMdRulesConfig } from '../types';
+ import type { LintMdRuleWithOptions, LintMdRulesConfig } from '../types';
+ import * as internalRuleConfig from '../rules';

- // eslint-disable-next-line @typescript-eslint/no-var-requires
- const internalRuleConfig: Record<string, LintMdRule> = require('../rules');
```

## 效果

| Before | After |
|--------|-------|
| `require()` → 返回值 `any`，手动标注类型 | `import * as` → 编译期自动推导精确类型 |
| 规则改名/删除后运行时才暴露 | 编译期即时报错 |
| 需要 `eslint-disable` 压制 | 无需压制 |

## 验证

- TypeScript `tsc --noEmit` 零错误
- 25 suites / 84 tests 全部通过