### PR TITLE
feat(diagnostics): add LintDiagnostic standard format and toALEOutput converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ lint-md/core 是 lint-md 体系中的规则引擎核心，专注解决中文 Mar
 - **高性能处理能力**：4 vCPU 环境下，处理 1000 篇文档耗时 4s 内。
 - **生态封装完善**：可接入 CLI、Prettier、ESLint、VSCode，也欢迎按业务场景继续封装。
 
+## 🏗️ 架构原则
+
+core 遵循「纯引擎 + 薄适配器」设计：
+
+- **core 零 I/O**：只接受字符串入参，返回结构化数据，不读写文件、不直接输出到终端
+- **集成做 I/O**：CLI、编辑器插件等适配器只负责输入输出和格式转换，不包含规则逻辑
+- **标准诊断**：`LintDiagnostic` 统一诊断格式，core 提供格式转换器（`toALEOutput`），适配器无需自行实现映射
+
 ## 🚀 快速使用
 
 从 API 到结果处理，核心只需要一个方法即可完成 lint/fix。当前对外仅提供 **1 个核心 API**：`lintMarkdown`。
@@ -44,6 +52,7 @@ lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: boolean)
 返回结果：
 
 - `lintResult`：命中规则后的诊断结果列表（含规则名、位置信息、消息、级别）
+- `diagnostics`：标准诊断格式列表（`LintDiagnostic[]`），供编辑器集成直接消费
 - `fixedResult`：开启修复模式时返回修复后的文本，否则为 `null`
 
 下面是一个最小示例，可直接作为接入起点：
@@ -61,6 +70,16 @@ const result = lintMarkdown(markdown, {
 
 console.log(result.lintResult);
 console.log(result.fixedResult);
+```
+
+```ts
+// 使用标准诊断格式接入编辑器（如 Vim/Neovim ALE）
+import { lintMarkdown, toALEOutput } from '@lint-md/core';
+
+const result = lintMarkdown('中文English 123', {}, false);
+console.log(toALEOutput(result.diagnostics, 'test.md'));
+// test.md:1:3: E space-around-alphabet: 中英文之间需要添加空格
+// test.md:1:12: W space-around-number: 中文与数字之间需要添加空格
 ```
 
 `no-long-code` 的 `exclude` 用于排除指定代码语言（如 `['dot', 'mermaid']`）的长度检查。
@@ -98,8 +117,20 @@ lint-md 提供了多个常用场景的官方封装，可按你的工程工具链
 - [@lint-md/prettier-plugin](https://github.com/lint-md/prettier-plugin)：在 Prettier 流程中统一执行中文 Markdown 规范。
 - [@lint-md/eslint-plugin](https://github.com/lint-md/eslint-plugin)：将 Markdown 规则纳入 ESLint 规则体系。
 - [@lint-md/vscode-plugin](https://github.com/lint-md/vscode-plugin)：在 VSCode 中实时提示并辅助修复。
+- [@lint-md/ale](https://github.com/lint-md/ale)：在 Vim/Neovim 中通过 ALE 实时检查 Markdown。
 
 也欢迎大家提交新的生态封装（Issue / PR），我们会持续收录。
+
+### 开发新集成
+
+按照架构原则，新集成的开发步骤（以 ALE 为例）：
+
+1. 依赖 `@lint-md/core`
+2. 调用 `lintMarkdown()` 获取 `diagnostics`
+3. 使用 `toALEOutput()` 或自行转换格式
+4. 处理 stdin/file 输入 → 输出 → 退出码
+
+约 30 行代码即可完成一个新编辑器集成。
 
 ## 📄 License
 

--- a/__tests__/unit/diagnostics.spec.ts
+++ b/__tests__/unit/diagnostics.spec.ts
@@ -1,0 +1,65 @@
+import { lintMarkdown, toALEOutput } from '../../src';
+import type { LintDiagnostic } from '../../src/types';
+
+describe('diagnostics', () => {
+  describe('diagnostics field in lintMarkdown()', () => {
+    test('returns diagnostics array when issues found', () => {
+      const markdown = '中文English 123';
+      const result = lintMarkdown(markdown, {}, false);
+
+      expect(result.diagnostics).toBeDefined();
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+
+    test('diagnostics item matches LintDiagnostic shape', () => {
+      const markdown = '中文English 123';
+      const result = lintMarkdown(markdown, {
+        'space-around-alphabet': 2
+      }, false);
+
+      const d = result.diagnostics[0];
+      expect(typeof d.line).toBe('number');
+      expect(typeof d.column).toBe('number');
+      expect(typeof d.ruleId).toBe('string');
+      expect(typeof d.message).toBe('string');
+      expect(typeof d.severity).toBe('number');
+    });
+
+    test('returns empty diagnostics array when no issues found', () => {
+      const markdown = '# Hello World\n\nThis is clean.';
+      const result = lintMarkdown(markdown, {}, false);
+
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    test('lintResult field is unchanged (backward compat)', () => {
+      const markdown = '中文English 123';
+      const result = lintMarkdown(markdown, {}, false);
+
+      expect(result.lintResult).toBeDefined();
+      expect(result.lintResult.length).toBeGreaterThan(0);
+      expect(result.lintResult[0]).toHaveProperty('loc');
+      expect(result.lintResult[0]).toHaveProperty('message');
+      expect(result.lintResult[0]).toHaveProperty('name');
+      expect(result.lintResult[0]).toHaveProperty('content');
+      expect(result.lintResult[0]).toHaveProperty('severity');
+    });
+  });
+
+  describe('toALEOutput()', () => {
+    test('formats diagnostics in ALE-compatible format', () => {
+      const diagnostics: LintDiagnostic[] = [
+        { line: 1, column: 3, ruleId: 'space-around-alphabet', message: '中英文之间需要添加空格', severity: 2 },
+        { line: 1, column: 12, ruleId: 'space-around-number', message: '中文与数字之间需要添加空格', severity: 1 }
+      ];
+      const output = toALEOutput(diagnostics, '/tmp/test.md');
+
+      expect(output).toContain('/tmp/test.md:1:3: E space-around-alphabet: 中英文之间需要添加空格');
+      expect(output).toContain('/tmp/test.md:1:12: W space-around-number: 中文与数字之间需要添加空格');
+    });
+
+    test('returns empty string for empty diagnostics', () => {
+      expect(toALEOutput([], 'test.md')).toBe('');
+    });
+  });
+});

--- a/src/core/lint-markdown.ts
+++ b/src/core/lint-markdown.ts
@@ -64,8 +64,17 @@ export const lintMarkdown = (markdown: string, rules: LintMdRulesConfig = {}, is
     };
   });
 
+  const diagnostics = (reportDataWithSeverity ?? []).map((item) => ({
+    line: item.loc.start.line,
+    column: item.loc.start.column,
+    ruleId: item.name,
+    message: item.message,
+    severity: item.severity
+  }));
+
   return {
     lintResult: reportDataWithSeverity,
+    diagnostics,
     fixedResult
   };
 };

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,19 @@
+import type { LintDiagnostic } from './types';
+
+/**
+ * 将标准诊断格式转为 ALE (Vim/Neovim) 兼容的输出字符串
+ *
+ * 输出格式：
+ *   <file>:<line>:<col>: <E|W|I> <ruleId>: <message>
+ *
+ * @param diagnostics 标准诊断列表
+ * @param filePath    文件路径
+ * @returns ALE 格式字符串，无诊断时返回空字符串
+ */
+export function toALEOutput(diagnostics: LintDiagnostic[], filePath: string): string {
+  const lines = diagnostics.map((d) => {
+    const type = d.severity === 2 ? 'E' : d.severity === 1 ? 'W' : 'I';
+    return `${filePath}:${d.line}:${d.column}: ${type} ${d.ruleId}: ${d.message}`;
+  });
+  return lines.length ? `${lines.join('\n')}\n` : '';
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { lintMarkdown } from './core/lint-markdown';
 export * from './rules';
 export * from './types';
+export { toALEOutput } from './diagnostics';

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,3 +102,17 @@ export enum RULE_SEVERITY {
 /** 注册的规则 */
 export type RegisteredRules = Record<string, LintMdRuleWithOptions & { severity: number }>;
 
+/** 标准诊断格式，供各集成平台消费 */
+export interface LintDiagnostic {
+  /** 行号（1-indexed） */
+  line: number
+  /** 列号（1-indexed） */
+  column: number
+  /** 规则名 */
+  ruleId: string
+  /** 诊断消息 */
+  message: string
+  /** 严重级别 */
+  severity: RULE_SEVERITY
+}
+


### PR DESCRIPTION
close #47 

## 变更

为 core 新增标准诊断格式，降低各集成平台的映射成本。

### 新增文件

**`src/diagnostics.ts`** — 格式转换器
- `toALEOutput(diagnostics, filePath)` → 输出 ALE 兼容格式

### 修改文件

**`src/types.ts`** — 新增 `LintDiagnostic` 接口

```ts
interface LintDiagnostic {
  line: number      // 1-indexed
  column: number    // 1-indexed
  ruleId: string
  message: string
  severity: RULE_SEVERITY
}
```

**`src/core/lint-markdown.ts`** — 返回值新增 `diagnostics` 字段

**`src/index.ts`** — 导出 `toALEOutput`

### 向后兼容

- `lintResult` 字段完全不变，现有测试全部通过
- `diagnostics` 作为新字段并行存在

### 用法示例

```ts
import { lintMarkdown, toALEOutput } from '@lint-md/core';

const result = lintMarkdown(markdown);
console.log(toALEOutput(result.diagnostics, '/tmp/test.md'));
// /tmp/test.md:1:3: E space-around-alphabet: 中英文之间需要添加空格
```

### 验证

- TypeScript `tsc --noEmit` 零错误
- 26 suites / 90 tests 全部通过（新增 6 个 diagnostics 测试）