### PR TITLE
fix(run-lint): replace console.log with console.error to surface rule execution failures

### DIFF
--- a/src/core/run-lint.ts
+++ b/src/core/run-lint.ts
@@ -26,8 +26,9 @@ export const runLint = (markdown: string, allRuleConfigs: LintMdRuleWithOptions[
           emitter.emit(node.type, node);
         }
         catch (e) {
-          // eslint-disable-next-line no-console
-          console.log(e);
+          if (e instanceof Error) {
+            console.error(`[lint-md] rule execution error on node type="${node.type}": ${e.message}`);
+          }
         }
       }
     }


### PR DESCRIPTION
Closes #140

## 改动

`src/core/run-lint.ts:28-32` — rule handler 异常处理：

- `console.log(e)` → `console.error(`[lint-md] rule execution error on node type="${node.type}": ${e.message}`)`
- 添加 `instanceof Error` 类型守卫

## 验证

- `tsc --noEmit`: 零错误
- `npm test`: 26 suites / 90 tests 全部通过