### PR TITLE
ci(build.yml,README): replace codecov with native build badge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,3 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7.0.0
-        with:
-          directory: coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,28 +20,3 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Coverage summary
-        run: |
-          node - <<'NODE' >> "$GITHUB_STEP_SUMMARY"
-          const fs = require('fs');
-          const path = 'coverage/coverage-summary.json';
-
-          if (!fs.existsSync(path)) {
-            console.log('## Coverage');
-            console.log('');
-            console.log('No coverage summary found.');
-            process.exit(0);
-          }
-
-          const s = JSON.parse(fs.readFileSync(path, 'utf8')).total;
-
-          console.log('## Coverage');
-          console.log('');
-          console.log('| Metric | Covered | Total | % |');
-          console.log('| --- | ---: | ---: | ---: |');
-          for (const key of ['lines', 'statements', 'functions', 'branches']) {
-            const v = s[key];
-            console.log(`| ${key} | ${v.covered} | ${v.total} | ${v.pct}% |`);
-          }
-          NODE
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,3 +20,28 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Coverage summary
+        run: |
+          node - <<'NODE' >> "$GITHUB_STEP_SUMMARY"
+          const fs = require('fs');
+          const path = 'coverage/coverage-summary.json';
+
+          if (!fs.existsSync(path)) {
+            console.log('## Coverage');
+            console.log('');
+            console.log('No coverage summary found.');
+            process.exit(0);
+          }
+
+          const s = JSON.parse(fs.readFileSync(path, 'utf8')).total;
+
+          console.log('## Coverage');
+          console.log('');
+          console.log('| Metric | Covered | Total | % |');
+          console.log('| --- | ---: | ---: | ---: |');
+          for (const key of ['lines', 'statements', 'functions', 'branches']) {
+            const v = s[key];
+            console.log(`| ${key} | ${v.covered} | ${v.total} | ${v.pct}% |`);
+          }
+          NODE
+

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ lint-md/core 是 lint-md 体系中的规则引擎核心，专注解决中文 Mar
 [![npm version](https://img.shields.io/npm/v/@lint-md/core.svg)](https://www.npmjs.com/package/@lint-md/core)
 [![npm downloads](https://img.shields.io/npm/dm/@lint-md/core.svg)](https://www.npmjs.com/package/@lint-md/core)
 [![license](https://img.shields.io/github/license/lint-md/lint-md)](https://github.com/lint-md/lint-md/blob/master/LICENSE)
-[![codecov](https://codecov.io/gh/lint-md/lint-md/branch/master/graph/badge.svg)](https://codecov.io/gh/lint-md/lint-md)
+[![build](https://github.com/lint-md/lint-md/actions/workflows/build.yml/badge.svg)](https://github.com/lint-md/lint-md/actions/workflows/build.yml)
 
 ## ✨ 特性
 


### PR DESCRIPTION
## 关联

Closes #142

## 改动

- `build.yml`：删除 `codecov/codecov-action@v7` upload step
- `README.md`：Codecov badge → GitHub Actions build badge

## 理由

避免第三方服务依赖（token、badge 失效、fork 权限），README 中仅展示 GitHub Actions build badge。