### PR TITLE
chore(release): prepare v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.1.2](https://github.com/lint-md/lint-md/compare/v2.1.1...v2.1.2) - 2026-07-03
+
+### Chore
+
+- bump @lint-md/parser to ~0.1.2 (#159)
+
 ## [2.1.1](https://github.com/lint-md/lint-md/compare/v2.0.0...v2.1.1) - 2026-06-30
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lint-md/core",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Core of lint-md which used to lint your markdown file for Chinese.",
   "main": "lib/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
## Summary

- Bump version to `2.1.2`
- Update `CHANGELOG.md` with v2.1.2 entry referencing parser upgrade (#159)

## Changes

- `package.json`: `2.1.1` → `2.1.2`
- `CHANGELOG.md`: add v2.1.2 section

## Source

Cherry-picked from `luojiyin1987/lint-md@0183d8e`. The underlying dependency upgrade (`@lint-md/parser` to `~0.1.2`, PR #159) is already merged into `master` via commit `edbf696`, so this PR only carries the release-prep commit.