### PR TITLE
feat(core): expose fixableErrorCount and fixableWarningCount (#152)

### DIFF
--- a/__tests__/unit/fixable-counts.spec.ts
+++ b/__tests__/unit/fixable-counts.spec.ts
@@ -1,0 +1,137 @@
+import { lintMarkdown } from '../../src';
+import * as internalRules from '../../src/rules';
+import type { LintMdRule, LintMdRulesConfig, PositionedTextNode } from '../../src/types';
+import { RULE_SEVERITY } from '../../src/types';
+
+const makeMockRule = (opts: {
+  name: string;
+  withFix: boolean;
+  matchesText?: string;
+}): LintMdRule => ({
+  meta: { name: opts.name },
+  create: (context) => ({
+    text: (node: PositionedTextNode) => {
+      if (opts.matchesText !== undefined && node.value !== opts.matchesText) {
+        return;
+      }
+      context.report({
+        loc: node.position,
+        message: `mock report from ${opts.name}`,
+        ...(opts.withFix
+          ? {
+              fix: (fixer) => fixer.replaceTextRange(
+                [node.position.start.offset, node.position.end.offset],
+                'X'
+              )
+            }
+          : {})
+      });
+    }
+  })
+});
+
+const disableAllInternal = (): LintMdRulesConfig =>
+  Object.fromEntries(
+    Object.values(internalRules).map((rule) => [rule.meta.name, RULE_SEVERITY.OFF])
+  );
+
+describe('lintMarkdown() fixable counts (issue #152)', () => {
+  test('1. counts one fixable error', () => {
+    const mockRule = makeMockRule({ name: 'mock-fixable-error', withFix: true });
+    const res = lintMarkdown('text only', {
+      ...disableAllInternal(),
+      'mock-fixable-error': [mockRule, RULE_SEVERITY.ERROR, {}]
+    }, false);
+
+    expect(res.fixableErrorCount).toBe(1);
+    expect(res.fixableWarningCount).toBe(0);
+  });
+
+  test('2. counts one fixable warning', () => {
+    const mockRule = makeMockRule({ name: 'mock-fixable-warning', withFix: true });
+    const res = lintMarkdown('text only', {
+      ...disableAllInternal(),
+      'mock-fixable-warning': [mockRule, RULE_SEVERITY.WARN, {}]
+    }, false);
+
+    expect(res.fixableErrorCount).toBe(0);
+    expect(res.fixableWarningCount).toBe(1);
+  });
+
+  test('3. non-fixable report does not increment counts', () => {
+    const mockRule = makeMockRule({ name: 'mock-no-fix', withFix: false });
+    const res = lintMarkdown('text only', {
+      ...disableAllInternal(),
+      'mock-no-fix': [mockRule, RULE_SEVERITY.ERROR, {}]
+    }, false);
+
+    expect(res.fixableErrorCount).toBe(0);
+    expect(res.fixableWarningCount).toBe(0);
+  });
+
+  test('4. counts mix of fixable / non-fixable and error / warning', () => {
+    const fixableError = makeMockRule({ name: 'mix-fixable-error', withFix: true, matchesText: 'alpha' });
+    const fixableWarning = makeMockRule({ name: 'mix-fixable-warning', withFix: true, matchesText: 'beta' });
+    const nonFixableError = makeMockRule({ name: 'mix-non-fixable-error', withFix: false, matchesText: 'gamma' });
+    const nonFixableWarning = makeMockRule({ name: 'mix-non-fixable-warning', withFix: false, matchesText: 'delta' });
+
+    const res = lintMarkdown('alpha\n\nbeta\n\ngamma\n\ndelta', {
+      ...disableAllInternal(),
+      'mix-fixable-error': [fixableError, RULE_SEVERITY.ERROR, {}],
+      'mix-fixable-warning': [fixableWarning, RULE_SEVERITY.WARN, {}],
+      'mix-non-fixable-error': [nonFixableError, RULE_SEVERITY.ERROR, {}],
+      'mix-non-fixable-warning': [nonFixableWarning, RULE_SEVERITY.WARN, {}]
+    }, false);
+
+    expect(res.lintResult).toHaveLength(4);
+    expect(res.fixableErrorCount).toBe(1);
+    expect(res.fixableWarningCount).toBe(1);
+  });
+
+  test('5. no reports yields zero counts', () => {
+    const res = lintMarkdown('', disableAllInternal(), false);
+
+    expect(res.lintResult).toHaveLength(0);
+    expect(res.fixableErrorCount).toBe(0);
+    expect(res.fixableWarningCount).toBe(0);
+  });
+
+  test('6. isFixMode=false still computes counts and fixedResult is null', () => {
+    const mockRule = makeMockRule({ name: 'lint-only-fixable', withFix: true });
+    const res = lintMarkdown('text only', {
+      ...disableAllInternal(),
+      'lint-only-fixable': [mockRule, RULE_SEVERITY.ERROR, {}]
+    }, false);
+
+    expect(res.fixableErrorCount).toBe(1);
+    expect(res.fixedResult).toBeNull();
+  });
+
+  test('7. isFixMode=true counts reflect pre-fix lintResult', () => {
+    const mockRule = makeMockRule({ name: 'fix-mode-fixable', withFix: true });
+    const res = lintMarkdown('text only', {
+      ...disableAllInternal(),
+      'fix-mode-fixable': [mockRule, RULE_SEVERITY.ERROR, {}]
+    }, true);
+
+    expect(res.fixableErrorCount).toBe(1);
+    expect(res.lintResult).toHaveLength(1);
+    expect(res.lintResult?.[0]?.name).toBe('fix-mode-fixable');
+  });
+
+  test('8. lintResult items do not expose fix function (worker-boundary safe)', () => {
+    const mockRule = makeMockRule({ name: 'no-fix-leak', withFix: true });
+    const res = lintMarkdown('text only', {
+      ...disableAllInternal(),
+      'no-fix-leak': [mockRule, RULE_SEVERITY.ERROR, {}]
+    }, false);
+
+    expect(res.lintResult).toHaveLength(1);
+    const item = res.lintResult?.[0];
+    expect(item).toBeDefined();
+    expect(Object.keys(item!)).toEqual(
+      expect.arrayContaining(['loc', 'message', 'name', 'content', 'severity'])
+    );
+    expect((item as Record<string, unknown>).fix).toBeUndefined();
+  });
+});

--- a/src/core/lint-markdown.ts
+++ b/src/core/lint-markdown.ts
@@ -48,14 +48,29 @@ export const lintMarkdown = (markdown: string, rules: LintMdRulesConfig = {}, is
 
   const { fixedResult, lintResult } = lintMarkdownInternal(markdown, internalRules, isFixMode);
 
-  const reportDataWithSeverity = lintResult?.ruleManager.getReportData().map((item) => {
+  const reportData = lintResult?.ruleManager.getReportData();
+  let fixableErrorCount = 0;
+  let fixableWarningCount = 0;
+
+  const reportDataWithSeverity = reportData?.map((item) => {
+    const severity = registeredRules[item.name].severity;
+
+    if (typeof item.fix === 'function') {
+      if (severity === RULE_SEVERITY.ERROR) {
+        fixableErrorCount++;
+      }
+      else if (severity === RULE_SEVERITY.WARN) {
+        fixableWarningCount++;
+      }
+    }
+
     const { loc, message, name, content } = item;
     return {
       loc,
       message,
       name,
       content,
-      severity: registeredRules[name].severity
+      severity
     };
   });
 
@@ -70,6 +85,8 @@ export const lintMarkdown = (markdown: string, rules: LintMdRulesConfig = {}, is
   return {
     lintResult: reportDataWithSeverity,
     diagnostics,
-    fixedResult
+    fixedResult,
+    fixableErrorCount,
+    fixableWarningCount
   };
 };


### PR DESCRIPTION
Closes #152

## Summary

在 `lintMarkdown()` 返回值中新增两个顶层计数字段：
- `fixableErrorCount: number`
- `fixableWarningCount: number`

计数由 core 产生，CLI 后续透传并启用现有的 potentially fixable 提示。

## 语义

- 当且仅当 `typeof report.fix === 'function'` 时计入可修复数量
- `RULE_SEVERITY.ERROR` 计入 `fixableErrorCount`
- `RULE_SEVERITY.WARN` 计入 `fixableWarningCount`
- `RULE_SEVERITY.OFF` 不执行规则，不产生报告
- 严重级别以 `registeredRules[report.name].severity` 为准
- 不调用 `fix` 函数；计数表示"规则提供了候选修复"，与 CLI 现有 "potentially fixable" 文案一致
- fix 模式返回的计数基于修复前第一次 lint 的 `lintResult`

## 公开形状

只增加两个顶层字段，不暴露 `fix` 函数：
- `lintResult` 元素结构不变 → 保持向后兼容
- 避免函数通过 Piscina worker 边界传输
- 满足 CLI 聚合需求

## 改动

- `src/core/lint-markdown.ts`: 在原 `reportDataWithSeverity.map` 内同一次遍历累加计数（不增加 `getReportData()` 调用次数）
- `__tests__/unit/fixable-counts.spec.ts`: 8 个测试覆盖 fixable error / warning、不可修复、混合、零报告、isFixMode=true/false、worker 边界安全

## 测试

```bash
npm run lint          # clean
npm run typecheck     # clean
npm test              # 105/105 passing (含新增 8 个)
npm run build         # CJS + ESM, both declare fixableErrorCount/fixableWarningCount
```

## 后续独立任务（不在本 PR 范围）

- `errorCount` / `warningCount` 一并暴露
- 公开返回类型整理为显式导出接口
- 规则配置键与 `meta.name` 不一致时 severity 查找失败
- `@lint-md/parser` 内置迁移