### PR TITLE
chore(benchmark): add memory benchmark infrastructure and plan doc (#160)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "lib:esm": "tsc -p tsconfig.json --target ESNext --module ESNext --outDir esm",
     "build": "rm -rf lib esm && run-p lib:*",
     "clean": "rimraf lib esm",
+    "benchmark": "node scripts/benchmark-memory.mjs",
+    "smoke-test": "node scripts/benchmark-memory-smoke.mjs",
     "prepublishOnly": "npm run lint && npm run typecheck && npm run build && npm test",
     "release": "npm publish"
   },

--- a/scripts/benchmark-memory-smoke.mjs
+++ b/scripts/benchmark-memory-smoke.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * Smoke test for benchmark-memory.mjs.
+ *
+ * Runs with small inputs and verifies output format.
+ * Does NOT assert absolute memory values.
+ *
+ * Usage:
+ *   npm run build
+ *   node scripts/benchmark-memory-smoke.mjs
+ */
+
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const BENCHMARK_PATH = path.join(SCRIPT_DIR, 'benchmark-memory.mjs');
+
+const REQUIRED_FIELDS = [
+  'case', 'shape', 'bytes', 'run',
+  'wallTimeMs', 'maxRss', 'rssBefore', 'rssAfter', 'rssDelta',
+  'heapBefore', 'heapAfter',
+  'reportCount', 'fixCount', 'runLintCalls',
+  'nodeVersion', 'platform', 'arch',
+];
+
+const VALID_CASES = new Set([
+  'noop', 'input-only', 'parser-only', 'parse-traverse',
+  'single-rule', 'all-rules', 'fix-mode',
+]);
+
+const VALID_SHAPES = new Set([
+  'long-paragraph', 'many-paragraphs', 'mixed-markdown',
+  'high-match-density', 'low-match-density', 'overlapping-fixes',
+]);
+
+function runBenchmark(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [BENCHMARK_PATH, ...args], {
+      cwd: path.resolve(SCRIPT_DIR, '..'),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+
+    child.on('error', reject);
+  });
+}
+
+function parseNDJSON(text) {
+  return text.trim().split('\n').filter(Boolean).map(line => JSON.parse(line));
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+async function main() {
+  console.log('Smoke test: benchmark-memory.mjs');
+
+  // Test 1: --help
+  let result = await runBenchmark(['--help']);
+  assert(result.code === 0, '--help should exit 0');
+  assert(result.stdout.includes('Usage'), '--help should print usage');
+
+  // Test 2: basic run with small input
+  console.log('  Running benchmark with 4 KiB long-paragraph, 1 run...');
+  result = await runBenchmark(['--bytes', '4096', '--shape', 'long-paragraph', '--runs', '1', '--warmup', '0']);
+  assert(result.code === 0, 'benchmark should exit 0');
+  assert(result.stderr === '', 'benchmark should have no stderr output');
+
+  const lines = parseNDJSON(result.stdout);
+  assert(lines.length > 0, 'should output at least one line');
+
+  console.log(`  Got ${lines.length} output lines`);
+
+  // Test 3: validate output format
+  for (const line of lines) {
+    // Check all required fields exist
+    for (const field of REQUIRED_FIELDS) {
+      assert(line[field] !== undefined, `field '${field}' should be present`);
+    }
+
+    // Check types
+    assert(typeof line.bytes === 'number' && line.bytes > 0, 'bytes should be a positive number');
+    assert(typeof line.wallTimeMs === 'number' && line.wallTimeMs >= 0, 'wallTimeMs should be a non-negative number');
+    assert(typeof line.maxRss === 'number' && line.maxRss > 0, 'maxRss should be positive');
+    assert(typeof line.rssBefore === 'number' && line.rssBefore > 0, 'rssBefore should be positive');
+    assert(typeof line.rssAfter === 'number' && line.rssAfter > 0, 'rssAfter should be positive');
+    assert(typeof line.rssDelta === 'number', 'rssDelta should be a number');
+    assert(typeof line.heapBefore === 'number' && line.heapBefore > 0, 'heapBefore should be positive');
+    assert(typeof line.heapAfter === 'number' && line.heapAfter > 0, 'heapAfter should be positive');
+    assert(typeof line.reportCount === 'number', 'reportCount should be a number');
+    assert(line.fixCount === null || typeof line.fixCount === 'number', 'fixCount should be number or null');
+    assert(line.runLintCalls === null || typeof line.runLintCalls === 'number', 'runLintCalls should be number or null');
+    assert(typeof line.run === 'number' && line.run >= 1, 'run should be >= 1');
+
+    assert(VALID_CASES.has(line.case), `unknown case: ${line.case}`);
+    assert(VALID_SHAPES.has(line.shape), `unknown shape: ${line.shape}`);
+
+    // heapAfterGc should be numeric if present
+    if (line.heapAfterGc !== null && line.heapAfterGc !== undefined) {
+      assert(typeof line.heapAfterGc === 'number', 'heapAfterGc should be a number if present');
+    }
+
+    // nodeVersion should be a string like v24.x.x
+    assert(typeof line.nodeVersion === 'string' && line.nodeVersion.startsWith('v'),
+      'nodeVersion should start with "v"');
+  }
+
+  // Test 4: basic run with different shape
+  console.log('  Running benchmark with 4 KiB many-paragraphs, 1 run...');
+  result = await runBenchmark(['--bytes', '4096', '--shape', 'many-paragraphs', '--runs', '1', '--warmup', '0']);
+  assert(result.code === 0, 'benchmark should exit 0');
+  const lines2 = parseNDJSON(result.stdout);
+  assert(lines2.length > 0, 'should output at least one line for many-paragraphs');
+
+  // Test 5: noop case should have minimal RSS delta (informational, no hard assertion)
+  const noopLines = lines.filter(l => l.case === 'noop');
+  if (noopLines.length > 0) {
+    console.log(`  noop baseline RSS delta: ${noopLines[0].rssDelta} bytes`);
+  }
+
+  console.log('\nSmoke test PASSED');
+}
+
+main().catch((err) => {
+  console.error(`\nSmoke test FAILED: ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/benchmark-memory.mjs
+++ b/scripts/benchmark-memory.mjs
@@ -1,0 +1,417 @@
+#!/usr/bin/env node
+/**
+ * Core memory benchmark for @lint-md/core.
+ *
+ * Usage:
+ *   npm run build
+ *   node scripts/benchmark-memory.mjs [--bytes 1048576] [--shape long-paragraph] [--runs 5]
+ *
+ * Output: NDJSON with one line per measurement run.
+ *
+ * When BENCHMARK_CHILD=1 is set, runs a single case in a child process
+ * (spawned by the parent) and outputs one JSON line.
+ *
+ * CLI params (parent mode):
+ *   --bytes <n>       Input size in bytes per case (default: 65536)
+ *   --shape <name>    Input shape: long-paragraph | many-paragraphs | mixed-markdown |
+ *                     high-match-density | low-match-density | overlapping-fixes
+ *                     (default: long-paragraph)
+ *   --runs <n>        Measured runs per case (default: 5)
+ *   --warmup <n>      Warmup runs before measurement (default: 2)
+ *   --all             Run all shape+size combinations
+ *   -h, --help        Show this help
+ */
+
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+
+// Shared constants (must be above child-mode block for TDZ in ESM)
+const CHINESE_CHARS = '的一是在不了有和人这中大为上个国以要到和自地们时生就学对得也子说着可';
+const ENGLISH_WORDS = 'the be to of and a in that have I it for not on with he as you do at this but his by from they we say her she or an will my one all would there their what so up out if about who get which go me when make can like time no just him know take people into year your good some could them see other than then now look only come its over think also back after use two how our work first well way even new want because any these give day most us'.split(' ');
+
+// ---------------------------------------------------------------------------
+// Child mode
+// ---------------------------------------------------------------------------
+if (process.env.BENCHMARK_CHILD === '1') {
+  const shape = process.env.BENCHMARK_SHAPE;
+  const bytes = parseInt(process.env.BENCHMARK_BYTES, 10);
+  const caseName = process.env.BENCHMARK_CASE;
+  const ruleName = process.env.BENCHMARK_RULE || '';
+  const warmupCount = parseInt(process.env.BENCHMARK_WARMUP || '0', 10);
+
+  const { input } = generateInput(shape, bytes);
+
+  // Use CJS build (ESM build has extensionless imports that break Node.js resolution)
+  const require_ = createRequire(import.meta.url);
+  const { parseMd } = require_('@lint-md/parser');
+  const core = require_('../lib/index.js');
+  const { runLint } = require_('../lib/core/run-lint.js');
+
+  const TEXT_RULE_IMPORTS = {
+    'space-around-alphabet': () => core.spaceAroundAlphabet,
+    'space-around-number': () => core.spaceAroundNumber,
+    'no-full-width-number': () => core.noFullWidthNumber,
+    'no-half-width-punctuation': () => core.noHalfWidthPunctuation,
+    'use-standard-ellipsis': () => core.useStandardEllipsis,
+    'no-special-characters': () => core.noSpecialCharacters,
+    'no-space-in-inline-code': () => core.noSpaceInInlineCode,
+    'no-space-in-link': () => core.noSpaceInLink,
+    'correct-title-trailing-punctuation': () => core.correctTitleTrailingPunctuation,
+  };
+
+  function runNoop() {
+    return { reportCount: 0, fixCount: 0, runLintCalls: 0 };
+  }
+
+  function runInputOnly() {
+    const s = input.slice(0);
+    void s;
+    return { reportCount: 0, fixCount: 0, runLintCalls: 0 };
+  }
+
+  function runParserOnly() {
+    parseMd(input);
+    return { reportCount: 0, fixCount: 0, runLintCalls: 0 };
+  }
+
+  function runParseTraverse() {
+    const result = runLint(input, []);
+    const reports = result.ruleManager.getReportData();
+    return { reportCount: reports.length, fixCount: 0, runLintCalls: 1 };
+  }
+
+  function runSingleRule() {
+    const ruleFactory = TEXT_RULE_IMPORTS[ruleName];
+    if (!ruleFactory) throw new Error(`Unknown rule: ${ruleName}`);
+    const result = runLint(input, [{ rule: ruleFactory() }]);
+    const reports = result.ruleManager.getReportData();
+    const fixes = result.ruleManager.getAllFixes();
+    return { reportCount: reports.length, fixCount: fixes.length, runLintCalls: 1 };
+  }
+
+  function runAllRules() {
+    const result = core.lintMarkdown(input, {}, false);
+    // lintMarkdown strips fix from public lintResult.
+    // fixCount will be available via fixableErrorCount+fixableWarningCount once PR #162 lands.
+    return {
+      reportCount: (result.lintResult || []).length,
+      fixCount: null,
+      runLintCalls: 1,
+    };
+  }
+
+  function runFixMode() {
+    const result = core.lintMarkdown(input, {}, true);
+    return {
+      reportCount: (result.lintResult || []).length,
+      fixCount: null,
+      runLintCalls: null, // handleFixMode may loop internally; exact count unknown here
+    };
+  }
+
+  const runners = {
+    noop: runNoop,
+    'input-only': runInputOnly,
+    'parser-only': runParserOnly,
+    'parse-traverse': runParseTraverse,
+    'single-rule': runSingleRule,
+    'all-rules': runAllRules,
+    'fix-mode': runFixMode,
+  };
+
+  const runner = runners[caseName];
+  if (!runner) throw new Error(`Unknown case: ${caseName}`);
+
+  // Warmup
+  for (let i = 0; i < warmupCount; i++) {
+    runner();
+    if (typeof global.gc === 'function') global.gc();
+  }
+
+  // Measure
+  const rssBefore = process.memoryUsage.rss();
+  const heapBefore = process.memoryUsage().heapUsed;
+  const start = performance.now();
+
+  const counts = runner();
+
+  const end = performance.now();
+  const rssAfter = process.memoryUsage.rss();
+  const heapAfter = process.memoryUsage().heapUsed;
+  // process.resourceUsage().maxRSS is in KiB; convert to bytes for consistency
+  const maxRssBytes = process.resourceUsage().maxRSS * 1024;
+
+  let heapAfterGc = null;
+  if (typeof global.gc === 'function') {
+    global.gc();
+    heapAfterGc = process.memoryUsage().heapUsed;
+  }
+
+  const result = {
+    case: caseName,
+    shape,
+    bytes,
+    rule: ruleName || undefined,
+    wallTimeMs: Math.round(end - start),
+    maxRss: maxRssBytes,
+    rssBefore,
+    rssAfter,
+    rssDelta: rssAfter - rssBefore,
+    heapBefore,
+    heapAfter,
+    heapAfterGc,
+    ...counts,
+    nodeVersion: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    timestamp: new Date().toISOString(),
+  };
+
+  process.stdout.write(JSON.stringify(result) + '\n');
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Parent mode
+// ---------------------------------------------------------------------------
+
+function printHelp() {
+  console.log(`Usage: node benchmark-memory.mjs [options]
+
+Options:
+  --bytes <n>       Input size in bytes (default: 65536)
+  --shape <name>    Input shape (default: long-paragraph)
+                    Shapes: long-paragraph | many-paragraphs | mixed-markdown |
+                            high-match-density | low-match-density | overlapping-fixes
+  --runs <n>        Measured runs per case (default: 5)
+  --warmup <n>      Warmup runs per child process (default: 2)
+  --all             Run all shape+size combinations
+  -h, --help        Show this help
+
+Examples:
+  node scripts/benchmark-memory.mjs --bytes 1048576 --shape long-paragraph --runs 5
+  node scripts/benchmark-memory.mjs --all --runs 3
+
+Environment:
+  BENCHMARK_CHILD=1  Internal flag for child process mode (do not set manually).
+`);
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts = { bytes: 65536, shape: 'long-paragraph', runs: 5, warmup: 2, all: false };
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+    case '-h': case '--help': printHelp(); process.exit(0);
+    case '--bytes': opts.bytes = parseInt(args[++i], 10); break;
+    case '--shape': opts.shape = args[++i]; break;
+    case '--runs': opts.runs = parseInt(args[++i], 10); break;
+    case '--warmup': opts.warmup = parseInt(args[++i], 10); break;
+    case '--all': opts.all = true; break;
+    default: console.error(`Unknown flag: ${args[i]}\n`); printHelp(); process.exit(1);
+    }
+  }
+  return opts;
+}
+
+// Run a single case measurement in a child process.
+// Returns a Promise that resolves with the parsed JSON result object.
+function runChildCase(opts) {
+  const { shape, bytes, caseName, ruleName, warmup } = opts;
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [
+      '--expose-gc',
+      SCRIPT_PATH,
+    ], {
+      env: {
+        ...process.env,
+        BENCHMARK_CHILD: '1',
+        BENCHMARK_SHAPE: shape,
+        BENCHMARK_BYTES: String(bytes),
+        BENCHMARK_CASE: caseName,
+        BENCHMARK_RULE: ruleName || '',
+        BENCHMARK_WARMUP: String(warmup || 0),
+        NODE_NO_WARNINGS: '1',
+      },
+      stdio: ['ignore', 'pipe', 'inherit'],
+      cwd: process.cwd(),
+    });
+
+    let stdout = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code !== 0) reject(new Error(`Child exited with code ${code}`));
+      else {
+        try { resolve(JSON.parse(stdout.trim())); }
+        catch (e) { reject(new Error(`Failed to parse child output: ${e.message}\n${stdout}`)); }
+      }
+    });
+  });
+}
+
+// Shapes and sizes for all-combinations mode
+const ALL_SHAPES = [
+  'long-paragraph', 'many-paragraphs', 'mixed-markdown',
+  'high-match-density', 'low-match-density', 'overlapping-fixes',
+];
+const ALL_SIZES = [64 * 1024, 256 * 1024, 1024 * 1024];
+
+// Text rules for single-rule benchmarking
+const TEXT_RULES = [
+  'space-around-alphabet',
+  'space-around-number',
+  'no-full-width-number',
+  'no-half-width-punctuation',
+];
+
+// Measurement scenarios in order
+const CASES = [
+  'noop',
+  'input-only',
+  'parser-only',
+  'parse-traverse',
+  'single-rule',
+  'all-rules',
+  'fix-mode',
+];
+
+// ---------------------------------------------------------------------------
+// Input generators
+// ---------------------------------------------------------------------------
+
+function repeatToSize(base, targetBytes) {
+  const buf = Buffer.from(base, 'utf8');
+  const times = Math.ceil(targetBytes / buf.length);
+  return Buffer.concat(Array(times).fill(buf)).slice(0, targetBytes).toString('utf8');
+}
+
+function generateLongParagraph(targetBytes) {
+  const base = '这是用于性能测试的长段落文本，包含中英文混合内容 test content and numbers 1234567890 以及标点符号。' +
+    CHINESE_CHARS.repeat(10) + ' ' + ENGLISH_WORDS.slice(0, 20).join(' ') + '。';
+  return repeatToSize(base, targetBytes);
+}
+
+function generateManyParagraphs(targetBytes) {
+  // Generate many short paragraphs, each with a heading + paragraph pattern.
+  const parts = [];
+  let acc = 0;
+  let i = 0;
+  while (acc < targetBytes) {
+    const p = `## 第${i + 1}个段落标题\n\n这是第${i + 1}个段落的正文内容。` +
+      `包含一些中文文本和 English words mixed together。\n\n`;
+    const buf = Buffer.from(p, 'utf8');
+    if (acc + buf.length > targetBytes) {
+      parts.push(buf.slice(0, targetBytes - acc));
+      break;
+    }
+    parts.push(buf);
+    acc += buf.length;
+    i++;
+  }
+  return Buffer.concat(parts).toString('utf8');
+}
+
+function generateMixedMarkdown(targetBytes) {
+  const templates = [
+    '# 一级标题\n\n这是一段**粗体**和*斜体*混合的段落文字。\n\n',
+    '- 列表项 1：包含 [链接](https://example.com)\n- 列表项 2：包含 `inline code`\n\n',
+    '> 这是一段引用文字，\n> 包含多行内容。\n\n',
+    '```javascript\nconst x = 1;\nconsole.log(x);\n```\n\n',
+    '| 表头 A | 表头 B |\n|--------|--------|\n| cell 1 | cell 2 |\n\n',
+    '![图片](https://example.com/img.png)\n\n',
+  ];
+  const parts = [];
+  let acc = 0; let i = 0;
+  while (acc < targetBytes) {
+    const t = templates[i % templates.length];
+    const buf = Buffer.from(t, 'utf8');
+    if (acc + buf.length > targetBytes) {
+      parts.push(buf.slice(0, targetBytes - acc));
+      break;
+    }
+    parts.push(buf);
+    acc += buf.length;
+    i++;
+  }
+  return Buffer.concat(parts).toString('utf8');
+}
+
+function generateHighMatchDensity(targetBytes) {
+  // Lots of Chinese + English adjacent text to trigger space-around-alphabet etc.
+  const base = '中文English中文123中文abc测试中文x' + CHINESE_CHARS.slice(0, 5);
+  return repeatToSize(base, targetBytes);
+}
+
+function generateLowMatchDensity(targetBytes) {
+  // Plain English text — most Chinese rules won't fire.
+  const base = 'This is plain English text for low match density testing. ' +
+    ENGLISH_WORDS.join(' ') + '. ';
+  return repeatToSize(base, targetBytes);
+}
+
+function generateOverlappingFixes(targetBytes) {
+  // Content that triggers fixes whose ranges may overlap (e.g. many space insertions).
+  const base = '中文English中文123中文,测试中文;测试中文:测试中文(测试)中文！测试？测试。' + CHINESE_CHARS.slice(0, 5);
+  return repeatToSize(base, targetBytes);
+}
+
+function generateInput(shape, bytes) {
+  const generators = {
+    'long-paragraph': generateLongParagraph,
+    'many-paragraphs': generateManyParagraphs,
+    'mixed-markdown': generateMixedMarkdown,
+    'high-match-density': generateHighMatchDensity,
+    'low-match-density': generateLowMatchDensity,
+    'overlapping-fixes': generateOverlappingFixes,
+  };
+  const gen = generators[shape];
+  if (!gen) throw new Error(`Unknown shape: ${shape}`);
+  return { input: gen(bytes), shape, bytes };
+}
+
+// ---------------------------------------------------------------------------
+// Main (parent mode)
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const opts = parseArgs();
+
+  const shapes = opts.all ? ALL_SHAPES : [opts.shape];
+  const sizes = opts.all ? ALL_SIZES : [opts.bytes];
+
+  for (const shape of shapes) {
+    for (const bytes of sizes) {
+      for (const caseName of CASES) {
+        if (caseName === 'single-rule') {
+          // Single-rule cases: run each text rule separately
+          for (const ruleName of TEXT_RULES) {
+            for (let run = 0; run < opts.runs; run++) {
+              const result = await runChildCase({
+                shape, bytes, caseName, ruleName, warmup: opts.warmup,
+              });
+              result.run = run + 1;
+              process.stdout.write(JSON.stringify(result) + '\n');
+            }
+          }
+        } else {
+          for (let run = 0; run < opts.runs; run++) {
+            const result = await runChildCase({
+              shape, bytes, caseName, ruleName: '', warmup: opts.warmup,
+            });
+            result.run = run + 1;
+            process.stdout.write(JSON.stringify(result) + '\n');
+          }
+        }
+      }
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Issue #160 的 PR 1：建立可重复的 core 分层内存基准基础设施。

本 PR **不修改任何 lint 行为**，只新增 benchmark 脚本和计划文档。

## 改动

| 文件 | 说明 |
|---|---|
| `scripts/benchmark-memory.mjs` | 内存基准脚本（父进程 orchestrator + 子进程 runner，412 行）|
| `scripts/benchmark-memory-smoke.mjs` | Smoke test 脚本（验证输出格式，不设绝对内存断言，138 行）|
| `package.json` | 新增 `benchmark` 和 `smoke-test` npm 命令 |

## benchmark-memory.mjs 功能

### CLI 参数
```bash
npm run build
node scripts/benchmark-memory.mjs --bytes 1048576 --shape long-paragraph --runs 5 --warmup 2
node scripts/benchmark-memory.mjs --all --runs 3
```

### 测量场景
- `noop`: 基线噪声
- `input-only`: 仅构造输入
- `parser-only`: 仅调用 `parseMd()`
- `parse-traverse`: `runLint()` 无规则
- `single-rule` × 4: space-around-alphabet / space-around-number / no-full-width-number / no-half-width-punctuation
- `all-rules`: 全默认规则 lint-only
- `fix-mode`: 全默认规则 fix 模式

### 输入形状
- `long-paragraph`, `many-paragraphs`, `mixed-markdown`, `high-match-density`, `low-match-density`, `overlapping-fixes`

### 指标
- wallTimeMs, maxRss (process.resourceUsage), rssBefore/After/Delta
- heapBefore/After, heapAfterGc (--expose-gc 必选)
- reportCount, fixCount, runLintCalls
- nodeVersion, platform, arch

### 关键设计
- **子进程隔离**：每个 measurement case 在独立子进程运行，避免前一个 case 的 heap 污染后续数据
- **Warmup**：每个子进程自动跑 warmup 消除 V8 JIT 首跑差异
- **NDJSON 输出**：每行一个 JSON 对象，方便 pipeline 处理（`jq` / `ndjson-cli`）
- **确定性输入生成**：不依赖文件系统 fixture，纯字符串 repeat
- **CJS 构建产物**：使用 `lib/` 产物（因为 `esm/` 有 extensionless import 问题）

## 验证

```bash
npm run lint        # clean
npm run typecheck   # clean
npm test            # 105/105 passing
npm run build       # CJS + ESM
npm run smoke-test  # PASSED: 10 output lines, valid NDJSON format
```

## 下一步

PR 合并后，按 plan doc 的阶段 1 → 2 → 3A/3B/3C 顺序执行：
1. 在真实 1 MiB 语料上跑分层基线
2. 采集 heap/CPU profile
3. 确定主要内存贡献者（parser vs text 规则 vs fix 重跑）
4. 按决策门槛实施优化

Closes #160