### PR TITLE
test: improve test coverage for mark-text, override-default-rules, text-scanner, and run-lint

### DIFF
--- a/__tests__/unit/core.spec.ts
+++ b/__tests__/unit/core.spec.ts
@@ -6,6 +6,10 @@ import { lintMarkdownInternal } from '../../src/core/lint-markdown';
 import type { LintMdRule } from '../../src/types';
 
 describe('test core methods for lint-markdown', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   test('test runLint() to lint source', () => {
     const lintResult = runLint(`# Hello
 
@@ -47,7 +51,6 @@ Some **importance**, and \`code\`.
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining('Test error from rule')
     );
-    consoleSpy.mockRestore();
   });
 
   test('test runLint() silently handles non-Error throws', () => {
@@ -64,7 +67,6 @@ Some **importance**, and \`code\`.
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
     runLint('hello world', [{ rule: throwingRule }]);
     expect(consoleSpy).not.toHaveBeenCalled();
-    consoleSpy.mockRestore();
   });
 
   test('test lintAndFixInternal() to lint or fix markdown source', () => {

--- a/__tests__/unit/core.spec.ts
+++ b/__tests__/unit/core.spec.ts
@@ -3,6 +3,7 @@ import noEmptyCode from '../../src/rules/no-empty-code';
 import { getExample } from '../utils/test-utils';
 import { runLint } from '../../src/core/run-lint';
 import { lintMarkdownInternal } from '../../src/core/lint-markdown';
+import type { LintMdRule } from '../../src/types';
 
 describe('test core methods for lint-markdown', () => {
   test('test runLint() to lint source', () => {
@@ -21,6 +22,49 @@ Some **importance**, and \`code\`.
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
     const res = lintResult.ruleManager.getReportData().pop();
     expect(res?.message).toStrictEqual('代码块内容不能为空，请删除空的代码块，或者填充代码内容');
+  });
+
+  test('test runLint() with empty rules array', () => {
+    const lintResult = runLint('# Hello', []);
+    expect(lintResult.ruleManager.getReportData().length).toBe(0);
+  });
+
+  test('test runLint() catches Error thrown by rule', () => {
+    const throwingRule: LintMdRule = {
+      meta: { name: 'throwing-rule' },
+      create: () => ({
+        text: () => {
+          throw new Error('Test error from rule');
+        }
+      })
+    };
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    runLint('hello world', [{ rule: throwingRule }]);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('rule execution error')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Test error from rule')
+    );
+    consoleSpy.mockRestore();
+  });
+
+  test('test runLint() silently handles non-Error throws', () => {
+    const throwingRule: LintMdRule = {
+      meta: { name: 'throwing-string' },
+      create: () => ({
+        text: () => {
+          // eslint-disable-next-line no-throw-literal
+          throw 'string error';
+        }
+      })
+    };
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    runLint('hello world', [{ rule: throwingRule }]);
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
   });
 
   test('test lintAndFixInternal() to lint or fix markdown source', () => {

--- a/__tests__/unit/utils/mark-text.spec.ts
+++ b/__tests__/unit/utils/mark-text.spec.ts
@@ -1,0 +1,77 @@
+import { markText } from '../../../src/utils/mark-text';
+
+describe('markText', () => {
+  it('should handle empty string', () => {
+    expect(markText('')).toBe('');
+  });
+
+  it('should mark single numeric character', () => {
+    expect(markText('0')).toBe('N');
+    expect(markText('1')).toBe('N');
+    expect(markText('9')).toBe('N');
+  });
+
+  it('should mark single Chinese character', () => {
+    expect(markText('你')).toBe('Z');
+    expect(markText('好')).toBe('Z');
+  });
+
+  it('should mark single lowercase English character', () => {
+    expect(markText('a')).toBe('A');
+    expect(markText('m')).toBe('A');
+    expect(markText('z')).toBe('A');
+  });
+
+  it('should mark single uppercase English character', () => {
+    expect(markText('A')).toBe('A');
+    expect(markText('Z')).toBe('A');
+  });
+
+  it('should mark space as dash', () => {
+    expect(markText(' ')).toBe('-');
+  });
+
+  it('should mark punctuation as dash', () => {
+    expect(markText('!')).toBe('-');
+    expect(markText('@')).toBe('-');
+    expect(markText('#')).toBe('-');
+    expect(markText(',')).toBe('-');
+    expect(markText('.')).toBe('-');
+  });
+
+  it('should mark mixed Chinese and English', () => {
+    expect(markText('你好hello')).toBe('ZZAAAAA');
+  });
+
+  it('should mark mixed numbers and English', () => {
+    expect(markText('123abc')).toBe('NNNAAA');
+  });
+
+  it('should mark mixed Chinese and numbers', () => {
+    expect(markText('测试123')).toBe('ZZNNN');
+  });
+
+  it('should mark space-separated content', () => {
+    expect(markText('a b c')).toBe('A-A-A');
+  });
+
+  it('should mark newline character', () => {
+    expect(markText('a\nb')).toBe('A-A');
+  });
+
+  it('should mark tab character', () => {
+    expect(markText('a\tb')).toBe('A-A');
+  });
+
+  it('should mark README example', () => {
+    expect(markText('你好世界 hello world!!!')).toBe('ZZZZ-AAAAA-AAAAA---');
+  });
+
+  it('should mark long Chinese text', () => {
+    expect(markText('中文测试')).toBe('ZZZZ');
+  });
+
+  it('should mark special characters', () => {
+    expect(markText('()[]{}')).toBe('------');
+  });
+});

--- a/__tests__/unit/utils/override-default-rules.spec.ts
+++ b/__tests__/unit/utils/override-default-rules.spec.ts
@@ -1,0 +1,94 @@
+import { overrideDefaultRules } from '../../../src/utils/override-default-rules';
+import { RULE_SEVERITY, type LintMdRule } from '../../../src/types';
+
+const createMockRule = (name: string): LintMdRule => ({
+  meta: { name },
+  create: () => ({})
+});
+
+describe('overrideDefaultRules', () => {
+  const defaultRules: Record<string, LintMdRule> = {
+    'rule-a': createMockRule('rule-a'),
+    'rule-b': createMockRule('rule-b')
+  };
+
+  it('should register all default rules with ERROR severity and empty options', () => {
+    const result = overrideDefaultRules(defaultRules, {});
+    expect(result['rule-a']).toEqual({
+      rule: defaultRules['rule-a'],
+      options: {},
+      severity: RULE_SEVERITY.ERROR
+    });
+    expect(result['rule-b']).toEqual({
+      rule: defaultRules['rule-b'],
+      options: {},
+      severity: RULE_SEVERITY.ERROR
+    });
+  });
+
+  it('should override severity with number config', () => {
+    const result = overrideDefaultRules(defaultRules, {
+      'rule-a': RULE_SEVERITY.WARN
+    });
+    expect(result['rule-a'].severity).toBe(RULE_SEVERITY.WARN);
+    expect(result['rule-a'].options).toEqual({});
+  });
+
+  it('should override severity and options with tuple config', () => {
+    const result = overrideDefaultRules(defaultRules, {
+      'rule-a': [RULE_SEVERITY.OFF, { foo: 'bar' }]
+    });
+    expect(result['rule-a'].severity).toBe(RULE_SEVERITY.OFF);
+    expect(result['rule-a'].options).toEqual({ foo: 'bar' });
+  });
+
+  it('should throw error for invalid tuple config (length !== 2)', () => {
+    expect(() => {
+      overrideDefaultRules(defaultRules, {
+        'rule-a': [RULE_SEVERITY.ERROR] as any
+      });
+    }).toThrow(/无效的规则配置/);
+  });
+
+  it('should register third-party rule with tuple config (length === 3)', () => {
+    const customRule = createMockRule('custom-rule');
+    const result = overrideDefaultRules(defaultRules, {
+      'custom-rule': [customRule, RULE_SEVERITY.WARN, { custom: true }]
+    });
+    expect(result['custom-rule']).toEqual({
+      rule: customRule,
+      severity: RULE_SEVERITY.WARN,
+      options: { custom: true }
+    });
+  });
+
+  it('should throw error for invalid third-party rule config (length !== 3)', () => {
+    const customRule = createMockRule('custom-rule');
+    expect(() => {
+      overrideDefaultRules(defaultRules, {
+        'custom-rule': [customRule, RULE_SEVERITY.WARN] as any
+      });
+    }).toThrow(/第三方规则.*配置长度必须为 3/);
+  });
+
+  it('should not register third-party rule when config is not an array', () => {
+    const result = overrideDefaultRules(defaultRules, {
+      'custom-rule': RULE_SEVERITY.WARN as any
+    });
+    expect(result['custom-rule']).toBeUndefined();
+  });
+
+  it('should handle empty default rules', () => {
+    const result = overrideDefaultRules({}, {});
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+
+  it('should handle config with disabled rules', () => {
+    const result = overrideDefaultRules(defaultRules, {
+      'rule-a': RULE_SEVERITY.OFF,
+      'rule-b': RULE_SEVERITY.OFF
+    });
+    expect(result['rule-a'].severity).toBe(RULE_SEVERITY.OFF);
+    expect(result['rule-b'].severity).toBe(RULE_SEVERITY.OFF);
+  });
+});

--- a/__tests__/unit/utils/text-scanner.spec.ts
+++ b/__tests__/unit/utils/text-scanner.spec.ts
@@ -1,0 +1,151 @@
+import { TextScanner } from '../../../src/utils/text-scanner';
+import type { MarkdownTextNode } from '../../../src/utils/get-text-nodes';
+
+const createTextNode = (
+  value: string,
+  startLine = 1,
+  startColumn = 1,
+  startOffset = 0
+): MarkdownTextNode => ({
+  type: 'text',
+  value,
+  position: {
+    start: { line: startLine, column: startColumn, offset: startOffset },
+    end: {
+      line: startLine,
+      column: startColumn + value.length,
+      offset: startOffset + value.length
+    }
+  }
+} as unknown as MarkdownTextNode);
+
+describe('TextScanner', () => {
+  describe('constructor and getters', () => {
+    it('should expose value', () => {
+      const node = createTextNode('hello');
+      const scanner = new TextScanner(node);
+      expect(scanner.value).toBe('hello');
+    });
+
+    it('should expose node', () => {
+      const node = createTextNode('hello');
+      const scanner = new TextScanner(node);
+      expect(scanner.node).toBe(node);
+    });
+  });
+
+  describe('matchAt', () => {
+    it('should match simple text', () => {
+      const scanner = new TextScanner(createTextNode('hello world'));
+      const match = scanner.matchAt(0, 5);
+      expect(match).toEqual({
+        index: 0,
+        length: 5,
+        loc: {
+          start: { line: 1, column: 1, offset: 0 },
+          end: { line: 1, column: 6, offset: 5 }
+        },
+        absoluteRange: [0, 5]
+      });
+    });
+
+    it('should handle match at end of text', () => {
+      const scanner = new TextScanner(createTextNode('hello'));
+      const match = scanner.matchAt(5, 0);
+      expect(match.index).toBe(5);
+      expect(match.length).toBe(0);
+      expect(match.absoluteRange).toEqual([5, 5]);
+    });
+
+    it('should handle match spanning newlines', () => {
+      const scanner = new TextScanner(createTextNode('a\nb\nc'));
+      const match = scanner.matchAt(0, 3);
+      expect(match.loc.start).toEqual({ line: 1, column: 1, offset: 0 });
+      expect(match.loc.end.line).toBe(2);
+      expect(match.loc.end.column).toBe(2);
+      expect(match.absoluteRange).toEqual([0, 3]);
+    });
+  });
+
+  describe('findAllMatches', () => {
+    it('should find all matches with global flag', () => {
+      const scanner = new TextScanner(createTextNode('hello world hello'));
+      const matches = scanner.findAllMatches(/hello/g);
+      expect(matches).toHaveLength(2);
+      expect(matches[0].index).toBe(0);
+      expect(matches[1].index).toBe(12);
+    });
+
+    it('should auto-add global flag if missing', () => {
+      const scanner = new TextScanner(createTextNode('hello world hello'));
+      const matches = scanner.findAllMatches(/hello/);
+      expect(matches).toHaveLength(2);
+    });
+
+    it('should handle zero-length matches without infinite loop', () => {
+      const scanner = new TextScanner(createTextNode('abc'));
+      const matches = scanner.findAllMatches(/(\b)/g);
+      expect(Array.isArray(matches)).toBe(true);
+    });
+
+    it('should return empty array when no matches', () => {
+      const scanner = new TextScanner(createTextNode('hello'));
+      const matches = scanner.findAllMatches(/xyz/g);
+      expect(matches).toEqual([]);
+    });
+  });
+
+  describe('findAllOccurrences', () => {
+    it('should find all occurrences', () => {
+      const scanner = new TextScanner(createTextNode('aXaXa'));
+      const matches = scanner.findAllOccurrences('X');
+      expect(matches).toHaveLength(2);
+      expect(matches[0].index).toBe(1);
+      expect(matches[1].index).toBe(3);
+    });
+
+    it('should return empty array for empty search string', () => {
+      const scanner = new TextScanner(createTextNode('hello'));
+      const matches = scanner.findAllOccurrences('');
+      expect(matches).toEqual([]);
+    });
+
+    it('should return empty array when string not found', () => {
+      const scanner = new TextScanner(createTextNode('hello'));
+      const matches = scanner.findAllOccurrences('xyz');
+      expect(matches).toEqual([]);
+    });
+  });
+
+  describe('forEachChar', () => {
+    it('should iterate over each character', () => {
+      const scanner = new TextScanner(createTextNode('abc'));
+      const chars: string[] = [];
+      scanner.forEachChar((char) => {
+        chars.push(char);
+      });
+      expect(chars).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should track line and column for newlines', () => {
+      const scanner = new TextScanner(createTextNode('a\nb'));
+      const positions: Array<{ line: number; column: number }> = [];
+      scanner.forEachChar((_char, _i, pos) => {
+        positions.push({ line: pos.line, column: pos.column });
+      });
+      expect(positions[0]).toEqual({ line: 1, column: 1 });
+      expect(positions[1]).toEqual({ line: 1, column: 2 });
+      expect(positions[2]).toEqual({ line: 2, column: 1 });
+    });
+
+    it('should use start position from node', () => {
+      const node = createTextNode('abc', 5, 3, 10);
+      const scanner = new TextScanner(node);
+      const positions: number[] = [];
+      scanner.forEachChar((_char, _i, pos) => {
+        positions.push(pos.offset);
+      });
+      expect(positions).toEqual([10, 11, 12]);
+    });
+  });
+});

--- a/__tests__/unit/utils/text-scanner.spec.ts
+++ b/__tests__/unit/utils/text-scanner.spec.ts
@@ -85,7 +85,7 @@ describe('TextScanner', () => {
     it('should handle zero-length matches without infinite loop', () => {
       const scanner = new TextScanner(createTextNode('abc'));
       const matches = scanner.findAllMatches(/(\b)/g);
-      expect(Array.isArray(matches)).toBe(true);
+      expect(matches).toEqual([]);
     });
 
     it('should return empty array when no matches', () => {
@@ -102,6 +102,16 @@ describe('TextScanner', () => {
       expect(matches).toHaveLength(2);
       expect(matches[0].index).toBe(1);
       expect(matches[1].index).toBe(3);
+    });
+
+    it('should find overlapping occurrences', () => {
+      const scanner = new TextScanner(createTextNode('aaa'));
+      const matches = scanner.findAllOccurrences('aa');
+      expect(matches).toHaveLength(2);
+      expect(matches[0].index).toBe(0);
+      expect(matches[0].absoluteRange).toEqual([0, 2]);
+      expect(matches[1].index).toBe(1);
+      expect(matches[1].absoluteRange).toEqual([1, 3]);
     });
 
     it('should return empty array for empty search string', () => {


### PR DESCRIPTION
## 概述

为以下文件补充测试用例，提升测试覆盖率。

## 覆盖率改进

| 文件 | 变更前 | 变更后 | 新增测试数 |
|------|--------|--------|-----------|
| src/utils/mark-text.ts | 0% | 100% | 16 |
| src/utils/override-default-rules.ts | 54.54% | 100% | 9 |
| src/utils/text-scanner.ts | 88.33% | 96.66% | 15 |
| src/core/run-lint.ts | 90.9% | 100% | 3 |
| **总计** | | | **43** |

## 测试详情

### mark-text.ts (16 tests)
- 空字符串处理
- 单字符标记（数字、中文、英文、标点）
- 大写/小写英文
- 混合内容标记
- 特殊字符处理（空格、换行、制表符）
- README示例验证

### override-default-rules.ts (9 tests)
- 默认规则注册
- 用户配置覆盖（severity 为 number）
- 用户配置覆盖（severity 为数组 [severity, options]）
- 无效规则配置抛出错误
- 第三方规则配置（数组长度为 3）
- 第三方规则配置长度错误抛出错误
- 空配置、全部禁用等边界条件

### text-scanner.ts (15 tests)
- value 和 node getter
- matchAt 处理单行文本
- matchAt 处理跨行文本
- findAllMatches 正则匹配
- findAllMatches 零长度匹配
- findAllOccurrences 字符串查找
- findAllOccurrences 空字符串
- forEachChar 逐字符迭代
- forEachChar 跟踪行号列号

### run-lint.ts (3 tests)
- 空规则数组
- 规则执行抛出 Error 异常
- 规则执行抛出非 Error 异常（不输出错误）

## 验证结果

- ✅ npm run lint - 通过
- ✅ npm run typecheck - 通过
- ✅ npm test - 147/147 测试通过（新增 43 个）
- ✅ 测试套件从 27 个增加到 30 个