### PR TITLE
fix(no-long-code): 计算真实 offset，避免 content 退化为整篇文档 [P0-1]

### DIFF
--- a/__tests__/unit/rules/no-long-code.spec.ts
+++ b/__tests__/unit/rules/no-long-code.spec.ts
@@ -35,10 +35,50 @@ describe('test no-long-code', () => {
     const { lintResult } = fixer(md);
     const options = lintResult.ruleManager.getReportData().pop();
 
+    // 精确校验 offset 落在对应代码行，而非仅断言为 number
+    expect(options?.loc.start.offset).toBe(md.indexOf(longCode));
+    expect(options?.loc.end.offset).toBe(md.indexOf(longCode) + longCode.length);
     expect(options?.loc).toEqual({
-      end: expect.objectContaining({ column: 114, line: 1 }),
-      start: expect.objectContaining({ column: 1, line: 1 })
+      end: expect.objectContaining({ column: 114, line: 2, offset: options?.loc.end.offset }),
+      start: expect.objectContaining({ column: 1, line: 2, offset: options?.loc.start.offset })
     });
+    // content 只应截取该行上下文，而非整篇文档
+    expect(options?.content.length).toBeLessThan(md.length);
+    expect(options?.content).toContain(longCode.slice(0, 20));
+  });
+
+  test('test fix applied with CRLF', () => {
+    const longCode = 'console.log("very long long long long long long long long long long long long long long long long long sentence");';
+    const md = [
+      '```js',
+      longCode,
+      '```'
+    ].join('\r\n');
+
+    const { lintResult } = fixer(md);
+    const options = lintResult.ruleManager.getReportData().pop();
+
+    // CRLF 下 offset 仍应精确落在代码行（基于原始文档坐标）
+    expect(options?.loc.start.offset).toBe(md.indexOf(longCode));
+    expect(options?.loc.end.offset).toBe(md.indexOf(longCode) + longCode.length);
+    expect(options?.content).toContain(longCode.slice(0, 20));
+  });
+
+  test('test fix applied with CRLF and preceding lines', () => {
+    const longCode = 'console.log("very long long long long long long long long long long long long long long long long long sentence");';
+    const md = [
+      'some text before',
+      '```js',
+      longCode,
+      '```'
+    ].join('\r\n');
+
+    const { lintResult } = fixer(md);
+    const options = lintResult.ruleManager.getReportData().pop();
+
+    // 代码块不在文档开头时，CRLF 下偏移也不能漂移
+    expect(options?.loc.start.offset).toBe(md.indexOf(longCode));
+    expect(options?.loc.end.offset).toBe(md.indexOf(longCode) + longCode.length);
   });
 
   test('test exclude option', () => {
@@ -67,14 +107,107 @@ describe('test no-long-code', () => {
     const { fixedResult, lintResult } = fixer(md);
 
     expect(fixedResult?.result).toStrictEqual(md);
+    const longLine = 'console.log("code code code code code code code code");';
     const [r1, r2] = lintResult.ruleManager.getReportData();
     expect(r1.loc).toEqual({
-      end: expect.objectContaining({ column: 55, line: 2 }),
-      start: expect.objectContaining({ column: 1, line: 2 })
+      end: expect.objectContaining({ column: 55, line: 3, offset: expect.any(Number) }),
+      start: expect.objectContaining({ column: 1, line: 3, offset: expect.any(Number) })
     });
     expect(r2.loc).toEqual({
-      end: expect.objectContaining({ column: 55, line: 4 }),
-      start: expect.objectContaining({ column: 1, line: 4 })
+      end: expect.objectContaining({ column: 55, line: 5, offset: expect.any(Number) }),
+      start: expect.objectContaining({ column: 1, line: 5, offset: expect.any(Number) })
     });
+    // 精确校验 offset 落在各自代码行
+    expect(r1.loc.start.offset).toBe(md.indexOf(longLine));
+    expect(r1.loc.end.offset).toBe(md.indexOf(longLine) + longLine.length);
+    expect(r2.loc.start.offset).toBe(md.lastIndexOf(longLine));
+    expect(r2.loc.end.offset).toBe(md.lastIndexOf(longLine) + longLine.length);
+    // content 只应截取对应行上下文，而非整篇文档
+    expect(r1.content.length).toBeLessThan(md.length);
+    expect(r2.content.length).toBeLessThan(md.length);
+  });
+
+  test('test content does not degrade to whole document for large doc', () => {
+    const longLine = 'x'.repeat(120);
+    const codeLines = Array.from({ length: 5 }, () => longLine);
+    // 构造 ~1000 行的文档，其中只有一个超长代码块
+    const padding = Array.from({ length: 1000 }, (_, i) => `这是第 ${i} 行普通文本，用于撑大文档体积。`).join('\n');
+    const md = [
+      padding,
+      '```js',
+      ...codeLines,
+      '```'
+    ].join('\n');
+
+    const { lintResult } = fixer(md);
+    const data = lintResult.ruleManager.getReportData();
+
+    expect(data.length).toBeGreaterThan(0);
+    for (const item of data) {
+      // content 应远小于全文（全文几千字符），只保留该行上下文
+      expect(item.content.length).toBeLessThan(300);
+      expect(item.content.length).toBeLessThan(md.length);
+    }
+    // 精确校验：每条报告的 offset 落在对应超长代码行，而非全文范围
+    const firstLongLine = codeLines[0];
+    const firstReport = data[0];
+    expect(firstReport.loc.start.offset).toBe(md.indexOf(firstLongLine));
+    expect(firstReport.loc.end.offset).toBe(md.indexOf(firstLongLine) + firstLongLine.length);
+  });
+
+  test('test indented code block', () => {
+    const longCode = 'x'.repeat(120);
+    const md = `    ${longCode}`;
+
+    const { lintResult } = fixer(md);
+    const [report] = lintResult.ruleManager.getReportData();
+
+    // 缩进代码块无围栏：offset 应落在实际代码内容（跳过起始缩进）
+    expect(report.loc.start.offset).toBe(md.indexOf(longCode));
+    expect(report.loc.end.offset).toBe(md.indexOf(longCode) + longCode.length);
+  });
+
+  test('test unclosed fenced code block', () => {
+    const longCode = 'x'.repeat(120);
+    const md = ['```js', longCode].join('\n');
+
+    const { lintResult } = fixer(md);
+    const [report] = lintResult.ruleManager.getReportData();
+
+    // EOF 未闭合围栏：最后一行是真实代码内容，不应被当成结尾围栏而漏报
+    expect(report.loc.start.offset).toBe(md.indexOf(longCode));
+    expect(report.loc.end.offset).toBe(md.indexOf(longCode) + longCode.length);
+  });
+
+  test('test multi-line indented code block', () => {
+    const longCode = 'x'.repeat(120);
+    const md = [
+      '    short',
+      `    ${longCode}`
+    ].join('\n');
+
+    const { lintResult } = fixer(md);
+    const [report] = lintResult.ruleManager.getReportData();
+
+    // 多行缩进代码块：offset 应落在实际代码内容（跳过起始缩进），非统一缩进也需准确
+    expect(report.loc.start.offset).toBe(md.indexOf(longCode));
+    expect(report.loc.end.offset).toBe(md.indexOf(longCode) + longCode.length);
+  });
+
+  test('test multi-line indented code block with uneven indent', () => {
+    const longCode = 'x'.repeat(120);
+    // parser 会保留第二行多出的缩进，value 行实际为 '    xxxx...'
+    const valueLine = `    ${longCode}`;
+    const md = [
+      '    short',
+      `        ${longCode}`
+    ].join('\n');
+
+    const { lintResult } = fixer(md);
+    const [report] = lintResult.ruleManager.getReportData();
+
+    // 缩进不一致时，offset/length 仍应精确对应真实代码内容
+    expect(report.loc.start.offset).toBe(md.indexOf(valueLine));
+    expect(report.loc.end.offset).toBe(md.indexOf(valueLine) + valueLine.length);
   });
 });

--- a/__tests__/unit/utils/rule-manager.spec.ts
+++ b/__tests__/unit/utils/rule-manager.spec.ts
@@ -1,0 +1,49 @@
+import { createRuleManager } from '../../../src/utils/rule-manager';
+
+describe('test rule-manager report content fallback', () => {
+  test('report with offset slices only the reported range', () => {
+    const markdown = 'line1\nline2\nline3';
+    const manager = createRuleManager(markdown);
+    const context = manager.createRuleContext(
+      { rule: { meta: { name: 'demo' }, create: () => ({}) } as any, options: {} },
+      { ast: {} as any, markdown }
+    );
+
+    context.report({
+      loc: {
+        start: { line: 2, column: 1, offset: 6 },
+        end: { line: 2, column: 5, offset: 10 }
+      },
+      message: 'demo'
+    });
+
+    const [report] = manager.getReportData();
+    // 仅包含第 2 行（line2）的上下文，而非整篇文档
+    expect(report.content).toContain('line2');
+    expect(report.content.length).toBeLessThan(markdown.length);
+  });
+
+  test('report without offset falls back to line/column, not whole doc', () => {
+    const markdown = 'aaaa\nbbbb\ncccc\ndddd';
+    const manager = createRuleManager(markdown);
+    const context = manager.createRuleContext(
+      { rule: { meta: { name: 'demo' }, create: () => ({}) } as any, options: {} },
+      { ast: {} as any, markdown }
+    );
+
+    context.report({
+      loc: {
+        start: { line: 3, column: 2 },
+        end: { line: 3, column: 4 }
+      },
+      message: 'demo'
+    });
+
+    const [report] = manager.getReportData();
+    expect(report.content).toContain('ccc');
+    expect(report.content.length).toBeLessThan(markdown.length);
+    // 不应包含首尾无关行
+    expect(report.content).not.toContain('aaaa');
+    expect(report.content).not.toContain('dddd');
+  });
+});

--- a/src/rules/no-long-code.ts
+++ b/src/rules/no-long-code.ts
@@ -13,32 +13,78 @@ const noLongCode: LintMdRule = {
           return;
         }
 
-        const codeArray = node.value.split('\n');
-        for (let i = 0; i < codeArray.length; i++) {
-          // 第 i 行超出限制
-          if (codeArray[i].length > maxLength) {
-            const firstLineInCodeArea = node.position.start.line;
-            // code 代码块包括开头的三个点，所以三点处为第 firstLineInCodeArea 行，则 lint 问题出现在第 1 + i 行
-            // 列数则从第一列开始
-            const start = {
-              line: firstLineInCodeArea + i,
-              column: 1
-            };
+        // 计算真实偏移：直接对原始文档中代码块区间（含围栏与真实换行符）按 \n 切分，
+        // 这样偏移始终落在 raw-md 坐标系（与 node.position.offset、rule-manager 切片一致），
+        // 同时兼容 CRLF——rawLine 包含行尾 \r，cursor 推进时 +1 仅计入 \n，行间隔即 \r\n。
+        // 注意：parser 会把 node.value 归一化为 LF，但 position.offset 仍是原始坐标，
+        // 因此不能基于 node.value 推算偏移，必须以原始文档切片为准。
+        const md = context.markdown;
+        const blockStart = node.position.start.offset;
+        const blockEnd = node.position.end.offset;
+        const rawLines = md.slice(blockStart, blockEnd).split('\n');
 
-            // 很明显，结束处在同一行，列数则是该行的长度
-            const end = {
-              line: firstLineInCodeArea + i,
-              column: codeArray[i].length
-            };
+        // 先判断首行是否真的是围栏（fenced），再据此决定跳过哪些行，
+        // 避免把缩进代码块（无围栏）或 EOF 未闭合围栏的最后一行误判为围栏而漏报。
+        const firstLine = rawLines[0]?.replace(/\r$/, '') ?? '';
+        const fenceMatch = /^( {0,3})(`{3,}|~{3,})/.exec(firstLine);
 
-            context.report({
-              loc: {
-                start,
-                end
-              },
-              message: '代码块不能有过长的代码'
-            });
+        let startIndex = 0;
+        let endIndex = rawLines.length;
+        let indentWidth = 0;
+
+        if (fenceMatch) {
+          // fenced：跳过开头围栏
+          startIndex = 1;
+          const marker = fenceMatch[2][0];
+          const size = fenceMatch[2].length;
+          const closeRe = new RegExp(`^ {0,3}\\${marker}{${size},}\\s*$`);
+          const lastLine = rawLines[rawLines.length - 1]?.replace(/\r$/, '') ?? '';
+          if (closeRe.test(lastLine)) {
+            // 仅当存在闭合围栏时才跳过结尾；EOF 未闭合则保留最后一行代码
+            endIndex = rawLines.length - 1;
           }
+        }
+        else {
+          // indented code：parser 会剥离首行缩进，需手动补偿偏移，使 offset 落在实际内容上
+          indentWidth = firstLine.length - firstLine.replace(/^[ \t]+/, '').length;
+        }
+
+        let cursor = blockStart;
+        for (let k = 0; k < endIndex; k++) {
+          const rawLine = rawLines[k];
+          // 仅扫描 [startIndex, endIndex) 之间的代码行；被跳过的围栏行也需推进 cursor
+          if (k >= startIndex) {
+            // 去除行尾可能的 \r，并跳过缩进代码块的起始空白
+            const content = rawLine.replace(/\r$/, '').slice(indentWidth);
+            const lineLength = content.length;
+            if (lineLength > maxLength) {
+              // 第 k 行超出限制（围栏在第 start.line 行，代码第 k 行位于 start.line + k 行）
+              const line = node.position.start.line + k;
+
+              // 列从第一列开始，结束处为同一行的末尾
+              const start = {
+                line,
+                column: 1,
+                offset: cursor + indentWidth
+              };
+              const end = {
+                line,
+                column: lineLength,
+                offset: cursor + indentWidth + lineLength
+              };
+
+              context.report({
+                loc: {
+                  start,
+                  end
+                },
+                message: '代码块不能有过长的代码'
+              });
+            }
+          }
+
+          // 移动到下一行：当前行长度（含 \r）+ 行末的换行符（\n）
+          cursor += rawLine.length + 1;
         }
       }
     };

--- a/src/utils/rule-manager.ts
+++ b/src/utils/rule-manager.ts
@@ -37,11 +37,30 @@ export const createRuleManager = (appliedMarkdown: string) => {
     const { rule, options } = ruleConfig;
     const { ast, markdown } = extra;
 
+    // 将 (line, column) 换算成文档中的真实偏移。
+    // 用于 offset 缺失（规则侧合成 loc）时的兜底，避免切片退化成整篇文档。
+    const resolveOffset = (line: number, column: number): number => {
+      let offset = 0;
+      let currentLine = 1;
+      while (currentLine < line && offset < appliedMarkdown.length) {
+        const next = appliedMarkdown.indexOf('\n', offset);
+        if (next === -1) {
+          break;
+        }
+        offset = next + 1;
+        currentLine += 1;
+      }
+      // 行内偏移：列从 1 开始
+      return Math.min(appliedMarkdown.length, offset + Math.max(0, column - 1));
+    };
+
     // 上报方法，供选择器内部调用
     const report = (option: Omit<ReportOption, 'content' | 'name'>) => {
       // offset 在 ReportOption 中是可选的（合成 loc 没有真实 offset），这里兜底
-      const startOffset = option.loc.start.offset ?? 0;
-      const endOffset = option.loc.end.offset ?? appliedMarkdown.length;
+      const startOffset = option.loc.start.offset
+        ?? resolveOffset(option.loc.start.line, option.loc.start.column);
+      const endOffset = option.loc.end.offset
+        ?? resolveOffset(option.loc.end.line, option.loc.end.column);
       const markStart = Math.max(0, startOffset - 5);
       const markEnd = Math.min(appliedMarkdown.length, endOffset + 5);
 


### PR DESCRIPTION
## 关联
- 修复 Issue #169
Close #169 

## 问题
`no-long-code` 报告 `loc` 缺少 `offset`，`rule-manager.report` 兜底取 `appliedMarkdown.length`，使每条超长代码行报告都存一份整篇文档 `content`，内存浪费且内容无意义。

## 修复
- **A（主修复）** `src/rules/no-long-code.ts`：基于 `node.position` 在**原始文档切片**（`md.slice(start, end)`）上按 `\n` 切分计算真实 `offset`，与 `node.position.offset`、`rule-manager` 的 `appliedMarkdown` 切片处于同一 raw 坐标系，兼容 CRLF。同时修正了行号 off-by-one bug，行号现指向真实代码行而非围栏行。
- **B（防御）** `src/utils/rule-manager.ts`：无 offset 时由 `line/column` 反算真实偏移，避免任何规则回归到整篇文档切片。

## 非仅有 fenced 代码块（blocker 修复）
`code` 选择器对缩进代码块、EOF 未闭合围栏同样生效，原实现把首/尾行固定当作围栏，会漏报。改为**检测**首行是否为围栏：
- fenced 且有闭合围栏：跳过首尾围栏；
- fenced 但 EOF 未闭合：仅跳过开头围栏，保留最后一行代码；
- indented code：不跳过任何行，并按首行缩进补偿偏移，使 offset 落在实际内容上（多行缩进、非统一缩进均已验证准确）。

## 验证
- 新增精确 offset 断言（含多行缩进、非统一缩进、CRLF、未闭合围栏等用例）。
- 新增 `rule-manager.spec.ts` 单测覆盖无 offset（line/column 兜底）与有 offset 两种场景。
- 1000 行文档：每条报告 `content.length < 300`，远小于全文。
- `npm test` 165 passed；`npm run lint`、`npm run typecheck` 均通过。

## 变更文件
- src/rules/no-long-code.ts
- src/utils/rule-manager.ts
- __tests__/unit/rules/no-long-code.spec.ts
- __tests__/unit/utils/rule-manager.spec.ts（新增）
