### PR TITLE
fix(lint-markdown): 标注返回类型并修正 README 的 fixedResult [P0-3]

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: boolean)
 
 - `lintResult`：命中规则后的诊断结果列表（含规则名、位置信息、消息、级别）
 - `diagnostics`：标准诊断格式列表（`LintDiagnostic[]`），供编辑器集成直接消费
-- `fixedResult`：开启修复模式时返回修复后的文本，否则为 `null`
+- `fixedResult`：开启修复模式时返回 `{ result, notAppliedFixes }`（`result` 为修复后的文本，`notAppliedFixes` 为因冲突等原因未能应用的修复项），否则为 `null`
 
 下面是一个最小示例，可直接作为接入起点：
 
@@ -70,7 +70,7 @@ const result = lintMarkdown(markdown, {
 }, true);
 
 console.log(result.lintResult);
-console.log(result.fixedResult);
+console.log(result.fixedResult.result);
 ```
 
 ```ts

--- a/__tests__/unit/fixable-counts.spec.ts
+++ b/__tests__/unit/fixable-counts.spec.ts
@@ -132,6 +132,6 @@ describe('lintMarkdown() fixable counts (issue #152)', () => {
     expect(Object.keys(item!)).toEqual(
       expect.arrayContaining(['loc', 'message', 'name', 'content', 'severity'])
     );
-    expect((item as Record<string, unknown>).fix).toBeUndefined();
+    expect((item as unknown as Record<string, unknown>).fix).toBeUndefined();
   });
 });

--- a/src/core/lint-markdown.ts
+++ b/src/core/lint-markdown.ts
@@ -1,6 +1,11 @@
 import type {
+  FixedResult,
+  LintMdFixResult,
+  LintMdLintResult,
+  LintMdResult,
   LintMdRuleWithOptions,
-  LintMdRulesConfig
+  LintMdRulesConfig,
+  LintReportItem
 } from '../types';
 import * as internalRuleConfig from '../rules';
 import { overrideDefaultRules } from '../utils/override-default-rules';
@@ -8,7 +13,11 @@ import { RULE_SEVERITY } from '../types';
 import { runLint } from './run-lint';
 import { handleFixMode } from './handle-fix-mode';
 
-export const lintMarkdownInternal = (markdown: string, rules: LintMdRuleWithOptions[], isFixMode: boolean) => {
+export const lintMarkdownInternal = (
+  markdown: string,
+  rules: LintMdRuleWithOptions[],
+  isFixMode: boolean
+): { lintResult: ReturnType<typeof runLint>; fixedResult: FixedResult | null } => {
   if (!isFixMode) {
     const lintResult = runLint(markdown, rules);
     return {
@@ -26,7 +35,10 @@ export const lintMarkdownInternal = (markdown: string, rules: LintMdRuleWithOpti
  *
  * @date 2021-12-14 17:16:12
  */
-export const lintMarkdown = (markdown: string, rules: LintMdRulesConfig = {}, isFixMode = true) => {
+export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: true): LintMdFixResult;
+export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: false): LintMdLintResult;
+export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: boolean): LintMdResult;
+export function lintMarkdown(markdown: string, rules: LintMdRulesConfig = {}, isFixMode = true): LintMdResult {
   // 基于用户配置覆盖默认配置
   const registeredRules = overrideDefaultRules(internalRuleConfig, rules);
 
@@ -52,8 +64,8 @@ export const lintMarkdown = (markdown: string, rules: LintMdRulesConfig = {}, is
   let fixableErrorCount = 0;
   let fixableWarningCount = 0;
 
-  const reportDataWithSeverity = reportData?.map((item) => {
-    const severity = registeredRules[item.name].severity;
+  const reportDataWithSeverity: LintReportItem[] = reportData?.map((item) => {
+    const severity = registeredRules[item.name].severity as RULE_SEVERITY;
 
     if (typeof item.fix === 'function') {
       if (severity === RULE_SEVERITY.ERROR) {
@@ -72,7 +84,7 @@ export const lintMarkdown = (markdown: string, rules: LintMdRulesConfig = {}, is
       content,
       severity
     };
-  });
+  }) ?? [];
 
   const diagnostics = (reportDataWithSeverity ?? []).map(item => ({
     line: item.loc.start.line,
@@ -89,4 +101,4 @@ export const lintMarkdown = (markdown: string, rules: LintMdRulesConfig = {}, is
     fixableErrorCount,
     fixableWarningCount
   };
-};
+}

--- a/src/core/lint-markdown.ts
+++ b/src/core/lint-markdown.ts
@@ -34,6 +34,10 @@ export const lintMarkdownInternal = (
  * 核心方法，对某个 Markdown 文本进行 lint 或者 fix
  *
  * @date 2021-12-14 17:16:12
+ *    默认开启 fix 模式：
+ * - isFixMode=true 或省略时，fixedResult 为 FixedResult
+ * - isFixMode=false 时，fixedResult 为 null
+ * - isFixMode 为 boolean 变量时，返回联合类型
  */
 export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: true): LintMdFixResult;
 export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: false): LintMdLintResult;

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,3 +159,41 @@ export interface LintDiagnostic {
   /** 严重级别 */
   severity: RULE_SEVERITY
 }
+
+/** fix 模式下 `fixedResult` 的形状 */
+export interface FixedResult {
+  /** 修复后的完整 Markdown 文本 */
+  result: string
+  /** 因冲突等原因未能应用的修复项 */
+  notAppliedFixes: FixConfig[]
+}
+
+/** `lintMarkdown` 返回的 lint 诊断项（带严重级别） */
+export interface LintReportItem {
+  loc: ReportOption['loc']
+  message: string
+  name: string
+  content: string
+  severity: RULE_SEVERITY
+}
+
+/** `lintMarkdown` 返回结果的公共部分 */
+export interface LintMdResultBase {
+  lintResult: LintReportItem[]
+  diagnostics: LintDiagnostic[]
+  fixableErrorCount: number
+  fixableWarningCount: number
+}
+
+/** 非修复模式（isFixMode=false）：`fixedResult` 为 null */
+export interface LintMdLintResult extends LintMdResultBase {
+  fixedResult: null
+}
+
+/** 修复模式（isFixMode=true，默认）：`fixedResult` 为对象 */
+export interface LintMdFixResult extends LintMdResultBase {
+  fixedResult: FixedResult
+}
+
+/** `lintMarkdown` 的返回类型（按 isFixMode 区分 fixedResult 形状） */
+export type LintMdResult = LintMdLintResult | LintMdFixResult;


### PR DESCRIPTION
## 关联
 Close #171

## 问题
`lintMarkdown` 的 `fixedResult` 在 fix 模式下实为对象 `{ result, notAppliedFixes }`，但：
- `lintMarkdown` / `lintMarkdownInternal` 无返回类型标注，类型不安全；
- `README.md` 描述称“返回修复后的文本”（按字符串理解），与实现不一致。

## 修复
- `types.ts` 新增 `FixedResult` / `LintReportItem` / `LintMdResultBase` / `LintMdLintResult` / `LintMdFixResult` / `LintMdResult`。
- `lintMarkdown` 增加函数重载，按 `isFixMode` 区分 `fixedResult` 形状：
  - `isFixMode=false` → `fixedResult: null`
  - `isFixMode=true`（默认）→ `fixedResult: { result, notAppliedFixes }`
  - 重载顺序将 fix 重载放在最前，使默认（无参）调用正确解析为 fix 模式。
- `lintMarkdownInternal` 同步标注返回类型。
- README 明确 `fixedResult` 在 fix 模式下为 `{ result, notAppliedFixes }`（`result` 才是修复文本），示例改为 `result.fixedResult.result`。

## 验收
- `npm run typecheck` 通过。
- `npm test` 165 passed；`npm run lint` 通过。
- README 示例与实现一致。

## 变更文件
- src/types.ts
- src/core/lint-markdown.ts
- README.md
- __tests__/unit/fixable-counts.spec.ts（类型断言随返回类型收紧微调）