### PR TITLE
fix(handle-fix-mode): 保留最后一轮 notAppliedFixes，公共 API 可访问 [P1-6]

### DIFF
--- a/__tests__/unit/core.spec.ts
+++ b/__tests__/unit/core.spec.ts
@@ -92,4 +92,84 @@ Some **importance**, and \`code\`.
 
     expect(res.fixedResult?.result).toMatchSnapshot();
   });
+
+  test('notAppliedFixes accessible via lintMarkdown public API', () => {
+    const ruleA: LintMdRule = {
+      meta: { name: 'replace-to-x' },
+      create: (ctx) => ({
+        text: (node: any) => {
+          if (node.value === 'abc') {
+            ctx.report({
+              loc: node.position,
+              message: 'to X',
+              fix: () => ({
+                range: [node.position.start.offset, node.position.end.offset],
+                text: 'X'
+              })
+            });
+          }
+        }
+      })
+    };
+
+    const ruleB: LintMdRule = {
+      meta: { name: 'replace-to-y' },
+      create: (ctx) => ({
+        text: (node: any) => {
+          if (node.value === 'abc') {
+            ctx.report({
+              loc: node.position,
+              message: 'to Y',
+              fix: () => ({
+                range: [node.position.start.offset, node.position.end.offset],
+                text: 'Y'
+              })
+            });
+          }
+        }
+      })
+    };
+
+    const res = lintMarkdown(
+      'abc',
+      { 'replace-to-x': [ruleA, 2, {}], 'replace-to-y': [ruleB, 2, {}] },
+      true
+    );
+
+    expect(res.fixedResult).not.toBeNull();
+    expect(res.fixedResult!.result).toBe('X');
+    // ruleB's fix conflicts with ruleA's — should be in notAppliedFixes
+    expect(res.fixedResult!.notAppliedFixes.length).toBe(1);
+    expect(res.fixedResult!.notAppliedFixes[0].text).toBe('Y');
+  });
+
+  test('notAppliedFixes empty when no conflicts', () => {
+    const ruleA: LintMdRule = {
+      meta: { name: 'replace-foo' },
+      create: (ctx) => ({
+        text: (node: any) => {
+          if (node.value === 'foo') {
+            ctx.report({
+              loc: node.position,
+              message: 'replace foo',
+              fix: () => ({
+                range: [node.position.start.offset, node.position.end.offset],
+                text: 'bar'
+              })
+            });
+          }
+        }
+      })
+    };
+
+    const res = lintMarkdown(
+      'foo',
+      { 'replace-foo': [ruleA, 2, {}] },
+      true
+    );
+
+    expect(res.fixedResult).not.toBeNull();
+    expect(res.fixedResult!.result).toBe('bar');
+    expect(res.fixedResult!.notAppliedFixes).toStrictEqual([]);
+  });
 });

--- a/__tests__/unit/handle-fix-mode.spec.ts
+++ b/__tests__/unit/handle-fix-mode.spec.ts
@@ -237,4 +237,114 @@ describe('handleFixMode', () => {
     expect(result.lintResult.ruleManager.getReportData().length).toBe(1);
     expect(result.lintResult.ruleManager.getReportData()[0].message).toBe('replace foo');
   });
+
+  test('notAppliedFixes reflects only last round, not historical', () => {
+    // Round 1: ruleA replaces "abc"→"X", ruleB replaces "abc"→"Y" (conflict, B skipped)
+    // Round 2: text is "X", ruleC replaces "X"→"Z" (applied cleanly, no conflict)
+    // If accumulated: notAppliedFixes would contain stale B fix (wrong)
+    // If last-round only: notAppliedFixes is [] (correct — round 2 had no conflict)
+    const ruleA = makeRule({
+      name: 'a',
+      selector: 'text',
+      reportFn: (ctx, node) => {
+        if (node.value === 'abc') {
+          ctx.report({
+            loc: node.position,
+            message: 'a',
+            fix: () => ({
+              range: [node.position.start.offset, node.position.end.offset],
+              text: 'X'
+            })
+          });
+        }
+      }
+    });
+
+    const ruleB = makeRule({
+      name: 'b',
+      selector: 'text',
+      reportFn: (ctx, node) => {
+        if (node.value === 'abc') {
+          ctx.report({
+            loc: node.position,
+            message: 'b',
+            fix: () => ({
+              range: [node.position.start.offset, node.position.end.offset],
+              text: 'Y'
+            })
+          });
+        }
+      }
+    });
+
+    const ruleC = makeRule({
+      name: 'c',
+      selector: 'text',
+      reportFn: (ctx, node) => {
+        if (node.value === 'X') {
+          ctx.report({
+            loc: node.position,
+            message: 'c',
+            fix: () => ({
+              range: [node.position.start.offset, node.position.end.offset],
+              text: 'Z'
+            })
+          });
+        }
+      }
+    });
+
+    const result = handleFixMode('abc', [{ rule: ruleA }, { rule: ruleB }, { rule: ruleC }]);
+    // Final text: "Z" (round 1: abc→X, round 2: X→Z)
+    expect(result.fixedResult.result).toBe('Z');
+    // Round 2 had no conflict → notAppliedFixes should be empty
+    // NOT: [ruleB's stale fix from round 1]
+    expect(result.fixedResult.notAppliedFixes).toStrictEqual([]);
+  });
+
+  test('notAppliedFixes from last round when text converges with conflicts', () => {
+    // Round 1: "abc" → ruleA wins "abc"→"X", ruleB conflict skipped
+    // Round 2: "X" → ruleA wins "X"→"W", ruleB conflict skipped
+    // Round 3: "W" → no fixes → exit
+    // lastNotAppliedFixes should be round 2's [ruleB fix], not accumulated [ruleB, ruleB]
+    const ruleA = makeRule({
+      name: 'a',
+      selector: 'text',
+      reportFn: (ctx, node) => {
+        if (node.value === 'abc' || node.value === 'X') {
+          ctx.report({
+            loc: node.position,
+            message: 'a',
+            fix: () => ({
+              range: [node.position.start.offset, node.position.end.offset],
+              text: node.value === 'abc' ? 'X' : 'W'
+            })
+          });
+        }
+      }
+    });
+
+    const ruleB = makeRule({
+      name: 'b',
+      selector: 'text',
+      reportFn: (ctx, node) => {
+        if (node.value === 'abc' || node.value === 'X') {
+          ctx.report({
+            loc: node.position,
+            message: 'b',
+            fix: () => ({
+              range: [node.position.start.offset, node.position.end.offset],
+              text: 'Y'
+            })
+          });
+        }
+      }
+    });
+
+    const result = handleFixMode('abc', [{ rule: ruleA }, { rule: ruleB }]);
+    expect(result.fixedResult.result).toBe('W');
+    // last round (round 2) had a conflict → 1 entry
+    expect(result.fixedResult.notAppliedFixes.length).toBe(1);
+    expect(result.fixedResult.notAppliedFixes[0].text).toBe('Y');
+  });
 });

--- a/src/core/handle-fix-mode.ts
+++ b/src/core/handle-fix-mode.ts
@@ -8,10 +8,7 @@ export const handleFixMode = (markdown: string, rules: LintMdRuleWithOptions[]) 
   let initialLintResult = {} as ReturnType<typeof runLint>;
 
   let current = markdown;
-  let fixedResult: { result: string; notAppliedFixes: FixConfig[] } = {
-    result: markdown,
-    notAppliedFixes: []
-  };
+  let lastNotAppliedFixes: FixConfig[] = [];
 
   while (lintTimes < MAX_LINT_AND_FIX_CALL_TIMES) {
     const lintResult = runLint(current, rules);
@@ -25,23 +22,26 @@ export const handleFixMode = (markdown: string, rules: LintMdRuleWithOptions[]) 
     const fixes = lintResult.ruleManager.getAllFixes();
 
     if (!fixes.length) {
-      fixedResult = {
-        result: current,
-        notAppliedFixes: []
-      };
       break;
     }
 
     const nextFixedResult = applyFix(current, fixes);
 
+    // 仅保留最后一轮 applyFix 返回的 notAppliedFixes
+    // 不跨轮累积：不同轮次的 fix range 基于各自输入文本，跨轮混用会导致 range 失效
+    lastNotAppliedFixes = nextFixedResult.notAppliedFixes;
+
     if (nextFixedResult.result === current) {
-      fixedResult = nextFixedResult;
       break;
     }
 
-    fixedResult = nextFixedResult;
     current = nextFixedResult.result;
   }
+
+  const fixedResult = {
+    result: current,
+    notAppliedFixes: lastNotAppliedFixes
+  };
 
   return {
     lintResult: initialLintResult,

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,7 +164,10 @@ export interface LintDiagnostic {
 export interface FixedResult {
   /** 修复后的完整 Markdown 文本 */
   result: string
-  /** 因冲突等原因未能应用的修复项 */
+  /**
+   * 最终轮次中因冲突等原因未能应用的修复项。
+   * range 基于 result 文本的坐标，可直接用于 result。
+   */
   notAppliedFixes: FixConfig[]
 }
 


### PR DESCRIPTION
## 背景

P1-6：暴露未应用 fix（部分未修复可感知）。P0-3 已将 `fixedResult` 改为 `{ result, notAppliedFixes }` 对象，但 `handleFixMode` 在 `fixes.length === 0` 时重置 `notAppliedFixes` 为 `[]`，导致跨轮冲突 fix 信息丢失。

## 修改内容

### `src/core/handle-fix-mode.ts`

**原问题**：`fixes.length === 0` 时重置 `notAppliedFixes = []`，丢失最后一轮的冲突信息。

**新逻辑**：
- 引入 `lastNotAppliedFixes` 追踪最后一轮 `applyFix` 返回值
- 不跨轮累积：不同轮次的 fix range 基于各自输入文本，跨轮混用会导致 range 失效
- 循环结束时赋给 `fixedResult.notAppliedFixes`

### `src/types.ts`

更新 `FixedResult.notAppliedFixes` 注释：说明 range 基于 `result` 文本坐标，可直接用于 `result`。

### `__tests__/unit/handle-fix-mode.spec.ts`（+2 tests）

1. **跨轮语义**：round 1 冲突 B 被跳过，round 2 C 成功修复 → `notAppliedFixes` 为空（不是历史累积）
2. **连续冲突**：round 1 和 round 2 都有冲突，round 3 无修复 → `notAppliedFixes` = round 2 的冲突条目（1 条，不是 2 条累积）

### `__tests__/unit/core.spec.ts`（+2 tests）

1. 冲突 fix 场景：`fixedResult.notAppliedFixes` 包含被跳过的 fix
2. 无冲突场景：`notAppliedFixes` 为空

## 验证

- `npm test`：185 tests passed ✅
- `npm run typecheck`：通过 ✅
- `npm run lint`：通过 ✅