### PR TITLE
fix(override-default-rules): alias third-party rules by meta.name and fail on invalid config

### DIFF
--- a/__tests__/unit/rule-alias.spec.ts
+++ b/__tests__/unit/rule-alias.spec.ts
@@ -124,4 +124,21 @@ describe('lintMarkdown() rule alias & config contract (issue #177)', () => {
     expect(res.fixableErrorCount).toBe(1);
     expect(res.fixableWarningCount).toBe(1);
   });
+
+  test('9. third-party rule cannot silently override a built-in rule by meta.name (P1)', () => {
+    // 复用内置规则名 space-around-alphabet，但实现为空，企图替换内置规则。
+    const hijackRule = makeMockRule({ name: 'space-around-alphabet', withFix: false });
+    expect(() => lintMarkdown('hello world', {
+      'hijack-alias': [hijackRule, RULE_SEVERITY.WARN, {}]
+    }, false)).toThrow(/别名冲突/);
+  });
+
+  test('10. same rule object reused under two config keys is a conflict (P1)', () => {
+    const sharedRule = makeMockRule({ name: 'shared-name', withFix: false });
+    expect(() => lintMarkdown('text only', {
+      ...disableAllInternal(),
+      'alias-a': [sharedRule, RULE_SEVERITY.ERROR, { source: 'a' }],
+      'alias-b': [sharedRule, RULE_SEVERITY.WARN, { source: 'b' }]
+    }, false)).toThrow(/别名冲突/);
+  });
 });

--- a/__tests__/unit/rule-alias.spec.ts
+++ b/__tests__/unit/rule-alias.spec.ts
@@ -1,0 +1,127 @@
+import { lintMarkdown } from '../../src';
+import * as internalRules from '../../src/rules';
+import type { LintMdRule, LintMdRulesConfig, PositionedTextNode } from '../../src/types';
+import { RULE_SEVERITY } from '../../src/types';
+
+const makeMockRule = (opts: {
+  name: string;
+  withFix?: boolean;
+  matchesText?: string;
+}): LintMdRule => ({
+  meta: { name: opts.name },
+  create: (context) => ({
+    text: (node: PositionedTextNode) => {
+      if (opts.matchesText !== undefined && node.value !== opts.matchesText) {
+        return;
+      }
+      context.report({
+        loc: node.position,
+        message: `mock report from ${opts.name}`,
+        ...(opts.withFix
+          ? {
+              fix: (fixer) => fixer.replaceTextRange(
+                [node.position.start.offset, node.position.end.offset],
+                'X'
+              )
+            }
+          : {})
+      });
+    }
+  })
+});
+
+const disableAllInternal = (): LintMdRulesConfig =>
+  Object.fromEntries(
+    Object.values(internalRules).map((rule) => [rule.meta.name, RULE_SEVERITY.OFF])
+  );
+
+describe('lintMarkdown() rule alias & config contract (issue #177)', () => {
+  test('1. alias config key (key !== meta.name) does not crash and reports correctly', () => {
+    const mockRule = makeMockRule({ name: 'actual-rule-name', withFix: false });
+    const res = lintMarkdown('text only', {
+      ...disableAllInternal(),
+      'configured-alias': [mockRule, RULE_SEVERITY.ERROR, {}]
+    }, false);
+
+    expect(res.lintResult).toHaveLength(1);
+    expect(res.lintResult?.[0]?.name).toBe('actual-rule-name');
+    expect(res.lintResult?.[0]?.severity).toBe(RULE_SEVERITY.ERROR);
+  });
+
+  test('2. same-name rule (config key === meta.name) still works', () => {
+    const mockRule = makeMockRule({ name: 'same-name-rule', withFix: false });
+    const res = lintMarkdown('text only', {
+      ...disableAllInternal(),
+      'same-name-rule': [mockRule, RULE_SEVERITY.WARN, {}]
+    }, false);
+
+    expect(res.lintResult).toHaveLength(1);
+    expect(res.lintResult?.[0]?.name).toBe('same-name-rule');
+    expect(res.lintResult?.[0]?.severity).toBe(RULE_SEVERITY.WARN);
+  });
+
+  test('3. alias does not double-run the rule (report count stays correct)', () => {
+    const mockRule = makeMockRule({ name: 'no-double-run', withFix: false, matchesText: 'alpha' });
+    const res = lintMarkdown('alpha', {
+      ...disableAllInternal(),
+      'alias-key': [mockRule, RULE_SEVERITY.ERROR, {}]
+    }, false);
+
+    // 配置键 + meta.name 别名指向同一记录，应只运行一次，不翻倍。
+    expect(res.lintResult).toHaveLength(1);
+  });
+
+  test('4. alias conflict (two configs mapping to same meta.name) throws', () => {
+    const ruleA = makeMockRule({ name: 'shared-meta-name', withFix: false });
+    const ruleB = makeMockRule({ name: 'shared-meta-name', withFix: false });
+
+    expect(() => lintMarkdown('text only', {
+      ...disableAllInternal(),
+      'key-a': [ruleA, RULE_SEVERITY.ERROR, {}],
+      'key-b': [ruleB, RULE_SEVERITY.ERROR, {}]
+    }, false)).toThrow(/别名冲突/);
+  });
+
+  test('5. unknown rule with illegal (non-array) config throws instead of silent ignore', () => {
+    expect(() => lintMarkdown('text only', {
+      ...disableAllInternal(),
+      // 拼写错误的规则名配了一个数字 -> 此前被静默忽略
+      'space-around-alphbet': RULE_SEVERITY.ERROR as unknown as LintMdRulesConfig[string]
+    }, false)).toThrow(/配置格式非法/);
+  });
+
+  test('6. third-party rule with illegal array length (not 3) throws', () => {
+    const mockRule = makeMockRule({ name: 'illegal-length', withFix: false });
+    expect(() => lintMarkdown('text only', {
+      ...disableAllInternal(),
+      'illegal-length': [mockRule, RULE_SEVERITY.ERROR] as unknown as LintMdRulesConfig[string]
+    }, false)).toThrow(/配置长度必须为 3/);
+  });
+
+  test('7. disabled (OFF) third-party rule produces no report', () => {
+    const mockRule = makeMockRule({ name: 'off-third-party', withFix: false, matchesText: 'alpha' });
+    const res = lintMarkdown('alpha', {
+      ...disableAllInternal(),
+      'off-third-party': [mockRule, RULE_SEVERITY.OFF, {}]
+    }, false);
+
+    expect(res.lintResult).toHaveLength(0);
+    expect(res.fixableErrorCount).toBe(0);
+    expect(res.fixableWarningCount).toBe(0);
+  });
+
+  test('8. error / warn counts correct for aliased third-party rules', () => {
+    const errRule = makeMockRule({ name: 'alias-error', withFix: true, matchesText: 'alpha' });
+    const warnRule = makeMockRule({ name: 'alias-warn', withFix: true, matchesText: 'beta' });
+
+    const res = lintMarkdown('alpha\n\nbeta', {
+      ...disableAllInternal(),
+      'err-alias': [errRule, RULE_SEVERITY.ERROR, {}],
+      'warn-alias': [warnRule, RULE_SEVERITY.WARN, {}]
+    }, false);
+
+    expect(res.lintResult).toHaveLength(2);
+    expect(res.fixableErrorCount).toBe(1);
+    expect(res.fixableWarningCount).toBe(1);
+  });
+});

--- a/__tests__/unit/utils/override-default-rules.spec.ts
+++ b/__tests__/unit/utils/override-default-rules.spec.ts
@@ -102,4 +102,25 @@ describe('overrideDefaultRules', () => {
     expect(result['rule-a'].severity).toBe(RULE_SEVERITY.OFF);
     expect(result['rule-b'].severity).toBe(RULE_SEVERITY.OFF);
   });
+  it('should throw for prototype-like unknown rule name and not pollute Object.prototype (issue #177)', () => {
+    const rules = JSON.parse('{"__proto__": 2}') as any;
+
+    expect(() => overrideDefaultRules(defaultRules, rules)).toThrow(/未知规则/);
+    expect(Object.prototype.hasOwnProperty.call(Object.prototype, 'severity')).toBe(false);
+  });
+
+  it('should store third-party rule whose meta.name is a prototype key as plain key without pollution (issue #177)', () => {
+    // 使用无原型注册表后，meta.name 为 __proto__ 的规则会被当作普通 own 属性保存，
+    // 不会改变 Object.prototype，也不会崩溃。
+    const protoRule = createMockRule('__proto__');
+    const result = overrideDefaultRules(defaultRules, {
+      'proto-alias': [protoRule, RULE_SEVERITY.WARN, {}]
+    });
+
+    expect(Object.prototype.hasOwnProperty.call(Object.prototype, 'severity')).toBe(false);
+    expect((result as any)['__proto__']).toBeDefined();
+    expect((result as any)['__proto__'].rule).toBe(protoRule);
+  });
 });
+
+

--- a/__tests__/unit/utils/override-default-rules.spec.ts
+++ b/__tests__/unit/utils/override-default-rules.spec.ts
@@ -71,11 +71,22 @@ describe('overrideDefaultRules', () => {
     }).toThrow(/第三方规则.*配置长度必须为 3/);
   });
 
-  it('should not register third-party rule when config is not an array', () => {
+  it('should throw for unknown rule when config is not an array (issue #177)', () => {
+    expect(() => {
+      overrideDefaultRules(defaultRules, {
+        'custom-rule': RULE_SEVERITY.WARN as any
+      });
+    }).toThrow(/配置格式非法/);
+  });
+
+  it('should register third-party rule alias by meta.name (issue #177)', () => {
+    const customRule = createMockRule('actual-name');
     const result = overrideDefaultRules(defaultRules, {
-      'custom-rule': RULE_SEVERITY.WARN as any
+      'configured-alias': [customRule, RULE_SEVERITY.WARN, {}]
     });
-    expect(result['custom-rule']).toBeUndefined();
+    // 配置键与 meta.name 不等时，按 meta.name 建立别名，回查仍能命中同一记录。
+    expect(result['configured-alias']).toBeDefined();
+    expect(result['actual-name']).toBe(result['configured-alias']);
   });
 
   it('should handle empty default rules', () => {

--- a/src/core/lint-markdown.ts
+++ b/src/core/lint-markdown.ts
@@ -3,6 +3,7 @@ import type {
   LintMdFixResult,
   LintMdLintResult,
   LintMdResult,
+  LintMdRule,
   LintMdRuleWithOptions,
   LintMdRulesConfig,
   LintReportItem
@@ -49,10 +50,22 @@ export function lintMarkdown(markdown: string, rules: LintMdRulesConfig = {}, is
   const registeredRuleEntries = Object.entries(registeredRules);
 
   // 最终的 rules
+  // 注意：注册表可能包含同一规则的多条记录（配置键 + meta.name 别名），
+  // 这里按 rule 引用去重，避免规则被重复执行导致报告与计数翻倍。
+  const seenRules = new Set<LintMdRule>();
   const internalRules = registeredRuleEntries
     .filter((item) => {
+      const value = item[1];
       // 过滤掉 severity 为 0 的规则，提高性能
-      return item[1].severity !== RULE_SEVERITY.OFF;
+      if (value.severity === RULE_SEVERITY.OFF) {
+        return false;
+      }
+      // 同一 rule 只保留一次（配置键与 meta.name 别名指向同一记录）
+      if (seenRules.has(value.rule)) {
+        return false;
+      }
+      seenRules.add(value.rule);
+      return true;
     })
     .map((options) => {
       const value = options[1];

--- a/src/core/lint-markdown.ts
+++ b/src/core/lint-markdown.ts
@@ -3,10 +3,10 @@ import type {
   LintMdFixResult,
   LintMdLintResult,
   LintMdResult,
-  LintMdRule,
   LintMdRuleWithOptions,
   LintMdRulesConfig,
-  LintReportItem
+  LintReportItem,
+  RegisteredRules
 } from '../types';
 import * as internalRuleConfig from '../rules';
 import { overrideDefaultRules } from '../utils/override-default-rules';
@@ -50,9 +50,12 @@ export function lintMarkdown(markdown: string, rules: LintMdRulesConfig = {}, is
   const registeredRuleEntries = Object.entries(registeredRules);
 
   // 最终的 rules
-  // 注意：注册表可能包含同一规则的多条记录（配置键 + meta.name 别名），
-  // 这里按 rule 引用去重，避免规则被重复执行导致报告与计数翻倍。
-  const seenRules = new Set<LintMdRule>();
+  // 注意：注册表可能为同一注册记录建立过别名（配置键 + meta.name 指向同一对象），
+  // 这里按注册记录引用去重，避免规则被重复执行导致报告与计数翻倍。
+  // 按记录（而非 rule）去重很重要：当同一个 rule 对象被两个配置键复用时，
+  // 它们是不同的注册记录（不同 severity/options），冲突检查已在注册阶段阻止，
+  // 此处不会遇到这种情况，但按记录去重更能与注册表契约保持一致。
+  const seenRecords = new Set<RegisteredRules[string]>();
   const internalRules = registeredRuleEntries
     .filter((item) => {
       const value = item[1];
@@ -60,11 +63,11 @@ export function lintMarkdown(markdown: string, rules: LintMdRulesConfig = {}, is
       if (value.severity === RULE_SEVERITY.OFF) {
         return false;
       }
-      // 同一 rule 只保留一次（配置键与 meta.name 别名指向同一记录）
-      if (seenRules.has(value.rule)) {
+      // 同一注册记录只保留一次（配置键与 meta.name 别名指向同一对象）
+      if (seenRecords.has(value)) {
         return false;
       }
-      seenRules.add(value.rule);
+      seenRecords.add(value);
       return true;
     })
     .map((options) => {

--- a/src/utils/override-default-rules.ts
+++ b/src/utils/override-default-rules.ts
@@ -55,7 +55,36 @@ export const overrideDefaultRules = (defaultRules: Record<string, LintMdRule>, r
           throw new Error(`[lint-md] 第三方规则 ${ruleName} 的配置长度必须为 3`);
         }
       }
+      else {
+        // 未知规则且配置不是数组（如拼写错误的规则名配了一个数字），不再静默忽略。
+        throw new TypeError(`[lint-md] 未知规则 ${ruleName} 的配置格式非法，第三方规则必须使用 [rule, severity, options] 形式`);
+      }
     }
+  }
+
+  // 收敛规则身份：第三方规则按用户配置键存入注册表，但报告阶段是用
+  // rule.meta.name 回查注册表的。当配置键与 meta.name 不一致时，回查会失败
+  // 并抛出 TypeError。这里为每个注册记录按其 meta.name 建立别名，使报告名称
+  // 仍能命中同一记录，从而修复崩溃且无需推翻既有注册结构。
+  const internalNames = new Set(Object.values(defaultRules).map(rule => rule.meta.name));
+
+  for (const [configKey, record] of Object.entries(registeredRules)) {
+    const nameKey = record.rule.meta.name;
+
+    // 配置键即 meta.name，无需建别名。
+    if (configKey === nameKey) {
+      continue;
+    }
+
+    // 若 meta.name 已被另一不同的规则占用（非内置规则），则明确报错。
+    if (!internalNames.has(nameKey)) {
+      const existing = registeredRules[nameKey];
+      if (existing && existing.rule !== record.rule) {
+        throw new TypeError(`[lint-md] 规则别名冲突：${nameKey} 已被另一规则占用`);
+      }
+    }
+
+    registeredRules[nameKey] = record;
   }
 
   return registeredRules;

--- a/src/utils/override-default-rules.ts
+++ b/src/utils/override-default-rules.ts
@@ -8,7 +8,9 @@ import { RULE_SEVERITY } from '../types';
  */
 export const overrideDefaultRules = (defaultRules: Record<string, LintMdRule>, ruleConfig: LintMdRulesConfig) => {
   // 默认所有的内部 rules 都会被初始化，等级为 Error，参数为空
-  const registeredRules: RegisteredRules = {};
+  // 使用无原型对象，避免 __proto__/constructor/toString 等键从原型链误读，
+  // 防止原型污染（见 issue #177 后续反馈）。
+  const registeredRules = Object.create(null) as RegisteredRules;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   for (const [_, ruleValue] of Object.entries(defaultRules)) {
@@ -22,7 +24,9 @@ export const overrideDefaultRules = (defaultRules: Record<string, LintMdRule>, r
   // 将用户传入的 rules 合并到内部 rules 中
   for (const [ruleName, ruleConfigValue] of Object.entries(ruleConfig)) {
     // 如果配置的 rule 为内部 rule，覆盖之（只覆盖配置过的）
-    const targetRule = registeredRules[ruleName];
+    const targetRule = Object.prototype.hasOwnProperty.call(registeredRules, ruleName)
+      ? registeredRules[ruleName]
+      : undefined;
 
     // 匹配到内部规则
     if (targetRule) {
@@ -79,9 +83,7 @@ export const overrideDefaultRules = (defaultRules: Record<string, LintMdRule>, r
     //  1. 阻止第三方规则通过 meta.name 静默覆盖内置规则；
     //  2. 阻止不同配置键占用同一 meta.name；
     //  3. 阻止同一 rule 对象被多个配置键重复注册（options/severity 错配）。
-    const existing = Object.prototype.hasOwnProperty.call(registeredRules, nameKey)
-      ? registeredRules[nameKey]
-      : undefined;
+    const existing = registeredRules[nameKey];
 
     if (existing && existing !== record) {
       throw new TypeError(`[lint-md] 规则别名冲突：${nameKey} 已被另一规则占用`);

--- a/src/utils/override-default-rules.ts
+++ b/src/utils/override-default-rules.ts
@@ -66,8 +66,6 @@ export const overrideDefaultRules = (defaultRules: Record<string, LintMdRule>, r
   // rule.meta.name 回查注册表的。当配置键与 meta.name 不一致时，回查会失败
   // 并抛出 TypeError。这里为每个注册记录按其 meta.name 建立别名，使报告名称
   // 仍能命中同一记录，从而修复崩溃且无需推翻既有注册结构。
-  const internalNames = new Set(Object.values(defaultRules).map(rule => rule.meta.name));
-
   for (const [configKey, record] of Object.entries(registeredRules)) {
     const nameKey = record.rule.meta.name;
 
@@ -76,12 +74,17 @@ export const overrideDefaultRules = (defaultRules: Record<string, LintMdRule>, r
       continue;
     }
 
-    // 若 meta.name 已被另一不同的规则占用（非内置规则），则明确报错。
-    if (!internalNames.has(nameKey)) {
-      const existing = registeredRules[nameKey];
-      if (existing && existing.rule !== record.rule) {
-        throw new TypeError(`[lint-md] 规则别名冲突：${nameKey} 已被另一规则占用`);
-      }
+    // 只要 nameKey 已被另一个（不同的）注册记录占用，就报冲突——
+    // 不区分内置/第三方，也不比较 rule 对象身份：
+    //  1. 阻止第三方规则通过 meta.name 静默覆盖内置规则；
+    //  2. 阻止不同配置键占用同一 meta.name；
+    //  3. 阻止同一 rule 对象被多个配置键重复注册（options/severity 错配）。
+    const existing = Object.prototype.hasOwnProperty.call(registeredRules, nameKey)
+      ? registeredRules[nameKey]
+      : undefined;
+
+    if (existing && existing !== record) {
+      throw new TypeError(`[lint-md] 规则别名冲突：${nameKey} 已被另一规则占用`);
     }
 
     registeredRules[nameKey] = record;


### PR DESCRIPTION
## 关联 Issue
Closes #177

## 背景
第三方规则按**用户配置键**存入注册表，但报告阶段用 `rule.meta.name` 回查注册表（`lint-markdown.ts:72`）。当配置键与 `meta.name` 不一致时，回查得到 `undefined` 并抛出 `TypeError`。此外，未知规则的数值配置被 `override-default-rules.ts` 的 else 分支静默忽略，拼写错误无法发现；普通对象注册表还存在原型属性误判与原型污染风险。

## 改动
- `src/utils/override-default-rules.ts`：注册后按 `rule.meta.name` 建立别名指向同一记录（修复崩溃，无需推翻既有注册结构）；未知规则的非数组配置改为抛 `TypeError`；同 `meta.name` 被另一个注册记录占用时统一报别名冲突（不区分内置/第三方，也不比较 rule 对象身份，从而阻止第三方规则静默覆盖内置规则、以及同一 rule 被多配置键复用导致的 options/severity 错配）；注册表改用 `Object.create(null)` 无原型对象并通过 own-property 判断查询，杜绝 `__proto__`/`constructor` 等键的原型污染。
- `src/core/lint-markdown.ts`：生成 `internalRules` 时按**注册记录引用**去重（而非 rule 引用），避免别名导致规则重复执行、报告与计数翻倍，与注册表契约保持一致。
- 测试：新增 `__tests__/unit/rule-alias.spec.ts`（别名、同名、别名冲突、未知规则、非法配置长度、关闭规则、error/warn 统计、第三方覆盖内置名、同对象复用）；并修正 `override-default-rules.spec.ts` 中依赖旧静默忽略行为的用例，新增原型污染 / 原型键第三方规则相关用例。

## 验证
`npm run typecheck`、`npm run lint` 通过，全量测试 198 passed。


