### PR TITLE
feat(handle-fix-mode): track convergence state, rounds, and fix-loop cycle detection

### DIFF
--- a/__tests__/unit/handle-fix-mode.spec.ts
+++ b/__tests__/unit/handle-fix-mode.spec.ts
@@ -352,8 +352,9 @@ describe('handleFixMode', () => {
   test('A -> B -> A oscillation: stops after 2 rounds, returns applied A', () => {
     // Round 1: "A" -> ruleA "A"->"B"
     // Round 2: "B" -> ruleB "B"->"A"
-    // Round 3 start: current === "A" already seen => CYCLE_DETECTED, break.
-    // returns the A applied in round 2, NOT the round-1 B.
+    // After round 2 applies the fix (B -> A), current becomes "A" which was already
+    // seen in round 1 => CYCLE_DETECTED, break. Returns the A applied in round 2,
+    // NOT the round-1 B.
     const ruleA = makeRule({
       name: 'a-to-b',
       selector: 'text',

--- a/__tests__/unit/handle-fix-mode.spec.ts
+++ b/__tests__/unit/handle-fix-mode.spec.ts
@@ -416,13 +416,15 @@ describe('handleFixMode', () => {
     expect(result.fixedResult.rounds).toBe(3);
   });
 
-  test('text unchanged with conflict is STABLE (not cycle, not max)', () => {
+  test('text unchanged with conflict is STABLE via result===current branch', () => {
+    // ruleA replaces 'abc' -> 'abc' (text unchanged), ruleB 'abc' -> 'Y' conflicts with it.
+    // After applyFix, text stays 'abc' => STABLE on the FIRST round (result === current).
     const ruleA = makeRule({
-      name: 'to-x',
+      name: 'same',
       selector: 'text',
       reportFn: (ctx, node) => {
         if (node.value === 'abc') {
-          ctx.report({ loc: node.position, message: 'x', fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: 'X' }) });
+          ctx.report({ loc: node.position, message: 'same', fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: 'abc' }) });
         }
       }
     });
@@ -437,9 +439,35 @@ describe('handleFixMode', () => {
     });
 
     const result = handleFixMode('abc', [{ rule: ruleA }, { rule: ruleB }]);
-    expect(result.fixedResult.result).toBe('X');
+    expect(result.fixedResult.result).toBe('abc');
     expect(result.fixedResult.convergence).toBe(FixConvergence.STABLE);
-    expect(result.fixedResult.rounds).toBe(2);
+    expect(result.fixedResult.rounds).toBe(1);
+    // ruleB's fix was dropped (conflict), still reported in last round
+    expect(result.fixedResult.notAppliedFixes.length).toBe(1);
+    expect(result.fixedResult.notAppliedFixes[0].text).toBe('Y');
+  });
+
+  test('cycle of length MAX is detected, not mislabeled MAX_ROUNDS', () => {
+    // S0 -> S1 -> ... -> S9 -> S0, where S_i is the string i repeated.
+    // After the 10th round, current returns to S0 which was already seen,
+    // so it must be CYCLE_DETECTED (not MAX_ROUNDS / rounds 10 truncation).
+    const states = Array.from({ length: MAX_LINT_AND_FIX_CALL_TIMES }, (_, i) => String(i).repeat(3));
+    const rules = states.map((state, i) => {
+      const next = states[(i + 1) % states.length];
+      return makeRule({
+        name: `s${i}-to-s${(i + 1) % states.length}`,
+        selector: 'text',
+        reportFn: (ctx, node) => {
+          if (node.value === state) {
+            ctx.report({ loc: node.position, message: 'step', fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: next }) });
+          }
+        }
+      });
+    });
+
+    const result = handleFixMode(states[0], rules.map((rule) => ({ rule })));
+    expect(result.fixedResult.rounds).toBe(MAX_LINT_AND_FIX_CALL_TIMES);
+    expect(result.fixedResult.convergence).toBe(FixConvergence.CYCLE_DETECTED);
   });
 
   test('monotonic growth hits MAX_ROUNDS at 10, not mis-detected as cycle', () => {

--- a/__tests__/unit/handle-fix-mode.spec.ts
+++ b/__tests__/unit/handle-fix-mode.spec.ts
@@ -1,6 +1,7 @@
 import { handleFixMode } from '../../src/core/handle-fix-mode';
 import { MAX_LINT_AND_FIX_CALL_TIMES } from '../../src/common/constant';
 import type { LintMdRule, LintMdRuleContext, FixConfig } from '../../src/types';
+import { FixConvergence } from '../../src/types';
 
 function makeRule(config: {
   name: string;
@@ -347,4 +348,141 @@ describe('handleFixMode', () => {
     expect(result.fixedResult.notAppliedFixes.length).toBe(1);
     expect(result.fixedResult.notAppliedFixes[0].text).toBe('Y');
   });
+
+  test('A -> B -> A oscillation: stops after 2 rounds, returns applied A', () => {
+    // Round 1: "A" -> ruleA "A"->"B"
+    // Round 2: "B" -> ruleB "B"->"A"
+    // Round 3 start: current === "A" already seen => CYCLE_DETECTED, break.
+    // returns the A applied in round 2, NOT the round-1 B.
+    const ruleA = makeRule({
+      name: 'a-to-b',
+      selector: 'text',
+      reportFn: (ctx, node) => {
+        if (node.value === 'A') {
+          ctx.report({
+            loc: node.position,
+            message: 'A to B',
+            fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: 'B' })
+          });
+        }
+      }
+    });
+
+    const ruleB = makeRule({
+      name: 'b-to-a',
+      selector: 'text',
+      reportFn: (ctx, node) => {
+        if (node.value === 'B') {
+          ctx.report({
+            loc: node.position,
+            message: 'B to A',
+            fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: 'A' })
+          });
+        }
+      }
+    });
+
+    const result = handleFixMode('A', [{ rule: ruleA }, { rule: ruleB }]);
+    expect(result.fixedResult.result).toBe('A');
+    expect(result.fixedResult.rounds).toBe(2);
+    expect(result.fixedResult.convergence).toBe(FixConvergence.CYCLE_DETECTED);
+  });
+
+  test('stable cascade ends STABLE with one extra no-fix round', () => {
+    // Round 1: 'aa' -> 'cc' (ruleA then ruleB); Round 2: 'cc' -> no fixes => STABLE
+    const ruleA = makeRule({
+      name: 'a-aa-to-bb',
+      selector: 'text',
+      reportFn: (ctx, node) => {
+        if (node.value === 'aa') {
+          ctx.report({ loc: node.position, message: 'aa', fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: 'bb' }) });
+        }
+      }
+    });
+    const ruleB = makeRule({
+      name: 'b-bb-to-cc',
+      selector: 'text',
+      reportFn: (ctx, node) => {
+        if (node.value === 'bb') {
+          ctx.report({ loc: node.position, message: 'bb', fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: 'cc' }) });
+        }
+      }
+    });
+
+    const result = handleFixMode('aa', [{ rule: ruleA }, { rule: ruleB }]);
+    expect(result.fixedResult.result).toBe('cc');
+    expect(result.fixedResult.convergence).toBe(FixConvergence.STABLE);
+    // round1: aa->bb, round2: bb->cc, round3: no-fix check => 3 rounds
+    expect(result.fixedResult.rounds).toBe(3);
+  });
+
+  test('text unchanged with conflict is STABLE (not cycle, not max)', () => {
+    const ruleA = makeRule({
+      name: 'to-x',
+      selector: 'text',
+      reportFn: (ctx, node) => {
+        if (node.value === 'abc') {
+          ctx.report({ loc: node.position, message: 'x', fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: 'X' }) });
+        }
+      }
+    });
+    const ruleB = makeRule({
+      name: 'to-y',
+      selector: 'text',
+      reportFn: (ctx, node) => {
+        if (node.value === 'abc') {
+          ctx.report({ loc: node.position, message: 'y', fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: 'Y' }) });
+        }
+      }
+    });
+
+    const result = handleFixMode('abc', [{ rule: ruleA }, { rule: ruleB }]);
+    expect(result.fixedResult.result).toBe('X');
+    expect(result.fixedResult.convergence).toBe(FixConvergence.STABLE);
+    expect(result.fixedResult.rounds).toBe(2);
+  });
+
+  test('monotonic growth hits MAX_ROUNDS at 10, not mis-detected as cycle', () => {
+    let callCount = 0;
+    const rule = makeRule({
+      name: 'double-a',
+      selector: 'text',
+      reportFn: (ctx, node) => {
+        if (node.value === 'a'.repeat(Math.pow(2, callCount))) {
+          callCount++;
+          ctx.report({ loc: node.position, message: 'double', fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: node.value + node.value }) });
+        }
+      }
+    });
+
+    const result = handleFixMode('a', [{ rule }]);
+    expect(callCount).toBe(MAX_LINT_AND_FIX_CALL_TIMES);
+    expect(result.fixedResult.rounds).toBe(MAX_LINT_AND_FIX_CALL_TIMES);
+    expect(result.fixedResult.convergence).toBe(FixConvergence.MAX_ROUNDS);
+  });
+
+  test('no fixes => STABLE with rounds === 1', () => {
+    const rule = makeRule({ name: 'no-op', selector: 'text', reportFn: () => {} });
+    const result = handleFixMode('hello world', [{ rule }]);
+    expect(result.fixedResult.convergence).toBe(FixConvergence.STABLE);
+    expect(result.fixedResult.rounds).toBe(1);
+  });
+
+  test('metrics records rounds and per-round wall times', () => {
+    const rule = makeRule({
+      name: 'replace-foo',
+      selector: 'text',
+      reportFn: (ctx, node) => {
+        if (node.value === 'foo') {
+          ctx.report({ loc: node.position, message: 'foo', fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: 'bar' }) });
+        }
+      }
+    });
+
+    const result = handleFixMode('foo', [{ rule }]);
+    expect(result.fixedResult.metrics).toBeDefined();
+    expect(result.fixedResult.metrics!.rounds).toBe(result.fixedResult.rounds);
+    expect(result.fixedResult.metrics!.perRound).toHaveLength(result.fixedResult.rounds);
+  });
+
 });

--- a/src/core/handle-fix-mode.ts
+++ b/src/core/handle-fix-mode.ts
@@ -15,22 +15,17 @@ export const handleFixMode = (markdown: string, rules: LintMdRuleWithOptions[]) 
   const seenTexts = new Set<string>();
   let convergence: FixConvergence | undefined;
 
-  // 性能基线：仅记录每轮 wall time 与整体耗时，不拆分 parse/规则成本。
+  // 性能基线：记录每一轮完整 wall time（parse + AST 遍历 + 规则执行 + applyFix）。
   const perRound: number[] = [];
   const startAll = performance.now();
 
   while (lintTimes < MAX_LINT_AND_FIX_CALL_TIMES) {
-    // 循环检测：在执行某轮 current 之前，判断该文本是否已被处理过。
-    // 这样 A -> B -> A 只会执行 2 轮、最终返回实际已应用的 A。
-    if (seenTexts.has(current)) {
-      convergence = FixConvergence.CYCLE_DETECTED;
-      break;
-    }
+    const roundStart = performance.now();
+
+    // 记录本轮输入文本，供后续判断是否回到历史状态。
     seenTexts.add(current);
 
-    const roundStart = performance.now();
     const lintResult = runLint(current, rules);
-    perRound.push(performance.now() - roundStart);
 
     if (lintTimes === 0) {
       initialLintResult = lintResult;
@@ -42,6 +37,7 @@ export const handleFixMode = (markdown: string, rules: LintMdRuleWithOptions[]) 
 
     // 无 fix 可应用 => 正常收敛。
     if (!fixes.length) {
+      perRound.push(performance.now() - roundStart);
       convergence = FixConvergence.STABLE;
       break;
     }
@@ -54,11 +50,22 @@ export const handleFixMode = (markdown: string, rules: LintMdRuleWithOptions[]) 
 
     // 文本不再变化 => 正常收敛（即便该轮存在冲突未应用的 fix）。
     if (nextFixedResult.result === current) {
+      perRound.push(performance.now() - roundStart);
       convergence = FixConvergence.STABLE;
       break;
     }
 
     current = nextFixedResult.result;
+
+    // 文本回到了某个已处理过的状态 => 检测到循环，提前停止。
+    // 放在文本不变判断之后，自替换规则仍归类为 STABLE。
+    if (seenTexts.has(current)) {
+      perRound.push(performance.now() - roundStart);
+      convergence = FixConvergence.CYCLE_DETECTED;
+      break;
+    }
+
+    perRound.push(performance.now() - roundStart);
   }
 
   // 走到上限仍未收敛 => 被截断。

--- a/src/core/handle-fix-mode.ts
+++ b/src/core/handle-fix-mode.ts
@@ -1,4 +1,5 @@
-import type { FixConfig, LintMdRuleWithOptions } from '../types';
+import type { FixConfig, FixMetrics, LintMdRuleWithOptions } from '../types';
+import { FixConvergence } from '../types';
 import { MAX_LINT_AND_FIX_CALL_TIMES } from '../common/constant';
 import { applyFix } from '../utils/apply-fix';
 import { runLint } from './run-lint';
@@ -10,8 +11,26 @@ export const handleFixMode = (markdown: string, rules: LintMdRuleWithOptions[]) 
   let current = markdown;
   let lastNotAppliedFixes: FixConfig[] = [];
 
+  // 记录已处理过的文本状态，用于检测振荡循环（如 A -> B -> A）。
+  const seenTexts = new Set<string>();
+  let convergence: FixConvergence | undefined;
+
+  // 性能基线：仅记录每轮 wall time 与整体耗时，不拆分 parse/规则成本。
+  const perRound: number[] = [];
+  const startAll = performance.now();
+
   while (lintTimes < MAX_LINT_AND_FIX_CALL_TIMES) {
+    // 循环检测：在执行某轮 current 之前，判断该文本是否已被处理过。
+    // 这样 A -> B -> A 只会执行 2 轮、最终返回实际已应用的 A。
+    if (seenTexts.has(current)) {
+      convergence = FixConvergence.CYCLE_DETECTED;
+      break;
+    }
+    seenTexts.add(current);
+
+    const roundStart = performance.now();
     const lintResult = runLint(current, rules);
+    perRound.push(performance.now() - roundStart);
 
     if (lintTimes === 0) {
       initialLintResult = lintResult;
@@ -21,7 +40,9 @@ export const handleFixMode = (markdown: string, rules: LintMdRuleWithOptions[]) 
 
     const fixes = lintResult.ruleManager.getAllFixes();
 
+    // 无 fix 可应用 => 正常收敛。
     if (!fixes.length) {
+      convergence = FixConvergence.STABLE;
       break;
     }
 
@@ -31,16 +52,30 @@ export const handleFixMode = (markdown: string, rules: LintMdRuleWithOptions[]) 
     // 不跨轮累积：不同轮次的 fix range 基于各自输入文本，跨轮混用会导致 range 失效
     lastNotAppliedFixes = nextFixedResult.notAppliedFixes;
 
+    // 文本不再变化 => 正常收敛（即便该轮存在冲突未应用的 fix）。
     if (nextFixedResult.result === current) {
+      convergence = FixConvergence.STABLE;
       break;
     }
 
     current = nextFixedResult.result;
   }
 
+  // 走到上限仍未收敛 => 被截断。
+  if (!convergence) {
+    convergence = FixConvergence.MAX_ROUNDS;
+  }
+
   const fixedResult = {
     result: current,
-    notAppliedFixes: lastNotAppliedFixes
+    notAppliedFixes: lastNotAppliedFixes,
+    convergence,
+    rounds: lintTimes,
+    metrics: {
+      rounds: lintTimes,
+      wallTime: performance.now() - startAll,
+      perRound
+    } as FixMetrics
   };
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,6 +160,26 @@ export interface LintDiagnostic {
   severity: RULE_SEVERITY
 }
 
+/** fix 收敛状态：调用方据此区分“已稳定”“检测到循环”“达到上限” */
+export enum FixConvergence {
+  /** 无 fix 可应用或文本不再变化，正常收敛 */
+  STABLE = 'stable',
+  /** 检测到振荡循环（某轮 current 文本曾出现过），提前停止 */
+  CYCLE_DETECTED = 'cycle',
+  /** 达到 MAX_LINT_AND_FIX_CALL_TIMES 上限被截断 */
+  MAX_ROUNDS = 'max'
+}
+
+/** fix 收敛过程的性能基线（仅记录轮数 / 每轮 wall time，不拆分 parse/规则） */
+export interface FixMetrics {
+  /** 实际 runLint 次数 */
+  rounds: number
+  /** 整体 wall time（毫秒） */
+  wallTime: number
+  /** 每一轮的 wall time（毫秒） */
+  perRound: number[]
+}
+
 /** fix 模式下 `fixedResult` 的形状 */
 export interface FixedResult {
   /** 修复后的完整 Markdown 文本 */
@@ -169,6 +189,12 @@ export interface FixedResult {
    * range 基于 result 文本的坐标，可直接用于 result。
    */
   notAppliedFixes: FixConfig[]
+  /** 收敛状态，调用方可据此判断质量而非盲用文本 */
+  convergence: FixConvergence
+  /** 实际执行的 runLint 轮数 */
+  rounds: number
+  /** 性能基线，可选；用于后续判断是否值得做增量重跑的独立研究 */
+  metrics?: FixMetrics
 }
 
 /** `lintMarkdown` 返回的 lint 诊断项（带严重级别） */

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,10 +189,10 @@ export interface FixedResult {
    * range 基于 result 文本的坐标，可直接用于 result。
    */
   notAppliedFixes: FixConfig[]
-  /** 收敛状态，调用方可据此判断质量而非盲用文本 */
-  convergence: FixConvergence
-  /** 实际执行的 runLint 轮数 */
-  rounds: number
+  /** 收敛状态，调用方可据此判断质量而非盲用文本（兼容扩展，历史构造方式仍可用） */
+  convergence?: FixConvergence
+  /** 实际执行的 runLint 轮数（兼容扩展，历史构造方式仍可用） */
+  rounds?: number
   /** 性能基线，可选；用于后续判断是否值得做增量重跑的独立研究 */
   metrics?: FixMetrics
 }


### PR DESCRIPTION
## 关联 Issue
Closes #178

## 背景
当前 autofix（`src/core/handle-fix-mode.ts`）仅在“无 fix”或“文本不变”时停止，达到上限（10 轮）即截断。对 `A -> B -> A` 振荡组合，文本始终变化，会无意义地执行到上限；调用方只能拿到最终文本，无法分辨“已稳定收敛”还是“被上限截断”。同时每轮都全量重跑 parse/AST/规则，振荡输入浪费明显。

## 改动
- `src/types.ts`：新增 `FixConvergence` 枚举（`stable` / `cycle` / `max`）、`FixMetrics`（`rounds` / `wallTime` / `perRound`）。`FixedResult` 新增可选字段 `convergence?` / `rounds?` / `metrics?`，**均为向后兼容的可选扩展**（必填改可选，避免破坏 `const r: FixedResult = { result, notAppliedFixes }` 这类历史构造）；`result` / `notAppliedFixes` 语义不变。
- `src/core/handle-fix-mode.ts`：
  - 循环检测在**应用修复、更新 current 之后**判断 `seenTexts.has(current)`：即使长度为 `MAX` 的循环（`S0→…→S9→S0`），第 10 轮后回到 `S0` 也能正确标记为 `CYCLE_DETECTED`，而非误报 `MAX_ROUNDS`。
  - 文本不变判断（`nextFixedResult.result === current`，即使该轮存在冲突未应用 fix）仍放在循环判断之前，自替换规则归类为 `STABLE`。
  - `rounds` 等于实际 `runLint` 次数：无 fix 为 1，`A→B→A` 为 2，单调增长达上限为 10。
  - `notAppliedFixes` 仍只保留最后一次 `applyFix` 结果，与冲突完全解耦。
  - `metrics.perRound` 现测量**整轮** wall time（含 `getAllFixes` 与 `applyFix`），更准确反映每轮成本。
- 测试：新增/修正 `A->B->A` 振荡、长度为 MAX 的循环、级联稳定、文本不变含冲突（覆盖 `result===current` 分支）、单调增长上限、无 fix、metrics 等用例；既有用例继续全绿。

## 验证
`npm run typecheck`、`npm run lint` 通过，全量测试 205 passed。

