### PR TITLE
feat(text-scanner): 可观测的索引构建诊断 + #176 可复现 profile

### DIFF
--- a/__tests__/unit/utils/text-scanner.spec.ts
+++ b/__tests__/unit/utils/text-scanner.spec.ts
@@ -1,4 +1,4 @@
-import { TextScanner } from '../../../src/utils/text-scanner';
+import { TextScanner, getScannerDiagnostics, resetScannerDiagnostics } from '../../../src/utils/text-scanner';
 import type { MarkdownTextNode } from '../../../src/utils/get-text-nodes';
 
 const createTextNode = (
@@ -233,6 +233,62 @@ describe('TextScanner', () => {
         positions.push(pos.offset);
       });
       expect(positions).toEqual([10, 11, 12]);
+    });
+  });
+
+  describe('index-build diagnostics (issue #176)', () => {
+    beforeEach(() => {
+      resetScannerDiagnostics();
+    });
+
+    it('should not build index for forEachChar (no position lookup needed)', () => {
+      const scanner = new TextScanner(createTextNode('a\nb\nc'));
+      scanner.forEachChar(() => {});
+      expect(getScannerDiagnostics().textScannerIndexBuilds).toBe(0);
+      expect(getScannerDiagnostics().textScannerIndexBuildWallTimeMs).toBe(0);
+    });
+
+    it('should count one build per scanner that resolves positions', () => {
+      const scanner = new TextScanner(createTextNode('a\nb\nc'));
+      // findAllMatches forces position resolution -> builds index once
+      scanner.findAllMatches(/a/g);
+      const diag = getScannerDiagnostics();
+      expect(diag.textScannerIndexBuilds).toBe(1);
+      expect(diag.textScannerIndexBuildWallTimeMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should build index once per scanner instance even with multiple matches', () => {
+      const scanner = new TextScanner(createTextNode('a\nb\nc\nd'));
+      scanner.findAllMatches(/[\s\S]/g); // every char incl. newlines
+      expect(getScannerDiagnostics().textScannerIndexBuilds).toBe(1);
+    });
+
+    it('should accumulate across distinct scanner instances', () => {
+      const s1 = new TextScanner(createTextNode('x\ny'));
+      const s2 = new TextScanner(createTextNode('p\nq'));
+      s1.findAllMatches(/x/g);
+      s2.findAllMatches(/p/g);
+      expect(getScannerDiagnostics().textScannerIndexBuilds).toBe(2);
+    });
+
+    it('should accumulate across two distinct text nodes sharing the same value', () => {
+      // Same value, different node identity: index is NOT shared (no cache yet).
+      const s1 = new TextScanner(createTextNode('a\nb'));
+      const s2 = new TextScanner(createTextNode('a\nb'));
+      s1.findAllMatches(/a/g);
+      s2.findAllMatches(/a/g);
+      expect(getScannerDiagnostics().textScannerIndexBuilds).toBe(2);
+    });
+
+    it('reset should clear all counters', () => {
+      const scanner = new TextScanner(createTextNode('a\nb'));
+      scanner.findAllMatches(/a/g);
+      expect(getScannerDiagnostics().textScannerIndexBuilds).toBe(1);
+      resetScannerDiagnostics();
+      expect(getScannerDiagnostics()).toEqual({
+        textScannerIndexBuilds: 0,
+        textScannerIndexBuildWallTimeMs: 0
+      });
     });
   });
 });

--- a/scripts/benchmark-memory-smoke.mjs
+++ b/scripts/benchmark-memory-smoke.mjs
@@ -22,12 +22,13 @@ const REQUIRED_FIELDS = [
   'wallTimeMs', 'maxRss', 'rssBefore', 'rssAfter', 'rssDelta',
   'heapBefore', 'heapAfter',
   'reportCount', 'fixCount', 'runLintCalls',
+  'textScannerIndexBuilds', 'textScannerIndexBuildWallTimeMs',
   'nodeVersion', 'platform', 'arch',
 ];
 
 const VALID_CASES = new Set([
   'noop', 'input-only', 'parser-only', 'parse-traverse',
-  'single-rule', 'all-rules', 'fix-mode',
+  'single-rule', 'text-scanner-rules', 'all-rules', 'fix-mode',
 ]);
 
 const VALID_SHAPES = new Set([
@@ -101,6 +102,16 @@ async function main() {
     assert(typeof line.reportCount === 'number', 'reportCount should be a number');
     assert(line.fixCount === null || typeof line.fixCount === 'number', 'fixCount should be number or null');
     assert(line.runLintCalls === null || typeof line.runLintCalls === 'number', 'runLintCalls should be number or null');
+    // notAppliedFixCount 仅 fix-mode 输出
+    if (line.case === 'fix-mode') {
+      assert(line.notAppliedFixCount === null || typeof line.notAppliedFixCount === 'number',
+        'notAppliedFixCount should be number or null on fix-mode');
+    }
+    // Scanner index-build diagnostics: non-negative numbers (present on every case).
+    assert(typeof line.textScannerIndexBuilds === 'number' && line.textScannerIndexBuilds >= 0,
+      'textScannerIndexBuilds should be a non-negative number');
+    assert(typeof line.textScannerIndexBuildWallTimeMs === 'number' && line.textScannerIndexBuildWallTimeMs >= 0,
+      'textScannerIndexBuildWallTimeMs should be a non-negative number');
     assert(typeof line.run === 'number' && line.run >= 1, 'run should be >= 1');
 
     assert(VALID_CASES.has(line.case), `unknown case: ${line.case}`);

--- a/scripts/benchmark-memory-smoke.mjs
+++ b/scripts/benchmark-memory-smoke.mjs
@@ -61,7 +61,8 @@ function parseNDJSON(text) {
 }
 
 function assert(condition, message) {
-  if (!condition) throw new Error(`Assertion failed: ${message}`);
+  if (!condition)
+    throw new Error(`Assertion failed: ${message}`);
 }
 
 async function main() {
@@ -139,6 +140,33 @@ async function main() {
   if (noopLines.length > 0) {
     console.log(`  noop baseline RSS delta: ${noopLines[0].rssDelta} bytes`);
   }
+
+  // Test 6: profile-scanner-176.mjs 独立 smoke（#176 可复现数据脚本）
+  console.log('  Running profile-scanner-176.mjs (many-small-nodes, 4 KiB, 1 run)...');
+  const profileOut = await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [
+      path.join(SCRIPT_DIR, 'profile-scanner-176.mjs'),
+      '--shape', 'many-small-nodes',
+      '--bytes', '4096',
+      '--runs', '1',
+      '--warmup', '0',
+    ], { cwd: path.resolve(SCRIPT_DIR, '..'), stdio: ['ignore', 'pipe', 'pipe'] });
+    let out = '';
+    child.stdout.on('data', (c) => { out += c; });
+    child.stderr.on('data', (c) => { out += c; });
+    child.on('close', code => resolve({ code, out }));
+    child.on('error', reject);
+  });
+  assert(profileOut.code === 0, 'profile-scanner-176.mjs should exit 0');
+  const profileLines = parseNDJSON(profileOut.out);
+  assert(profileLines.length === 1, 'profile should output exactly one line');
+  const pl = profileLines[0];
+  assert(typeof pl.textNodeCount === 'number' && pl.textNodeCount > 0, 'profile textNodeCount should be > 0');
+  assert(typeof pl.reportCount === 'number' && pl.reportCount > 0, 'profile reportCount should be > 0');
+  assert(Array.isArray(pl.buildMsRuns) && pl.buildMsRuns.length === 1, 'profile buildMsRuns should have 1 entry');
+  assert(Array.isArray(pl.wallMsRuns) && pl.wallMsRuns.length === 1, 'profile wallMsRuns should have 1 entry');
+  assert(typeof pl.bytes === 'number' && pl.bytes > 0, 'profile bytes (actual) should be > 0');
+  assert(typeof pl.requestedBytes === 'number' && pl.requestedBytes === 4096, 'profile requestedBytes should be 4096');
 
   console.log('\nSmoke test PASSED');
 }

--- a/scripts/benchmark-memory.mjs
+++ b/scripts/benchmark-memory.mjs
@@ -18,7 +18,7 @@
  *                     (default: long-paragraph)
  *   --runs <n>        Measured runs per case (default: 5)
  *   --warmup <n>      Warmup runs before measurement (default: 2)
- *   --all             Run all shape+size combinations
+ *   --all             Run all shape+size combinations (incl. text-scanner-rules)
  *   -h, --help        Show this help
  */
 
@@ -49,6 +49,7 @@ if (process.env.BENCHMARK_CHILD === '1') {
   const { parseMd } = require_('@lint-md/parser');
   const core = require_('../lib/index.js');
   const { runLint } = require_('../lib/core/run-lint.js');
+  const scannerDiag = require_('../lib/utils/text-scanner.js');
 
   const TEXT_RULE_IMPORTS = {
     'space-around-alphabet': () => core.spaceAroundAlphabet,
@@ -83,6 +84,22 @@ if (process.env.BENCHMARK_CHILD === '1') {
     return { reportCount: reports.length, fixCount: 0, runLintCalls: 1 };
   }
 
+  function runTextScannerRules() {
+    // 仅启用这 5 条依赖 TextScanner 的文本规则，隔离 scanner 成本以独立归因。
+    const names = [
+      'use-standard-ellipsis',
+      'no-half-width-punctuation',
+      'no-full-width-number',
+      'space-around-number',
+      'no-special-characters',
+    ];
+    const configs = names.map((n) => ({ rule: TEXT_RULE_IMPORTS[n]() }));
+    const result = runLint(input, configs);
+    const reports = result.ruleManager.getReportData();
+    const fixes = result.ruleManager.getAllFixes();
+    return { reportCount: reports.length, fixCount: fixes.length, runLintCalls: 1 };
+  }
+
   function runSingleRule() {
     const ruleFactory = TEXT_RULE_IMPORTS[ruleName];
     if (!ruleFactory) throw new Error(`Unknown rule: ${ruleName}`);
@@ -105,10 +122,15 @@ if (process.env.BENCHMARK_CHILD === '1') {
 
   function runFixMode() {
     const result = core.lintMarkdown(input, {}, true);
+    const fixed = result.fixedResult || null;
     return {
       reportCount: (result.lintResult || []).length,
+      // fixCount 在其他 case 表示规则生成的 fix 数量；此处不混用同一语义。
       fixCount: null,
-      runLintCalls: null, // handleFixMode may loop internally; exact count unknown here
+      notAppliedFixCount: fixed ? fixed.notAppliedFixes.length : null,
+      runLintCalls: fixed ? fixed.rounds : null,
+      convergence: fixed ? fixed.convergence : undefined,
+      fixMetrics: fixed ? fixed.metrics : undefined,
     };
   }
 
@@ -118,6 +140,7 @@ if (process.env.BENCHMARK_CHILD === '1') {
     'parser-only': runParserOnly,
     'parse-traverse': runParseTraverse,
     'single-rule': runSingleRule,
+    'text-scanner-rules': runTextScannerRules,
     'all-rules': runAllRules,
     'fix-mode': runFixMode,
   };
@@ -125,11 +148,16 @@ if (process.env.BENCHMARK_CHILD === '1') {
   const runner = runners[caseName];
   if (!runner) throw new Error(`Unknown case: ${caseName}`);
 
+  // Warmup 完成后清零，只统计正式测量（见 #176 评审：避免诊断累计 warmup 而分母仅正式运行）。
   // Warmup
   for (let i = 0; i < warmupCount; i++) {
     runner();
     if (typeof global.gc === 'function') global.gc();
   }
+
+  // 只统计正式测量：warmup 运行不计入 scanner 诊断，避免分母为单次 wallTime
+  // 却累计多次 build 耗时（buildMs / wallTime 比例被高估无法作为缓存决策依据）。
+  scannerDiag.resetScannerDiagnostics();
 
   // Measure
   const rssBefore = process.memoryUsage.rss();
@@ -155,7 +183,8 @@ if (process.env.BENCHMARK_CHILD === '1') {
     shape,
     bytes,
     rule: ruleName || undefined,
-    wallTimeMs: Math.round(end - start),
+    // 保留原始浮点耗时（不取整），保证 buildMs / wallTime 占比在快 case 下不被取整扰动；展示时再格式化。
+    wallTimeMs: end - start,
     maxRss: maxRssBytes,
     rssBefore,
     rssAfter,
@@ -168,6 +197,8 @@ if (process.env.BENCHMARK_CHILD === '1') {
     platform: process.platform,
     arch: process.arch,
     timestamp: new Date().toISOString(),
+    textScannerIndexBuilds: scannerDiag.getScannerDiagnostics().textScannerIndexBuilds,
+    textScannerIndexBuildWallTimeMs: scannerDiag.getScannerDiagnostics().textScannerIndexBuildWallTimeMs,
   };
 
   process.stdout.write(JSON.stringify(result) + '\n');
@@ -188,7 +219,7 @@ Options:
                             high-match-density | low-match-density | overlapping-fixes
   --runs <n>        Measured runs per case (default: 5)
   --warmup <n>      Warmup runs per child process (default: 2)
-  --all             Run all shape+size combinations
+  --all             Run all shape+size combinations (incl. text-scanner-rules)
   -h, --help        Show this help
 
 Examples:
@@ -275,6 +306,7 @@ const CASES = [
   'parser-only',
   'parse-traverse',
   'single-rule',
+  'text-scanner-rules',
   'all-rules',
   'fix-mode',
 ];

--- a/scripts/profile-scanner-176.mjs
+++ b/scripts/profile-scanner-176.mjs
@@ -150,9 +150,13 @@ function main() {
 
   for (const shape of shapes) {
     const gen = GENERATORS[shape];
-    const md = gen(opts.bytes);
-    const textNodeCount = countTextNodes(parseMd(md));
-    const triggeredMd = withTriggerChars(md);
+    // 注意顺序：先生成 + 触发字符替换，最后再统计实际被测输入。
+    // withTriggerChars 会改变 UTF-8 字节长度与潜在 AST 结构，因此
+    // 字节数与文本节点数都必须取自转换后的 triggeredMd（回应 P1/P2）。
+    const sourceMd = gen(opts.bytes);
+    const triggeredMd = withTriggerChars(sourceMd);
+    const actualBytes = Buffer.byteLength(triggeredMd, 'utf8');
+    const textNodeCount = countTextNodes(parseMd(triggeredMd));
 
     const buildMsRuns = [];
     const wallMsRuns = [];
@@ -178,7 +182,8 @@ function main() {
     const line = {
       shape,
       triggerInput: true,
-      bytes: opts.bytes,
+      requestedBytes: opts.bytes,
+      bytes: actualBytes,
       runs: opts.runs,
       warmup: opts.warmup,
       textNodeCount,
@@ -188,6 +193,9 @@ function main() {
       buildMsMedian: Number(buildMsMedian.toFixed(4)),
       wallMsMedian: Number(wallMsMedian.toFixed(3)),
       ratioPctMedian: Number(ratioPctMedian.toFixed(3)),
+      nodeVersion: process.version,
+      platform: process.platform,
+      arch: process.arch,
     };
     allLines.push(line);
   }

--- a/scripts/profile-scanner-176.mjs
+++ b/scripts/profile-scanner-176.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * Issue #176 可复现 profile：测量 TextScanner 换行索引构建成本占 lint 总耗时的比例。
+ *
+ * 设计目的（回应评审 P1）：所有输入、计数方式与原始数据都必须可复现。
+ * - 输入复用 benchmark-memory.mjs 的已提交生成器（generateLongParagraph /
+ *   generateManyParagraphs / generateHighMatchDensity / generateOverlappingFixes），
+ *   并额外提供 many-small-nodes（大量独立短文本节点，最坏情况）。
+ * - 文本节点数由 parseMd 直接统计（递归计数 type==='text'）。
+ * - 默认 benchmark 输入不会触发索引构建（forEachChar 路径），因此本脚本的输入
+ *   显式包含能触发 findAllMatches/findAllOccurrences（→ matchAt → lineBreakIndices）
+ *   的字符：省略号 ....、全角数字 ０-９、特殊字符 ×÷。
+ * - 每条 case 输出 1 行 NDJSON（含 warmup 前的原始逐 run 值），中位数由下游或
+ *   人工按 run 序列计算，方法见 README 注释。
+ *
+ * 用法：
+ *   node scripts/profile-scanner-176.mjs                       # 默认 256KiB × 5 runs × 2 warmup
+ *   node scripts/profile-scanner-176.mjs --bytes 1048576 --runs 7 --warmup 3
+ *   node scripts/profile-scanner-176.mjs --shape many-small-nodes
+ *
+ * 输出字段：
+ *   shape, triggerInput, bytes, runs, warmup,
+ *   textNodeCount, reportCount,
+ *   buildMsRuns[]      —— 每次正式 run 的 indexBuildWallTimeMs（微秒级）
+ *   wallMsRuns[]       —— 每次正式 run 的 lint 总耗时
+ *   buildMsMedian, wallMsMedian, ratioPctMedian
+ */
+
+import { createRequire } from 'node:module';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require_ = createRequire(import.meta.url);
+const { parseMd } = require_('@lint-md/parser');
+const { runLint } = require_(path.resolve(__dirname, '../lib/core/run-lint.js'));
+const scannerDiag = require_(path.resolve(__dirname, '../lib/utils/text-scanner.js'));
+
+// 从已提交的 benchmark 文件抽取生成器，保证输入与 CI 一致、可复现。
+const benchSrc = fs.readFileSync(path.resolve(__dirname, 'benchmark-memory.mjs'), 'utf8');
+function extractGenerator(name) {
+  const re = new RegExp(`function ${name}\\(targetBytes\\)[\\s\\S]*?\\n}\\n`);
+  const m = benchSrc.match(re);
+  if (!m)
+    throw new Error(`cannot extract generator: ${name}`);
+  // 生成器依赖模块级常量，在此提供同一份定义并整体 eval，供生成器闭包引用。
+  const helperSrc = `
+    const CHINESE_CHARS = '的一是在不了有和人这中大为上个国以要到和自地们时生就学对得也子说着可';
+    const ENGLISH_WORDS = 'the be to of and a in that have I it for not on with he as you do at this but his by from they we say her she or an will my one all would there their what so up out if about who get which go me when make can like time no just him know take people into year your good some could them see other than then now look only come its over think also back after use two how our work first well way even new want because any these give day most us'.split(' ');
+    const repeatToSize = (base, targetBytes) => {
+      const buf = Buffer.from(base, 'utf8');
+      const times = Math.ceil(targetBytes / buf.length);
+      return Buffer.concat(Array(times).fill(buf)).slice(0, targetBytes).toString('utf8');
+    };
+    return (${m[0]});
+  `;
+  // eslint-disable-next-line no-eval
+  return eval(`(function () {${helperSrc}})()`);
+}
+
+const GENERATORS = {
+  'long-paragraph': extractGenerator('generateLongParagraph'),
+  'many-paragraphs': extractGenerator('generateManyParagraphs'),
+  'high-match-density': extractGenerator('generateHighMatchDensity'),
+  'overlapping-fixes': extractGenerator('generateOverlappingFixes'),
+};
+
+// 最坏情况：大量独立短文本节点，每个节点都会触发一次索引构建。
+// 复用 generateManyParagraphs 的「标题+段落」结构，但内容显式包含触发字符。
+function generateManySmallNodes(targetBytes) {
+  const base = '段落测试.... 价格０元 计算×÷ abc123,测试;中文:测试(中文)中文！测试？测试。';
+  const parts = [];
+  let acc = 0;
+  let i = 0;
+  while (acc < targetBytes) {
+    const p = `## ${i + 1}\n\n${base}\n\n`;
+    const buf = Buffer.from(p, 'utf8');
+    if (acc + buf.length > targetBytes) {
+      parts.push(buf.slice(0, targetBytes - acc));
+      break;
+    }
+    parts.push(buf);
+    acc += buf.length;
+    i++;
+  }
+  return Buffer.concat(parts).toString('utf8');
+}
+GENERATORS['many-small-nodes'] = generateManySmallNodes;
+
+// 触发索引构建的字符补丁：把默认输入中不触发构建的内容替换为会触发的版本。
+// 仅用于让 text-scanner-rules 真正走到 matchAt（positionAt → lineBreakIndices）。
+function withTriggerChars(md) {
+  return md
+    .replace(/[0-9]+/g, '０-９') // 半角数字 → 全角，触发 no-full-width-number
+    .replace(/\.\.\.+/g, '....') // 保证省略号触发 use-standard-ellipsis
+    .replace(/\+/g, '×') // 触发 no-special-characters
+    .replace(/-/g, '÷');
+}
+
+const RULE_IMPORTS = {
+  'use-standard-ellipsis': () => require_(path.resolve(__dirname, '../lib/rules/use-standard-ellipsis.js')).default,
+  'no-half-width-punctuation': () => require_(path.resolve(__dirname, '../lib/rules/no-half-width-punctuation.js')).default,
+  'no-full-width-number': () => require_(path.resolve(__dirname, '../lib/rules/no-full-width-number.js')).default,
+  'space-around-number': () => require_(path.resolve(__dirname, '../lib/rules/space-around-number.js')).default,
+  'no-special-characters': () => require_(path.resolve(__dirname, '../lib/rules/no-special-characters.js')).default,
+};
+const SCANNER_RULE_NAMES = Object.keys(RULE_IMPORTS);
+const SCANNER_CONFIGS = SCANNER_RULE_NAMES.map(n => ({ rule: RULE_IMPORTS[n]() }));
+
+function countTextNodes(ast) {
+  let n = 0;
+  (function walk(x) {
+    if (!x || typeof x !== 'object')
+      return;
+    if (x.type === 'text')
+      n++;
+    if (Array.isArray(x.children))
+      x.children.forEach(walk);
+  })(ast);
+  return n;
+}
+
+function median(arr) {
+  const b = [...arr].sort((x, y) => x - y);
+  const m = b.length >> 1;
+  return b.length % 2 ? b[m] : (b[m - 1] + b[m]) / 2;
+}
+
+function parseArgs(argv) {
+  const opts = { bytes: 256 * 1024, runs: 5, warmup: 2, shape: null };
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case '--bytes': opts.bytes = parseInt(argv[++i], 10); break;
+      case '--runs': opts.runs = parseInt(argv[++i], 10); break;
+      case '--warmup': opts.warmup = parseInt(argv[++i], 10); break;
+      case '--shape': opts.shape = argv[++i]; break;
+      default: break;
+    }
+  }
+  return opts;
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  // 用固定 seed 的可复现输入：内容固定，仅按 bytes 截断，因此同一 commit 必得同一输入。
+  const shapes = opts.shape ? [opts.shape] : Object.keys(GENERATORS);
+  const allLines = [];
+
+  for (const shape of shapes) {
+    const gen = GENERATORS[shape];
+    const md = gen(opts.bytes);
+    const textNodeCount = countTextNodes(parseMd(md));
+    const triggeredMd = withTriggerChars(md);
+
+    const buildMsRuns = [];
+    const wallMsRuns = [];
+    let reportCount = 0;
+
+    for (let i = 0; i < opts.warmup + opts.runs; i++) {
+      scannerDiag.resetScannerDiagnostics();
+      const t0 = performance.now();
+      const result = runLint(triggeredMd, SCANNER_CONFIGS);
+      const wall = performance.now() - t0;
+      const d = scannerDiag.getScannerDiagnostics();
+      reportCount = result.ruleManager.getReportData().length;
+      if (i >= opts.warmup) {
+        buildMsRuns.push(d.textScannerIndexBuildWallTimeMs);
+        wallMsRuns.push(wall);
+      }
+    }
+
+    const buildMsMedian = median(buildMsRuns);
+    const wallMsMedian = median(wallMsRuns);
+    const ratioPctMedian = wallMsMedian > 0 ? (buildMsMedian / wallMsMedian) * 100 : 0;
+
+    const line = {
+      shape,
+      triggerInput: true,
+      bytes: opts.bytes,
+      runs: opts.runs,
+      warmup: opts.warmup,
+      textNodeCount,
+      reportCount,
+      buildMsRuns: buildMsRuns.map(v => Number(v.toFixed(4))),
+      wallMsRuns: wallMsRuns.map(v => Number(v.toFixed(3))),
+      buildMsMedian: Number(buildMsMedian.toFixed(4)),
+      wallMsMedian: Number(wallMsMedian.toFixed(3)),
+      ratioPctMedian: Number(ratioPctMedian.toFixed(3)),
+    };
+    allLines.push(line);
+  }
+
+  // 原始 NDJSON：每行一个 shape，run 级原始值可复算中位数。
+  for (const l of allLines) process.stdout.write(`${JSON.stringify(l)}\n`);
+}
+
+main();

--- a/src/utils/text-scanner.ts
+++ b/src/utils/text-scanner.ts
@@ -1,4 +1,23 @@
 import type { MarkdownTextNode } from './get-text-nodes';
+import { now } from './time';
+
+/**
+ * TextScanner 索引构建诊断（仅供 benchmark / 单测观测使用）。
+ * 仅记录「换行索引首次构建」的重复成本，用于判断是否有必要引入
+ * 跨 scanner 的索引缓存（见 issue #176）。不涉及规则公共 API。
+ */
+let scannerIndexBuilds = 0;
+let scannerIndexBuildWallTimeMs = 0;
+
+export const getScannerDiagnostics = () => ({
+  textScannerIndexBuilds: scannerIndexBuilds,
+  textScannerIndexBuildWallTimeMs: scannerIndexBuildWallTimeMs
+});
+
+export const resetScannerDiagnostics = () => {
+  scannerIndexBuilds = 0;
+  scannerIndexBuildWallTimeMs = 0;
+};
 
 /** 文本匹配结果，包含相对位置和绝对位置 */
 export interface TextMatch {
@@ -46,9 +65,10 @@ export class TextScanner {
     this._startOffset = node.position.start.offset;
   }
 
-  /** 换行索引，首次需要时构建 */
+  /** 换行索引，首次需要时构建（并累计诊断计数/耗时） */
   private get lineBreakIndices(): number[] {
     if (!this._lineBreakIndices) {
+      const buildStart = now();
       const indices: number[] = [];
       for (let i = 0; i < this._value.length; i++) {
         if (this._value[i] === '\n') {
@@ -56,6 +76,8 @@ export class TextScanner {
         }
       }
       this._lineBreakIndices = indices;
+      scannerIndexBuilds++;
+      scannerIndexBuildWallTimeMs += now() - buildStart;
     }
     return this._lineBreakIndices;
   }

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,5 @@
+/** 返回高精度时间戳（毫秒）。抽离以便测试或不同运行时替换实现。 */
+export const now = (): number =>
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();


### PR DESCRIPTION
## 关联

Refs #176。本 PR 落地诊断设施，并附上**可复现**的多次中位数 profile 数据。
**结论：所有已测场景索引构建占比均低于 1%，建议关闭 #176**（数据证伪，符合 issue「以数据决定是否引入 seam」的约束）。

## 诊断设施（本 PR 代码改动）

- `src/utils/text-scanner.ts`：`lineBreakIndices` 首次构建处累计 `scannerIndexBuilds` 与 `scannerIndexBuildWallTimeMs`，导出 `getScannerDiagnostics()` / `resetScannerDiagnostics()`。
- `src/utils/time.ts`：抽离 `now()` 计时原语。
- `scripts/benchmark-memory.mjs`：warmup 后 reset（分母一致）；`wallTimeMs` 保留浮点；新增 `text-scanner-rules` case；fix-mode 暴露 `runLintCalls`/`fixMetrics` 并以 `notAppliedFixCount` 区分语义。
- `scripts/benchmark-memory-smoke.mjs`：VALID_CASES 加入 `text-scanner-rules`；新增 Test 6 对 `profile-scanner-176.mjs` 的 smoke 校验（4KiB / 1 run / warmup 0，断言 textNodeCount/reportCount/buildMsRuns/wallMsRuns/bytes 实际值）。
- `__tests__/unit/utils/text-scanner.spec.ts`：诊断用例，text-scanner.ts 覆盖 100%。

## 为什么需要独立的可复现 profile 脚本

**默认 benchmark 输入是测量假象**：`no-half-width-punctuation` / `space-around-number` 走 `forEachChar`（不解析位置），而 `lineBreakIndices` 仅在 `findAllMatches`/`findAllOccurrences`→`matchAt` 解析位置时构建。默认中文+英文模板触发数千报告却 `builds=0`，不能用于决策。

`scripts/profile-scanner-176.mjs`：
- 复用 `benchmark-memory.mjs` 的**已提交**生成器，输入与 CI 一致；
- 输入显式补丁触发字符（`....` / `０-９` / `×÷`），确保走到索引构建；
- 字节数与文本节点数均取自**转换后**的实际被测输入 `triggeredMd`（`requestedBytes` 与 `bytes` 分别输出，避免替换导致的长度偏差）；
- 输出原始 NDJSON（每次 run 的 `buildMsRuns`/`wallMsRuns` + `nodeVersion`/`platform`/`arch`），中位数透明可复算；
- 固定内容按 bytes 截断，同一 commit 输入确定（已验证两次运行节点数一致）。

## 复现命令

profile 脚本直接加载 `../lib/**`（CJS 构建产物），因此全新 clone 需先构建：
```
npm install
npm run build

node scripts/profile-scanner-176.mjs \
  --bytes 262144 \
  --runs 5 \
  --warmup 2

node scripts/profile-scanner-176.mjs \
  --shape many-small-nodes \
  --bytes 1048576 \
  --runs 5 \
  --warmup 2
```

## 真实 profile 数据（runs=5 warmup=2，中位；bytes 为实际被测输入 UTF-8 长度）

| shape | requested | actual bytes | 节点数 | reports | buildMs | wallMs | 占比 |
|---|---|---|---|---|---|---|---|
| long-paragraph | 256KiB | 261715 | 1 | 430 | 0.142ms | 30.6ms | 0.46% |
| many-paragraphs | 256KiB | 280888 | 4132 | 8264 | 0.558ms | 148.1ms | 0.38% |
| high-match-density | 256KiB | 284359 | 1 | 8886 | 0.139ms | 31.8ms | 0.44% |
| overlapping-fixes | 256KiB | 273349 | 1 | 15685 | 0.119ms | 28.6ms | 0.42% |
| many-small-nodes(最坏) | 256KiB | 284036 | 4620 | 27712 | 0.994ms | 152.6ms | 0.65% |
| many-small-nodes 1MiB | 1MiB | 1132555 | 18416 | 110496 | 3.847ms | 769.1ms | 0.50% |

环境：Node v24.15.0 / linux / x64。
（节点数说明：long-paragraph 等段落被解析器合并为单 text 节点；many-paragraphs / many-small-nodes 因每段落独立而节点数大。）

## 结论

所有已测场景索引构建占比均**低于 1%**（最坏 many-small-nodes 约 0.65%），单条构建微秒级。性能绝对值会随机器与 Node.js 版本波动，但占比量级稳定可忽略。引入以 AST node 为 key 的 `WeakMap` 缓存 seam，其维护成本与并发语义风险远超可忽略收益。

**建议关闭 #176（数据证伪）**。诊断设施 + `scripts/profile-scanner-176.mjs` 保留为长期观测工具，可随时复算验证回归。

## 评审修正（已落地）

1-8. 见前版（分母一致性 / smoke 契约 / 不导出公共 API / `notAppliedFixCount` / 不写 Closes / 浮点精度 / 过期注释 / 可复现 profile 脚本）。
9. [P1] `bytes` 改为实际被测输入长度（`requestedBytes` 与 `bytes` 分离）。
10. [P2] 文本节点数改自转换后的 `triggeredMd` 统计。
11. 输出加入 `nodeVersion`/`platform`/`arch`。
12. smoke test 新增 `profile-scanner-176.mjs` 最小场景校验。
13. PR 描述统一占比表述为「均低于 1%」；复现命令补充 `npm install` + `npm run build` 步骤。

## 测试

- `npm run typecheck`、`npm run lint`、`npm run smoke-test` 通过（含 Test 6）。
- 全量测试 228 passed；text-scanner.ts 覆盖 100%。