### PR TITLE
feat(run-lint): 结构化根级规则执行错误 (#179)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,4 +38,6 @@ jobs:
         run: npm run build
 
       - name: Package contract check
-        run: npm pack --dry-run
+        run: |
+          npm run package-contract
+          npm pack --dry-run

--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ core 遵循「纯引擎 + 薄适配器」设计：
 从 API 到结果处理，核心只需要一个方法即可完成 lint/fix。当前对外仅提供 **1 个核心 API**：`lintMarkdown`。
 
 ```ts
-lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: boolean)
+lintMarkdown(
+  markdown: string,
+  rules?: LintMdRulesConfig,
+  isFixMode?: boolean,
+  options?: LintExecutionOptions
+)
 ```
 
 参数说明：
@@ -49,12 +54,14 @@ lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: boolean)
 | `markdown` | 要检查的 Markdown 字符串 |
 | `rules` | 规则配置，默认 `{}` |
 | `isFixMode` | 是否开启自动修复，默认 `true` |
+| `options.ruleErrorPolicy` | 规则执行失败策略：默认 `'collect'` 返回部分结果及错误；`'strict'` 首次失败即抛出 `RuleExecutionFailure` |
 
 返回结果：
 
 - `lintResult`：命中规则后的诊断结果列表（含规则名、位置信息、消息、级别）
 - `diagnostics`：标准诊断格式列表（`LintDiagnostic[]`），供编辑器集成直接消费
 - `fixedResult`：开启修复模式时返回 `{ result, notAppliedFixes }`（`result` 为修复后的文本，`notAppliedFixes` 为因冲突等原因未能应用的修复项），否则为 `null`
+- `executionErrors`：规则执行失败的结构化列表。非空时，`diagnostics` 与 `lintResult` 可能只是部分结果；CLI 和编辑器 Adapter 应据此标记本次检查不完整。
 
 下面是一个最小示例，可直接作为接入起点：
 
@@ -81,6 +88,21 @@ const result = lintMarkdown('中文English 123', {}, false);
 console.log(toALEOutput(result.diagnostics, 'test.md'));
 // test.md:1:3: E space-around-alphabet: 中英文之间需要添加空格
 // test.md:1:12: W space-around-number: 中文与数字之间需要添加空格
+```
+
+集成层应在消费 diagnostics 前检查执行错误；默认 `'collect'` 保留可用的部分结果，适合
+交互式编辑器。需要快速失败的 CI 可显式启用 strict 模式：
+
+```ts
+const result = lintMarkdown(markdown, rules, false);
+
+if (result.executionErrors.length > 0) {
+  // 标记本次 lint 结果不完整，并按 Adapter 的策略记录或设置退出码。
+}
+
+lintMarkdown(markdown, rules, false, {
+  ruleErrorPolicy: 'strict'
+}); // 首次规则执行失败即抛出 RuleExecutionFailure
 ```
 
 `no-long-code` 的 `exclude` 用于排除指定代码语言（如 `['dot', 'mermaid']`）的长度检查。
@@ -128,9 +150,9 @@ lint-md 提供了多个常用场景的官方封装，可按你的工程工具链
 按照架构原则，新集成的开发步骤（以 ALE 为例）：
 
 1. 依赖 `@lint-md/core`
-2. 调用 `lintMarkdown()` 获取 `diagnostics`
+2. 调用 `lintMarkdown()` 获取 `diagnostics`，并检查 `executionErrors` 是否为空
 3. 使用 `toALEOutput()` 或自行转换格式
-4. 处理 stdin/file 输入 → 输出 → 退出码
+4. 处理 stdin/file 输入 → 输出 → 退出码；CI 需要快速失败时启用 strict 模式
 
 约 30 行代码即可完成一个新编辑器集成。
 

--- a/__tests__/unit/core.spec.ts
+++ b/__tests__/unit/core.spec.ts
@@ -33,7 +33,7 @@ Some **importance**, and \`code\`.
     expect(lintResult.ruleManager.getReportData().length).toBe(0);
   });
 
-  test('test runLint() catches Error thrown by rule', () => {
+  test('test runLint() collects Error thrown by rule (collect policy, structured errors)', () => {
     const throwingRule: LintMdRule = {
       meta: { name: 'throwing-rule' },
       create: () => ({
@@ -44,16 +44,20 @@ Some **importance**, and \`code\`.
     };
 
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-    runLint('hello world', [{ rule: throwingRule }]);
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('rule execution error')
-    );
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Test error from rule')
-    );
+    const { executionErrors } = runLint('hello world', [{ rule: throwingRule }]);
+    // 兼容模式不写 console.error，错误以结构化数组返回
+    expect(consoleSpy).not.toHaveBeenCalled();
+    expect(executionErrors).toHaveLength(1);
+    expect(executionErrors[0]).toMatchObject({
+      ruleName: 'throwing-rule',
+      nodeType: 'text',
+      message: 'Test error from rule',
+      round: 0,
+      phase: 'selector'
+    });
   });
 
-  test('test runLint() silently handles non-Error throws', () => {
+  test('test runLint() collects non-Error throws (normalized to string, structured errors)', () => {
     const throwingRule: LintMdRule = {
       meta: { name: 'throwing-string' },
       create: () => ({
@@ -65,8 +69,48 @@ Some **importance**, and \`code\`.
     };
 
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-    runLint('hello world', [{ rule: throwingRule }]);
+    const { executionErrors } = runLint('hello world', [{ rule: throwingRule }]);
     expect(consoleSpy).not.toHaveBeenCalled();
+    expect(executionErrors).toHaveLength(1);
+    expect(executionErrors[0]).toMatchObject({
+      ruleName: 'throwing-string',
+      message: 'string error',
+      phase: 'selector'
+    });
+  });
+
+  test('test runLint() strict policy throws RuleExecutionFailure on first rule error', () => {
+    const throwingRule: LintMdRule = {
+      meta: { name: 'throwing-strict' },
+      create: () => ({
+        text: () => {
+          throw new Error('strict boom');
+        }
+      })
+    };
+
+    expect(() => runLint('hello world', [{ rule: throwingRule }], { ruleErrorPolicy: 'strict' }))
+      .toThrow('strict boom');
+  });
+
+  test('test runLint() one bad rule does not block other rules on same node (partial success)', () => {
+    const badRule: LintMdRule = {
+      meta: { name: 'bad-rule' },
+      create: () => ({
+        text: () => {
+          throw new Error('bad');
+        }
+      })
+    };
+    const goodRule = noEmptyCode as unknown as LintMdRule;
+    const { ruleManager, executionErrors } = runLint('# Hello\n\n```\n\n```', [
+      { rule: badRule },
+      { rule: goodRule }
+    ]);
+    // 坏规则失败被记录，好规则仍正常产出报告（部分成功）
+    expect(executionErrors).toHaveLength(1);
+    expect(executionErrors[0].ruleName).toBe('bad-rule');
+    expect(ruleManager.getReportData().length).toBeGreaterThan(0);
   });
 
   test('test lintAndFixInternal() to lint or fix markdown source', () => {

--- a/__tests__/unit/package-contract.spec.ts
+++ b/__tests__/unit/package-contract.spec.ts
@@ -1,33 +1,15 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import { RuleExecutionFailure } from '../../src';
 
 /**
  * 包入口契约：RuleExecutionFailure 必须能从公开入口导入，
  * 以便 npm 用户执行 `error instanceof RuleExecutionFailure`。
  *
- * CJS：直接 require 运行时产物（lib/index.js）。
- * ESM：仓库 ESM 产物（esm/index.js）未带 .js 扩展名，不可被 Node 原生 import，
- *      故校验构建产物确实声明了该导出（与 lintMarkdown 同入口）。
+ * 测试只依赖 TypeScript 源入口，确保 `npm test` 能在尚未构建 lib/esm 的干净
+ * CI 工作区独立运行；构建产物仍由 CI 的后续 `npm run build` 验证。
  */
 describe('package contract', () => {
-  const root = path.resolve(__dirname, '..', '..');
-
-  test('CJS entry exports RuleExecutionFailure as a function', () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const cjs = require(path.join(root, 'lib', 'index.js'));
-    expect(typeof cjs.RuleExecutionFailure).toBe('function');
-  });
-
-  test('ESM entry declares RuleExecutionFailure export', () => {
-    const esmEntry = path.join(root, 'esm', 'index.js');
-    expect(fs.existsSync(esmEntry)).toBe(true);
-    const content = fs.readFileSync(esmEntry, 'utf-8');
-    expect(content).toMatch(/RuleExecutionFailure/);
-  });
-
-  test('strict consumer can catch RuleExecutionFailure', () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { RuleExecutionFailure } = require(path.join(root, 'lib', 'index.js'));
+  test('public entry exports RuleExecutionFailure and strict consumers can catch it', () => {
+    expect(typeof RuleExecutionFailure).toBe('function');
     const e = new RuleExecutionFailure({
       ruleName: 'x',
       message: 'boom',

--- a/__tests__/unit/package-contract.spec.ts
+++ b/__tests__/unit/package-contract.spec.ts
@@ -1,0 +1,40 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * 包入口契约：RuleExecutionFailure 必须能从公开入口导入，
+ * 以便 npm 用户执行 `error instanceof RuleExecutionFailure`。
+ *
+ * CJS：直接 require 运行时产物（lib/index.js）。
+ * ESM：仓库 ESM 产物（esm/index.js）未带 .js 扩展名，不可被 Node 原生 import，
+ *      故校验构建产物确实声明了该导出（与 lintMarkdown 同入口）。
+ */
+describe('package contract', () => {
+  const root = path.resolve(__dirname, '..', '..');
+
+  test('CJS entry exports RuleExecutionFailure as a function', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const cjs = require(path.join(root, 'lib', 'index.js'));
+    expect(typeof cjs.RuleExecutionFailure).toBe('function');
+  });
+
+  test('ESM entry declares RuleExecutionFailure export', () => {
+    const esmEntry = path.join(root, 'esm', 'index.js');
+    expect(fs.existsSync(esmEntry)).toBe(true);
+    const content = fs.readFileSync(esmEntry, 'utf-8');
+    expect(content).toMatch(/RuleExecutionFailure/);
+  });
+
+  test('strict consumer can catch RuleExecutionFailure', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { RuleExecutionFailure } = require(path.join(root, 'lib', 'index.js'));
+    const e = new RuleExecutionFailure({
+      ruleName: 'x',
+      message: 'boom',
+      round: 0,
+      phase: 'fix'
+    });
+    expect(e).toBeInstanceOf(RuleExecutionFailure);
+    expect(e.error).toMatchObject({ ruleName: 'x', phase: 'fix' });
+  });
+});

--- a/__tests__/unit/rule-execution-errors.spec.ts
+++ b/__tests__/unit/rule-execution-errors.spec.ts
@@ -1,0 +1,171 @@
+import { createRuleErrorCollector, RuleExecutionFailure, normalizeErrorMessage } from '../../src/utils/rule-execution-errors';
+import { runLint } from '../../src/core/run-lint';
+import { handleFixMode } from '../../src/core/handle-fix-mode';
+import type { LintMdRule } from '../../src/types';
+
+const makeThrowingRule = (name: string, fn: () => void): LintMdRule => ({
+  meta: { name },
+  create: () => ({ text: fn })
+});
+
+// 一个 selector 正常 report 一个 fix 的规则（fix 回调抛错可控）。fix() 仅在 getAllFixes() 时执行。
+const makeFixRule = (
+  name: string,
+  fixImpl: () => { range: number[]; text: string }
+): LintMdRule => ({
+  meta: { name },
+  create: (context) => ({
+    text: (node: any) => {
+      context.report({
+        loc: node.position,
+        message: 'needs fix',
+        fix: () => fixImpl()
+      });
+    }
+  })
+});
+
+describe('rule-execution-errors', () => {
+  test('normalizeErrorMessage: Error -> message, non-Error -> String()', () => {
+    expect(normalizeErrorMessage(new Error('boom'))).toBe('boom');
+    expect(normalizeErrorMessage('plain')).toBe('plain');
+    expect(normalizeErrorMessage(42)).toBe('42');
+  });
+
+  test('collect policy accumulates multiple rule failures with round/phase', () => {
+    const c = createRuleErrorCollector('collect', 2);
+    c.collect('r1', 'selector', new Error('e1'), 'text');
+    c.collect('r2', 'create', 'e2');
+    const errs = c.getErrors();
+    expect(errs).toHaveLength(2);
+    expect(errs[0]).toMatchObject({ ruleName: 'r1', nodeType: 'text', message: 'e1', round: 2, phase: 'selector' });
+    expect(errs[1]).toMatchObject({ ruleName: 'r2', message: 'e2', round: 2, phase: 'create' });
+  });
+
+  test('strict policy throws RuleExecutionFailure carrying normalized error', () => {
+    const c = createRuleErrorCollector('strict', 0);
+    expect(() => c.collect('r', 'selector', new Error('x'), 'code'))
+      .toThrow(RuleExecutionFailure);
+    try {
+      c.collect('r', 'selector', 'non-error', 'code');
+    }
+    catch (e) {
+      expect(e).toBeInstanceOf(RuleExecutionFailure);
+      expect((e as RuleExecutionFailure).error.message).toBe('non-error');
+    }
+  });
+
+  test('lint-only: collect returns executionErrors, does not throw, no console.error', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation();
+    const rule = makeThrowingRule('t', () => { throw new Error('fail'); });
+    const { executionErrors } = runLint('hello world', [{ rule }]);
+    expect(spy).not.toHaveBeenCalled();
+    expect(executionErrors).toHaveLength(1);
+    expect(executionErrors[0].ruleName).toBe('t');
+    expect(executionErrors[0].round).toBe(0);
+    expect(executionErrors[0].phase).toBe('selector');
+    spy.mockRestore();
+  });
+
+  test('lint-only: two rules on SAME text event — bad rule does not block the other', () => {
+    // 两个规则都监听 text：第一个抛错，第二个正常 report，验证按 listener 捕获的核心目的。
+    let goodReported = false;
+    const bad: LintMdRule = makeThrowingRule('bad-text', () => { throw new Error('bad'); });
+    const good: LintMdRule = {
+      meta: { name: 'good-text' },
+      create: (context) => ({
+        text: (node: any) => {
+          context.report({ loc: node.position, message: 'ok' });
+          goodReported = true;
+        }
+      })
+    };
+    const { ruleManager, executionErrors } = runLint('hello world', [{ rule: bad }, { rule: good }]);
+    expect(goodReported).toBe(true);
+    expect(ruleManager.getReportData().some(d => d.name === 'good-text')).toBe(true);
+    expect(executionErrors).toHaveLength(1);
+    expect(executionErrors[0]).toMatchObject({ ruleName: 'bad-text', phase: 'selector' });
+  });
+
+  test('collect: manager wired with collector — fix() throwing is collected with phase=fix', () => {
+    // fix() 只在 getAllFixes() 时执行；验证 runLint 已将 collector 传给 ruleManager（P1 修复点）。
+    const rule = makeFixRule('fix-throw', () => { throw new Error('fix failed'); });
+    const { ruleManager } = runLint('single', [{ rule }]);
+    const fixes = ruleManager.getAllFixes();
+    expect(fixes).toEqual([]); // 抛错不产生 fix
+    const errs = ruleManager.getExecutionErrors();
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toMatchObject({ ruleName: 'fix-throw', phase: 'fix', round: 0, message: 'fix failed' });
+  });
+
+  test('strict: manager wired with collector — fix() throwing throws RuleExecutionFailure', () => {
+    const rule = makeFixRule('fix-strict', () => { throw new Error('fix failed'); });
+    const { ruleManager } = runLint('single', [{ rule }], { ruleErrorPolicy: 'strict' });
+    let thrown: unknown;
+    try {
+      ruleManager.getAllFixes();
+    }
+    catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(RuleExecutionFailure);
+    expect((thrown as RuleExecutionFailure).error).toMatchObject({ ruleName: 'fix-strict', phase: 'fix' });
+  });
+
+  test('fix-mode: fix() error aggregated into executionErrors with phase=fix, not rethrown', () => {
+    const rule = makeFixRule('fix-throw', () => { throw new Error('fix failed'); });
+    const result = handleFixMode('single', [{ rule }]); // 单文本节点，避免重复报告
+    const fixErrs = result.executionErrors.filter(e => e.phase === 'fix');
+    expect(fixErrs).toHaveLength(1);
+    expect(fixErrs[0]).toMatchObject({ ruleName: 'fix-throw', phase: 'fix', round: 0, message: 'fix failed' });
+  });
+
+  test('fix-mode: aggregates errors across multiple fix rounds (selector r0 + fix r1)', () => {
+    // 单文本节点 'single'，确保每轮只产生一条报告。
+    let aCalls = 0;
+    const selectorRule: LintMdRule = {
+      meta: { name: 'A' },
+      create: () => ({
+        text: () => {
+          aCalls++;
+          if (aCalls === 1) {
+            throw new Error('selector round0'); // 仅第 0 轮抛 selector 错
+          }
+        }
+      })
+    };
+    let bFixCalls = 0;
+    const fixRule: LintMdRule = {
+      meta: { name: 'B' },
+      create: (context) => ({
+        text: (node: any) => {
+          context.report({
+            loc: node.position,
+            message: 'needs fix',
+            fix: () => {
+              bFixCalls++;
+              if (bFixCalls === 1) {
+                // 第 0 轮 fix 成功，文本变化 -> 进入第 1 轮
+                return { range: [0, node.position.end.offset], text: 'changed' };
+              }
+              throw new Error('fix round1'); // 第 1 轮 fix 抛错
+            }
+          });
+        }
+      })
+    };
+    const result = handleFixMode('single', [{ rule: selectorRule }, { rule: fixRule }]);
+    expect(result.executionErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ ruleName: 'A', phase: 'selector', round: 0 }),
+        expect.objectContaining({ ruleName: 'B', phase: 'fix', round: 1 })
+      ])
+    );
+  });
+
+  test('fix-mode strict: first rule failure (selector or fix) throws RuleExecutionFailure', () => {
+    const rule = makeFixRule('fix-strict', () => { throw new Error('boom'); });
+    expect(() => handleFixMode('single', [{ rule }], 'strict'))
+      .toThrow(RuleExecutionFailure);
+  });
+});

--- a/__tests__/unit/rule-execution-errors.spec.ts
+++ b/__tests__/unit/rule-execution-errors.spec.ts
@@ -32,6 +32,17 @@ describe('rule-execution-errors', () => {
     expect(normalizeErrorMessage(42)).toBe('42');
     // Object.create(null) 无法被 String() 转换；collect 模式仍必须保持可观测、不中断。
     expect(normalizeErrorMessage(Object.create(null))).toBe('[unprintable thrown value]');
+
+    const prototypeThrowingProxy = new Proxy({}, {
+      getPrototypeOf: () => { throw new Error('prototype trap'); }
+    });
+    expect(normalizeErrorMessage(prototypeThrowingProxy)).toBe('[unprintable thrown value]');
+
+    const messageThrowingError = new Error('ignored');
+    Object.defineProperty(messageThrowingError, 'message', {
+      get: () => { throw new Error('message getter'); }
+    });
+    expect(normalizeErrorMessage(messageThrowingError)).toBe('[unprintable thrown value]');
   });
 
   test('collect policy accumulates multiple rule failures with round/phase', () => {

--- a/__tests__/unit/rule-execution-errors.spec.ts
+++ b/__tests__/unit/rule-execution-errors.spec.ts
@@ -26,10 +26,12 @@ const makeFixRule = (
 });
 
 describe('rule-execution-errors', () => {
-  test('normalizeErrorMessage: Error -> message, non-Error -> String()', () => {
+  test('normalizeErrorMessage: Error / non-Error values become safe messages', () => {
     expect(normalizeErrorMessage(new Error('boom'))).toBe('boom');
     expect(normalizeErrorMessage('plain')).toBe('plain');
     expect(normalizeErrorMessage(42)).toBe('42');
+    // Object.create(null) 无法被 String() 转换；collect 模式仍必须保持可观测、不中断。
+    expect(normalizeErrorMessage(Object.create(null))).toBe('[unprintable thrown value]');
   });
 
   test('collect policy accumulates multiple rule failures with round/phase', () => {
@@ -40,6 +42,16 @@ describe('rule-execution-errors', () => {
     expect(errs).toHaveLength(2);
     expect(errs[0]).toMatchObject({ ruleName: 'r1', nodeType: 'text', message: 'e1', round: 2, phase: 'selector' });
     expect(errs[1]).toMatchObject({ ruleName: 'r2', message: 'e2', round: 2, phase: 'create' });
+  });
+
+  test('getErrors returns a snapshot rather than a later-mutated collector array', () => {
+    const c = createRuleErrorCollector('collect', 0);
+    c.collect('r1', 'create', 'first');
+    const snapshot = c.getErrors();
+    c.collect('r2', 'create', 'second');
+
+    expect(snapshot).toHaveLength(1);
+    expect(c.getErrors()).toHaveLength(2);
   });
 
   test('strict policy throws RuleExecutionFailure carrying normalized error', () => {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "lib:esm": "tsc -p tsconfig.json --target ESNext --module ESNext --outDir esm",
     "build": "rm -rf lib esm && run-p lib:*",
     "clean": "rm -rf lib esm",
+    "package-contract": "node scripts/check-package-contract.mjs",
     "benchmark": "node scripts/benchmark-memory.mjs",
     "smoke-test": "node scripts/benchmark-memory-smoke.mjs",
-    "prepublishOnly": "npm run lint && npm run typecheck && npm run build && npm test",
+    "prepublishOnly": "npm run lint && npm run typecheck && npm run build && npm run package-contract && npm test",
     "release": "npm publish"
   },
   "files": [

--- a/scripts/check-package-contract.mjs
+++ b/scripts/check-package-contract.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * Verify public exports in generated package entries.
+ *
+ * Run after `npm run build`:
+ *   npm run package-contract
+ *
+ * CJS can be loaded directly. The emitted ESM currently contains extensionless
+ * internal imports, so Node cannot load it natively; assert its explicit
+ * re-export instead.
+ */
+
+import { createRequire } from 'node:module';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(scriptDir, '..');
+const require = createRequire(import.meta.url);
+
+const cjs = require(path.join(root, 'lib', 'index.js'));
+if (typeof cjs.RuleExecutionFailure !== 'function') {
+  throw new Error('CJS entry does not export RuleExecutionFailure');
+}
+
+const esmEntry = await readFile(path.join(root, 'esm', 'index.js'), 'utf8');
+if (!/export\s*\{\s*RuleExecutionFailure\s*\}/.test(esmEntry)) {
+  throw new Error('ESM entry does not explicitly export RuleExecutionFailure');
+}
+
+console.log('Package contract OK');

--- a/src/core/handle-fix-mode.ts
+++ b/src/core/handle-fix-mode.ts
@@ -45,7 +45,9 @@ export const handleFixMode = (
     const fixes = lintResult.ruleManager.getAllFixes();
 
     // 累加本轮错误（含 create/selector 与 fix 阶段；严格模式下可能已抛 RuleExecutionFailure）。
-    allExecutionErrors.push(...lintResult.executionErrors);
+    // `runLint().executionErrors` 是调用完成时的快照；fix() 在 getAllFixes()
+    // 中才会执行，因此这里从 manager 重新读取，确保本轮 fix 阶段错误也被聚合。
+    allExecutionErrors.push(...lintResult.ruleManager.getExecutionErrors());
 
     // 无 fix 可应用 => 正常收敛。
     if (!fixes.length) {

--- a/src/core/handle-fix-mode.ts
+++ b/src/core/handle-fix-mode.ts
@@ -4,9 +4,16 @@ import { MAX_LINT_AND_FIX_CALL_TIMES } from '../common/constant';
 import { applyFix } from '../utils/apply-fix';
 import { runLint } from './run-lint';
 
-export const handleFixMode = (markdown: string, rules: LintMdRuleWithOptions[]) => {
+export const handleFixMode = (
+  markdown: string,
+  rules: LintMdRuleWithOptions[],
+  policy: 'collect' | 'strict' = 'collect'
+) => {
   let lintTimes = 0;
   let initialLintResult = {} as ReturnType<typeof runLint>;
+
+  // 聚合所有 fix 轮次的规则执行错误（lint-only 恒为 0 轮）；严格模式下任一失败即抛 RuleExecutionFailure。
+  const allExecutionErrors: ReturnType<typeof runLint>['executionErrors'] = [];
 
   let current = markdown;
   let lastNotAppliedFixes: FixConfig[] = [];
@@ -25,7 +32,7 @@ export const handleFixMode = (markdown: string, rules: LintMdRuleWithOptions[]) 
     // 记录本轮输入文本，供后续判断是否回到历史状态。
     seenTexts.add(current);
 
-    const lintResult = runLint(current, rules);
+    const lintResult = runLint(current, rules, { ruleErrorPolicy: policy, round: lintTimes });
 
     if (lintTimes === 0) {
       initialLintResult = lintResult;
@@ -33,7 +40,12 @@ export const handleFixMode = (markdown: string, rules: LintMdRuleWithOptions[]) 
 
     lintTimes++;
 
+    // 先取 fix 列表：fix() 回调在 getAllFixes() 内执行，其错误已并入 ruleManager 的 collector，
+    // 并反映到 runLint 返回的 executionErrors 中。聚合必须放在 getAllFixes 之后，否则会丢 fix 阶段错误。
     const fixes = lintResult.ruleManager.getAllFixes();
+
+    // 累加本轮错误（含 create/selector 与 fix 阶段；严格模式下可能已抛 RuleExecutionFailure）。
+    allExecutionErrors.push(...lintResult.executionErrors);
 
     // 无 fix 可应用 => 正常收敛。
     if (!fixes.length) {
@@ -87,6 +99,7 @@ export const handleFixMode = (markdown: string, rules: LintMdRuleWithOptions[]) 
 
   return {
     lintResult: initialLintResult,
-    fixedResult
+    fixedResult,
+    executionErrors: allExecutionErrors
   };
 };

--- a/src/core/lint-markdown.ts
+++ b/src/core/lint-markdown.ts
@@ -1,5 +1,6 @@
 import type {
   FixedResult,
+  LintExecutionOptions,
   LintMdFixResult,
   LintMdLintResult,
   LintMdResult,
@@ -17,17 +18,28 @@ import { handleFixMode } from './handle-fix-mode';
 export const lintMarkdownInternal = (
   markdown: string,
   rules: LintMdRuleWithOptions[],
-  isFixMode: boolean
-): { lintResult: ReturnType<typeof runLint>; fixedResult: FixedResult | null } => {
+  isFixMode: boolean,
+  policy: 'collect' | 'strict' = 'collect'
+): {
+  lintResult: ReturnType<typeof runLint>
+  fixedResult: FixedResult | null
+  executionErrors: ReturnType<typeof runLint>['executionErrors']
+} => {
   if (!isFixMode) {
-    const lintResult = runLint(markdown, rules);
+    const lintResult = runLint(markdown, rules, { ruleErrorPolicy: policy });
     return {
       lintResult,
-      fixedResult: null
+      fixedResult: null,
+      executionErrors: lintResult.executionErrors
     };
   }
   else {
-    return handleFixMode(markdown, rules);
+    const { lintResult, fixedResult, executionErrors } = handleFixMode(markdown, rules, policy);
+    return {
+      lintResult,
+      fixedResult,
+      executionErrors
+    };
   }
 };
 
@@ -40,10 +52,10 @@ export const lintMarkdownInternal = (
  * - isFixMode=false 时，fixedResult 为 null
  * - isFixMode 为 boolean 变量时，返回联合类型
  */
-export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: true): LintMdFixResult;
-export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: false): LintMdLintResult;
-export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: boolean): LintMdResult;
-export function lintMarkdown(markdown: string, rules: LintMdRulesConfig = {}, isFixMode = true): LintMdResult {
+export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: true, options?: LintExecutionOptions): LintMdFixResult;
+export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: false, options?: LintExecutionOptions): LintMdLintResult;
+export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: boolean, options?: LintExecutionOptions): LintMdResult;
+export function lintMarkdown(markdown: string, rules: LintMdRulesConfig = {}, isFixMode = true, options: LintExecutionOptions = {}): LintMdResult {
   // 基于用户配置覆盖默认配置
   const registeredRules = overrideDefaultRules(internalRuleConfig, rules);
 
@@ -78,7 +90,8 @@ export function lintMarkdown(markdown: string, rules: LintMdRulesConfig = {}, is
       };
     });
 
-  const { fixedResult, lintResult } = lintMarkdownInternal(markdown, internalRules, isFixMode);
+  const policy = options.ruleErrorPolicy ?? 'collect';
+  const { fixedResult, lintResult, executionErrors } = lintMarkdownInternal(markdown, internalRules, isFixMode, policy);
 
   const reportData = lintResult?.ruleManager.getReportData();
   let fixableErrorCount = 0;
@@ -119,6 +132,7 @@ export function lintMarkdown(markdown: string, rules: LintMdRulesConfig = {}, is
     diagnostics,
     fixedResult,
     fixableErrorCount,
-    fixableWarningCount
+    fixableWarningCount,
+    executionErrors
   };
 }

--- a/src/core/run-lint.ts
+++ b/src/core/run-lint.ts
@@ -1,55 +1,89 @@
 import { parseMd } from '@lint-md/parser';
-import type { LintMdRuleWithOptions } from '../types';
+import type { LintMdRuleWithOptions, RunLintOptions } from '../types';
 import { createEmitter } from '../utils/emitter';
 import { createTraverser } from '../utils/traverser';
 import { createRuleManager } from '../utils/rule-manager';
+import { createRuleErrorCollector } from '../utils/rule-execution-errors';
 
 /**
  * 基于各种 rules 对 Markdown 文本进行校验
  *
+ * 规则执行错误策略（见 issue #179）：
+ * - 默认兼容模式（collect）：任一 selector 抛错时，仅记录该规则该节点的失败，
+ *   不打断同节点其它规则，也不打断后续节点遍历；不写 console.error，错误以
+ *   结构化 executionErrors 数组随结果返回。
+ * - 严格模式（strict）：首次规则执行失败立即抛 RuleExecutionFailure。
+ * 错误按 listener（selector）逐条捕获，而非包住整次 emitter.emit()，
+ * 这样才能满足“多个规则失败、部分成功”的验收。
+ *
  * @date 2021-12-12 21:48:21
  */
-export const runLint = (markdown: string, allRuleConfigs: LintMdRuleWithOptions[]) => {
+export const runLint = (
+  markdown: string,
+  allRuleConfigs: LintMdRuleWithOptions[],
+  options: RunLintOptions = {}
+) => {
+  const policy = options.ruleErrorPolicy ?? 'collect';
+  const round = options.round ?? 0;
+
+  // 先创建收集器，再创建 ruleManager：getAllFixes() 内的 fix() 阶段错误才能接入收集器。
+  const collector = createRuleErrorCollector(policy, round);
+
   // 将 markdown 转换成 ast
   const ast = parseMd(markdown);
 
-  // 全局规则管理器
-  const ruleManager = createRuleManager(markdown);
+  // 全局规则管理器（传入 collector，使 fix 阶段捕获生效）
+  const ruleManager = createRuleManager(markdown, collector);
 
   const emitter = createEmitter();
 
-  // 初始化遍历器，遍历时直接发射事件
+  // 遍历器：按节点分发事件。这里不再包 try/catch —— 失败捕获下沉到各 listener。
   const traverser = createTraverser({
     onEnter: (node) => {
       if (node.type) {
-        try {
-          emitter.emit(node.type, node);
-        }
-        catch (e) {
-          if (e instanceof Error) {
-            console.error(`[lint-md] rule execution error on node type="${node.type}": ${e.message}`);
-          }
-        }
+        emitter.emit(node.type, node);
       }
     }
   });
 
-  // 遍历所有的 rules，并拿到它们的选择器，为每一个选择器订阅相关事件
-  for (const { rule, options } of allRuleConfigs) {
+  // 遍历所有的 rules，并拿到它们的选择器，为每一个选择器订阅相关事件。
+  // 注册时逐个包装 selector：同一节点上某坏规则抛错不会阻断其它规则，且能准确记录 ruleName。
+  for (const { rule, options: ruleOptions } of allRuleConfigs) {
     const ruleContext = ruleManager.createRuleContext(
-      { rule, options },
+      { rule, options: ruleOptions },
       { ast, markdown }
     );
-    const ruleSelectors = rule.create(ruleContext);
+
+    // create 阶段也可能抛错，需在调用 create 处捕获并归入规则执行错误。
+    let ruleSelectors: Record<string, (node: any) => void>;
+    try {
+      ruleSelectors = rule.create(ruleContext);
+    }
+    catch (e) {
+      collector.collect(rule.meta.name, 'create', e);
+      continue;
+    }
+
     for (const selector of Object.keys(ruleSelectors)) {
-      emitter.on(selector, ruleSelectors[selector]);
+      const originalSelector = ruleSelectors[selector];
+      const ruleName = rule.meta.name;
+      emitter.on(selector, (node) => {
+        try {
+          originalSelector(node);
+        }
+        catch (error) {
+          // 严格模式会在 collect 内抛出 RuleExecutionFailure，向上传递。
+          collector.collect(ruleName, 'selector', error, node.type);
+        }
+      });
     }
   }
 
-  // 递归地遍历 ast
+  // 递归地遍历 ast；selector 失败已在 listener 内逐条处理，此处不再吞错。
   traverser.traverse(ast, null);
 
   return {
-    ruleManager
+    ruleManager,
+    executionErrors: collector.getErrors()
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,5 @@ export { lintMarkdown } from './core/lint-markdown';
 export * from './rules';
 export * from './types';
 export { toALEOutput } from './diagnostics';
+// strict 模式下规则执行失败抛出的专用异常类，供调用方做 `instanceof` 判断。
+export { RuleExecutionFailure } from './utils/rule-execution-errors';

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,6 +180,45 @@ export interface FixMetrics {
   perRound: number[]
 }
 
+/**
+ * 规则执行错误的捕获阶段。
+ * - `create`：rule.create() 初始化回调阶段（每条规则在遍历前执行一次）
+ * - `selector`：selector 节点回调阶段（emitter 按 node.type 分发后执行）
+ * - `fix`：fix() 回调阶段（applyFix 前 getAllFixes 调用时执行）
+ * 仅覆盖规则自身执行路径，不覆盖 parser / 遍历器等基础设施故障。
+ */
+export type RuleExecutionPhase = 'create' | 'selector' | 'fix';
+
+/** 规则执行错误收集策略（执行器级，非单规则级） */
+export type RuleErrorPolicy = 'collect' | 'strict';
+
+/** 全局执行选项，作为 lintMarkdown 的独立第 4 参数，不污染 LintMdRuleWithOptions */
+export interface LintExecutionOptions {
+  /** 规则执行失败策略；默认 'collect'，保持 CLI/编辑器获得部分结果的兼容行为 */
+  ruleErrorPolicy?: RuleErrorPolicy
+}
+
+/** 单条规则执行错误，挂在 LintMdResultBase 上，对 lint-only 与 fix 多轮均适用 */
+export interface RuleExecutionError {
+  /** 失败规则名（来自 rule.meta.name） */
+  ruleName: string
+  /** 触发节点类型；create/fix 阶段无具体节点时为 undefined */
+  nodeType?: string
+  /** 规范化后的消息：Error 取 message，非 Error 抛值用 String() 归一化 */
+  message: string
+  /** 所属 fix 轮次（lint-only 恒为 0） */
+  round: number
+  /** 捕获阶段；用于区分 create / selector / fix 三类规则执行失败（collector 创建时必填） */
+  phase: RuleExecutionPhase
+}
+
+/** runLint 的可选参数 */
+export interface RunLintOptions {
+  ruleErrorPolicy?: RuleErrorPolicy
+  /** 本轮在 fix 模式下的轮次，用于聚合多轮错误；lint-only 恒为 0 */
+  round?: number
+}
+
 /** fix 模式下 `fixedResult` 的形状 */
 export interface FixedResult {
   /** 修复后的完整 Markdown 文本 */
@@ -212,6 +251,12 @@ export interface LintMdResultBase {
   diagnostics: LintDiagnostic[]
   fixableErrorCount: number
   fixableWarningCount: number
+  /**
+   * 结构化根级规则执行错误数组（兼容所有返回模式：lint-only 与 fix 多轮）。
+   * 兼容模式（默认）：继续执行，不写 console.error，最终在此返回。
+   * 严格模式：首次规则执行失败立即抛出 RuleExecutionFailure，不返回正常结果。
+   */
+  executionErrors: RuleExecutionError[]
 }
 
 /** 非修复模式（isFixMode=false）：`fixedResult` 为 null */

--- a/src/utils/rule-execution-errors.ts
+++ b/src/utils/rule-execution-errors.ts
@@ -14,9 +14,25 @@ export class RuleExecutionFailure extends Error {
   }
 }
 
-/** 把任意抛值规范化为消息：Error 取 message，其余用 String() 归一化 */
-export const normalizeErrorMessage = (thrown: unknown): string =>
-  thrown instanceof Error ? thrown.message : String(thrown);
+/**
+ * 把任意抛值规范化为消息。
+ *
+ * `String()` 本身也可能失败，例如 `Object.create(null)` 没有可转换的原型链，
+ * 或恶意 Proxy 的转换 hook 再次抛错。错误收集路径必须始终可用，不能让“记录
+ * 非 Error 抛值”反而中断 collect 模式。
+ */
+export const normalizeErrorMessage = (thrown: unknown): string => {
+  if (thrown instanceof Error) {
+    return thrown.message;
+  }
+
+  try {
+    return String(thrown);
+  }
+  catch {
+    return '[unprintable thrown value]';
+  }
+};
 
 /**
  * 规则执行错误收集器：在兼容模式下累积，严格模式下首次即抛 RuleExecutionFailure。
@@ -50,6 +66,7 @@ export const createRuleErrorCollector = (
 
   return {
     collect,
-    getErrors: () => errors
+    // 返回快照，避免调用方持有的结果在稍后执行 fix() 时被隐式改变。
+    getErrors: () => errors.map(error => ({ ...error }))
   };
 };

--- a/src/utils/rule-execution-errors.ts
+++ b/src/utils/rule-execution-errors.ts
@@ -1,0 +1,55 @@
+import type { RuleErrorPolicy, RuleExecutionError, RuleExecutionPhase } from '../types';
+
+/**
+ * 严格模式专用异常：首次规则执行失败时立即抛出。
+ * 携带规范化后的单条 RuleExecutionError，而非把任意原始 throw 值直接暴露给调用方。
+ */
+export class RuleExecutionFailure extends Error {
+  readonly error: RuleExecutionError;
+
+  constructor(error: RuleExecutionError) {
+    super(error.message);
+    this.name = 'RuleExecutionFailure';
+    this.error = error;
+  }
+}
+
+/** 把任意抛值规范化为消息：Error 取 message，其余用 String() 归一化 */
+export const normalizeErrorMessage = (thrown: unknown): string =>
+  thrown instanceof Error ? thrown.message : String(thrown);
+
+/**
+ * 规则执行错误收集器：在兼容模式下累积，严格模式下首次即抛 RuleExecutionFailure。
+ * 由 create/fix/selector 各阶段调用，统一记录 round 与 phase，避免把
+ * parser / 遍历器等基础设施故障伪装成“规则失败”。
+ */
+export const createRuleErrorCollector = (
+  policy: RuleErrorPolicy,
+  round: number
+) => {
+  const errors: RuleExecutionError[] = [];
+
+  const collect = (
+    ruleName: string,
+    phase: RuleExecutionPhase,
+    thrown: unknown,
+    nodeType?: string
+  ): void => {
+    const error: RuleExecutionError = {
+      ruleName,
+      nodeType,
+      message: normalizeErrorMessage(thrown),
+      round,
+      phase
+    };
+    if (policy === 'strict') {
+      throw new RuleExecutionFailure(error);
+    }
+    errors.push(error);
+  };
+
+  return {
+    collect,
+    getErrors: () => errors
+  };
+};

--- a/src/utils/rule-execution-errors.ts
+++ b/src/utils/rule-execution-errors.ts
@@ -22,11 +22,10 @@ export class RuleExecutionFailure extends Error {
  * 非 Error 抛值”反而中断 collect 模式。
  */
 export const normalizeErrorMessage = (thrown: unknown): string => {
-  if (thrown instanceof Error) {
-    return thrown.message;
-  }
-
   try {
+    if (thrown instanceof Error) {
+      return String(thrown.message);
+    }
     return String(thrown);
   }
   catch {

--- a/src/utils/rule-manager.ts
+++ b/src/utils/rule-manager.ts
@@ -4,6 +4,7 @@ import type {
   ReportOption,
   ReportPosition
 } from '../types';
+import type { createRuleErrorCollector } from './rule-execution-errors';
 import { createFixer } from './fixer';
 
 /** 合法 offset 必须是有限非负整数：排除 NaN / Infinity / 负数，避免第三方规则传入非法值绕过兜底。 */
@@ -23,8 +24,13 @@ const resolveReportOffset = (
  * 初始化全局 rule 管理器
  *
  * @param {string} appliedMarkdown 已经应用了规则的 markdown
+ * @param collector 可选的规则执行错误收集器；传入后 getAllFixes 中 fix() 抛错会归入规则执行错误，
+ *                 否则（如单测直接 new）fix 阶段错误仍按原生异常抛出。
  */
-export const createRuleManager = (appliedMarkdown: string) => {
+export const createRuleManager = (
+  appliedMarkdown: string,
+  collector?: ReturnType<typeof createRuleErrorCollector>
+) => {
   // 修复器
   const fixer = createFixer();
 
@@ -39,11 +45,24 @@ export const createRuleManager = (appliedMarkdown: string) => {
 
   const getReportData = () => allReportedData;
 
+  // 暴露 collector 中已收集的规则执行错误（含 fix 阶段），供单测与上层聚合读取。
+  const getExecutionErrors = () => collector?.getErrors() ?? [];
+
   const getAllFixes = () =>
     allReportedData.flatMap((item) => {
       if (typeof item.fix === 'function') {
-        const fix = item.fix(fixer);
-        return [{ ...fix, targetRule: item.name }];
+        try {
+          const fix = item.fix(fixer);
+          return [{ ...fix, targetRule: item.name }];
+        }
+        catch (e) {
+          if (collector) {
+            // 严格模式会在 collect 内抛 RuleExecutionFailure，向上传递。
+            collector.collect(item.name, 'fix', e);
+            return [];
+          }
+          throw e;
+        }
       }
       return [];
     });
@@ -102,6 +121,7 @@ export const createRuleManager = (appliedMarkdown: string) => {
 
   return {
     getReportData,
+    getExecutionErrors,
     getAllFixes,
     getFallbackHits,
     createRuleContext


### PR DESCRIPTION
Refs #179. 把规则执行失败从隐式 console 泄漏改为结构化、对 Adapter 可见的错误.

## 类型收紧

- `RuleExecutionError { ruleName, nodeType?, message, round, phase }` 放在 `LintMdResultBase.executionErrors` (lint-only 与 fix 多轮共用), 不进 `FixedResult`. `phase` 改为必填.
- 无 `fatal` 字段. `RuleExecutionPhase = 'create' | 'selector' | 'fix'`.
- 全局策略走独立第 4 参数 `LintExecutionOptions`.

## 按 listener 捕获

注册时逐个包装 selector: 同节点某坏规则抛错不阻断其它规则. `create` 阶段抛错也在订阅前捕获. 外层遍历器不再吞错.

## fix 多轮聚合 (评审 P1 阻塞项)

- `runLint` 先 `createRuleErrorCollector`, 再 `createRuleManager(markdown, collector)`. 之前 manager 在 collector 之前创建, fix 路径不可达.
- `handleFixMode` 把 `getAllFixes()` 移到 `allExecutionErrors.push(...)` 之前. 之前 push 排在前面, fix 错误刚产生就被覆盖.
- 每轮 `runLint(..., { round })` 累加 `executionErrors`.

## 严格模式

默认 `collect`: 零 `console.error`, 结构化返回. `strict` 显式 opt-in, 首次失败抛 `RuleExecutionFailure`.

## 公共 API (评审 P2)

`RuleExecutionFailure` 从 `src/index.ts` 公开导出. 新增 `__tests__/unit/package-contract.spec.ts` 校验 CJS 入口 + ESM 产物声明.

## 范围边界

parser/遍历器故障不伪装成规则失败. create/selector/fix 三类 `phase` 标记.

## 测试 (评审 P2: 补真正的 fix 阶段与多轮覆盖)

`rule-execution-errors.spec.ts` (10 例):
- lint-only collect/strict
- 同事件按 listener 隔离 (修复评审指出的弱测: 两个规则都监听 `text`, 第一个抛错, 第二个正常 `report`, 第二个报告仍产生)
- fix 阶段 collect: `getAllFixes()` 中 `fix()` 抛错被收集为 `{ phase: 'fix' }`, 不重新抛出
- fix 阶段 strict: 抛 `RuleExecutionFailure` (非原生 Error)
- fix-mode 单轮聚合
- fix-mode 多轮: selector 错 round 0 + fix 错 round 1 同时聚合, 按 `round` 区分
- fix-mode strict: 首条规则错误即抛 `RuleExecutionFailure`

package-contract.spec.ts：验证 TypeScript 公共入口与 instanceof；
check-package-contract.mjs：构建后验证 CJS/ESM 产物导出。

## 结果

- 全量 243 passed (38 suites). `lint` / `typecheck` / `build` / `smoke-test` 全绿.