### PR TITLE
fix(text-scanner): align fix offsets with raw markdown for escapes/entities (#155)

### DIFF
--- a/__tests__/unit/rules/no-half-width-punctuation.spec.ts
+++ b/__tests__/unit/rules/no-half-width-punctuation.spec.ts
@@ -116,3 +116,19 @@ describe('test no-half-width-punctuation', () => {
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
   });
 });
+
+  test('fix mixed full-width/half-width parentheses with escaped backslash in text (issue #155)', () => {
+    const md = '在 DOM 检查器中按下 ctrl + \\\\(（(Chrome/Window）) 可以随时暂停 JS 的执行。这样您就可以检查 DOM 的快照，而不必担心 JS 会改变 DOM 或事件（如鼠标悬停）会导致 DOM 从您脚下发生变化。';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual('在 DOM 检查器中按下 ctrl + \\\\(（（Chrome/Window）） 可以随时暂停 JS 的执行。这样您就可以检查 DOM 的快照，而不必担心 JS 会改变 DOM 或事件（如鼠标悬停）会导致 DOM 从您脚下发生变化。');
+    const { lintResult: after } = fixer(fixedResult!.result);
+    expect(after.ruleManager.getReportData().length).toStrictEqual(0);
+  });
+
+  test('fix ASCII parentheses adjacent to HTML entity in text', () => {
+    const md = '价格&amp;(test)很不错';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual('价格&amp;（test）很不错');
+  });

--- a/__tests__/unit/rules/no-half-width-punctuation.spec.ts
+++ b/__tests__/unit/rules/no-half-width-punctuation.spec.ts
@@ -166,4 +166,24 @@ describe('test no-half-width-punctuation', () => {
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual(`中文${entity}（test）中文`);
   });
+
+  test.each([
+    '<https://example.com/?a&amp;b>',
+    'www.example.com/?a&amp;b'
+  ])('does not reinterpret entities inside an autolink: %s', md => {
+    const { executionErrors, lintResult } = fixer(md);
+    expect(executionErrors).toHaveLength(0);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+
+  test.each([
+    '&#00000049;',
+    '&#x0000028;'
+  ])('keeps overlong numeric entity-like text aligned: %s', entity => {
+    const md = `中文${entity}(test)中文`;
+    const { executionErrors, fixedResult, lintResult } = fixer(md);
+    expect(executionErrors).toHaveLength(0);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(2);
+    expect(fixedResult?.result).toStrictEqual(`中文${entity}（test）中文`);
+  });
 });

--- a/__tests__/unit/rules/no-half-width-punctuation.spec.ts
+++ b/__tests__/unit/rules/no-half-width-punctuation.spec.ts
@@ -115,7 +115,6 @@ describe('test no-half-width-punctuation', () => {
     const { lintResult } = fixer(md);
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
   });
-});
 
   test('fix mixed full-width/half-width parentheses with escaped backslash in text (issue #155)', () => {
     const md = '在 DOM 检查器中按下 ctrl + \\\\(（(Chrome/Window）) 可以随时暂停 JS 的执行。这样您就可以检查 DOM 的快照，而不必担心 JS 会改变 DOM 或事件（如鼠标悬停）会导致 DOM 从您脚下发生变化。';
@@ -132,3 +131,18 @@ describe('test no-half-width-punctuation', () => {
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('价格&amp;（test）很不错');
   });
+
+  test('fix ASCII parentheses after multiple different HTML entities', () => {
+    const md = '甲&amp;乙&lt;(test)中文';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual('甲&amp;乙&lt;（test）中文');
+  });
+
+  test('fix ASCII parentheses after an HTML entity that decodes to two UTF-16 code units', () => {
+    const md = '甲&Afr;(test)中文';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual('甲&Afr;（test）中文');
+  });
+});

--- a/__tests__/unit/rules/no-half-width-punctuation.spec.ts
+++ b/__tests__/unit/rules/no-half-width-punctuation.spec.ts
@@ -145,4 +145,25 @@ describe('test no-half-width-punctuation', () => {
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('甲&Afr;（test）中文');
   });
+
+  test('replace the complete escaped parenthesis source', () => {
+    const md = '中文\\(test\\)中文';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual('中文（test）中文');
+  });
+
+  test('replace the complete parenthesis entity source', () => {
+    const md = '中文&#40;test&#41;中文';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual('中文（test）中文');
+  });
+
+  test.each(['&copy', '&amp'])('keep non-terminated entity-like text aligned: %s', entity => {
+    const md = `中文${entity}(test)中文`;
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual(`中文${entity}（test）中文`);
+  });
 });

--- a/__tests__/unit/rules/no-half-width-punctuation.spec.ts
+++ b/__tests__/unit/rules/no-half-width-punctuation.spec.ts
@@ -186,4 +186,19 @@ describe('test no-half-width-punctuation', () => {
     expect(lintResult.ruleManager.getReportData()).toHaveLength(2);
     expect(fixedResult?.result).toStrictEqual(`中文${entity}（test）中文`);
   });
+
+  test.each([
+    '&#0;',
+    '&#11;',
+    '&#127;',
+    '&#128;',
+    '&#xFDD0;',
+    '&#xFFFF;'
+  ])('aligns numeric entities normalized to replacement character: %s', entity => {
+    const md = `中文${entity}(test)中文`;
+    const { executionErrors, fixedResult, lintResult } = fixer(md);
+    expect(executionErrors).toHaveLength(0);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(2);
+    expect(fixedResult?.result).toStrictEqual(`中文${entity}（test）中文`);
+  });
 });

--- a/__tests__/unit/rules/space-around-number.spec.ts
+++ b/__tests__/unit/rules/space-around-number.spec.ts
@@ -35,4 +35,11 @@ describe('test space-around-number', () => {
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
     expect(fixedResult?.result).toStrictEqual(md);
   });
+
+  test('insert spaces outside a numeric character entity', () => {
+    const md = '中&#49;文';
+    const { fixedResult, lintResult } = fixer(md);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual('中 &#49; 文');
+  });
 });

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "chinese"
   ],
   "dependencies": {
-    "@lint-md/parser": "~0.1.2"
+    "@lint-md/parser": "~0.1.2",
+    "parse-entities": "^2.0.0"
   },
   "devDependencies": {
     "@attachments/eslint-config": "^0.3.3",

--- a/src/rules/no-full-width-number.ts
+++ b/src/rules/no-full-width-number.ts
@@ -21,7 +21,7 @@ const noFullWidthNumber: LintMdRule = {
   create: (context) => {
     return {
       text: (node: PositionedTextNode) => {
-        const scanner = new TextScanner(node);
+        const scanner = new TextScanner(node, context.markdown);
         const matches = scanner.findAllMatches(/[０-９]+/g);
 
         matches.forEach((m) => {

--- a/src/rules/no-half-width-punctuation.ts
+++ b/src/rules/no-half-width-punctuation.ts
@@ -92,13 +92,11 @@ const noHalfWidthPunctuation: LintMdRule = {
             : hasAdjacentChinese(value, i);
 
           if (shouldConvert) {
+            const match = scanner.matchAt(i, 1);
             context.report({
-              loc: {
-                start: { line: pos.line, column: pos.column, offset: pos.offset },
-                end: { line: pos.line, column: pos.column + 1, offset: pos.offset + 1 }
-              },
+              loc: match.loc,
               message: `不应在中文中使用半角标点"${char}"，请使用全角"${fullChar}"`,
-              fix: fixer => fixer.replaceTextRange([pos.offset, pos.offset + 1], fullChar)
+              fix: fixer => fixer.replaceTextRange([pos.offset, pos.endOffset], fullChar)
             });
           }
         });

--- a/src/rules/no-half-width-punctuation.ts
+++ b/src/rules/no-half-width-punctuation.ts
@@ -66,7 +66,7 @@ const noHalfWidthPunctuation: LintMdRule = {
   create: (context) => {
     return {
       text: (node: PositionedTextNode) => {
-        const scanner = new TextScanner(node);
+        const scanner = new TextScanner(node, context.markdown);
         const { value } = scanner;
 
         // 预处理：找出需要转换的括号对

--- a/src/rules/no-special-characters.ts
+++ b/src/rules/no-special-characters.ts
@@ -11,7 +11,7 @@ const noSpecialCharacters: LintMdRule = {
   create: (context) => {
     return {
       text: (node: PositionedTextNode) => {
-        const scanner = new TextScanner(node);
+        const scanner = new TextScanner(node, context.markdown);
 
         SPECIAL_CHARACTERS.forEach((sc) => {
           const matches = scanner.findAllOccurrences(sc);

--- a/src/rules/space-around-number.ts
+++ b/src/rules/space-around-number.ts
@@ -26,7 +26,7 @@ const spaceAroundNumber: LintMdRule = {
   create: (context) => {
     return {
       text: (node: PositionedTextNode) => {
-        const scanner = new TextScanner(node);
+        const scanner = new TextScanner(node, context.markdown);
         const { value } = scanner;
 
         scanner.forEachChar((char, i, pos) => {

--- a/src/rules/space-around-number.ts
+++ b/src/rules/space-around-number.ts
@@ -31,13 +31,11 @@ const spaceAroundNumber: LintMdRule = {
 
         scanner.forEachChar((char, i, pos) => {
           if (i < value.length - 1 && shouldInsertSpaceBetween(value, i)) {
+            const match = scanner.matchAt(i, 2);
             context.report({
-              loc: {
-                start: { line: pos.line, column: pos.column, offset: pos.offset },
-                end: { line: pos.line, column: pos.column + 2, offset: pos.offset + 2 }
-              },
+              loc: match.loc,
               message: '中文与数字之间需要增加空格',
-              fix: fixer => fixer.insertTextAt(pos.offset + 1, ' ')
+              fix: fixer => fixer.insertTextAt(pos.endOffset, ' ')
             });
           }
         });

--- a/src/rules/use-standard-ellipsis.ts
+++ b/src/rules/use-standard-ellipsis.ts
@@ -8,7 +8,7 @@ const useStandardEllipsis: LintMdRule = {
   create: (context) => {
     return {
       text: (node: PositionedTextNode) => {
-        const scanner = new TextScanner(node);
+        const scanner = new TextScanner(node, context.markdown);
 
         // 找到所有的 . 组成的省略号
         const dotMatches = scanner.findAllMatches(/\.{4,}/g);

--- a/src/utils/text-scanner.ts
+++ b/src/utils/text-scanner.ts
@@ -1,6 +1,10 @@
-import parseEntities = require('parse-entities');
+import * as parseEntitiesNs from 'parse-entities';
 import type { MarkdownTextNode } from './get-text-nodes';
 import { now } from './time';
+
+// parse-entities 使用 `export =`，需兼容 CommonJS 与 ESM 两种产物：
+// 在 ESM 构建下命名空间对象本身不可调用，需取 .default。
+const parseEntities = (parseEntitiesNs as { default?: typeof parseEntitiesNs }).default ?? parseEntitiesNs;
 
 /** CommonMark 可转义标点集合（与解析器一致）。 */
 const ESCAPABLE_PUNCTUATION = new Set('!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'.split(''));

--- a/src/utils/text-scanner.ts
+++ b/src/utils/text-scanner.ts
@@ -1,5 +1,60 @@
+import parseEntities = require('parse-entities');
 import type { MarkdownTextNode } from './get-text-nodes';
 import { now } from './time';
+
+/** CommonMark 可转义标点集合（与解析器一致）。 */
+const ESCAPABLE_PUNCTUATION = new Set('!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'.split(''));
+
+/**
+ * 构建「归一化文本索引 -> 原始文档偏移」的前缀长度映射。
+ *
+ * 解析器返回的 `node.value` 是**已解码/去转义**的文本（如 `\\` -> `\`、
+ * `\(` -> `(`、`&amp;` -> `&`），而 `node.position` 的 offset 指向**原始**
+ * markdown 文本。两者在出现转义/实体的文本上长度不一致，导致基于
+ * `value` 索引推算出的 fix offset 与 `applyFix` 实际操作的原始文档错位。
+ *
+ * 映射约定：`prefixLengths[k]` = `value[0..k)` 对应的原始文档字符数
+ * （含第 0 项 0）。于是 `value[k]` 在原始文档中的字节起点偏移为
+ * `node.position.start.offset + prefixLengths[k]`。
+ *
+ * @see issue #155
+ */
+const buildDecodePrefixLengths = (raw: string): number[] => {
+  const prefixLengths: number[] = [0];
+  let i = 0;
+  while (i < raw.length) {
+    const char = raw[i];
+
+    if (char === '&') {
+      // 注意：parse-entities 的 reference 回调第三个参数类型声明为 Location，
+      // 但运行时实际传入的是该字符引用的原始源片段字符串（见 micromark 实现）。
+      let entityRaw: string | '' = '';
+      const refHandler = (_value: string, _pos: unknown, full: unknown) => {
+        entityRaw = typeof full === 'string' ? full : '';
+      };
+      parseEntities(raw.slice(i), { text: () => {}, reference: refHandler as never });
+      if (entityRaw !== '' && raw.startsWith(entityRaw, i)) {
+        prefixLengths.push(prefixLengths[prefixLengths.length - 1] + entityRaw.length);
+        i += entityRaw.length;
+        continue;
+      }
+      prefixLengths.push(prefixLengths[prefixLengths.length - 1] + 1);
+      i++;
+      continue;
+    }
+
+    if (char === '\\' && i + 1 < raw.length && ESCAPABLE_PUNCTUATION.has(raw[i + 1])) {
+      // 转义序列占两个原始字符，但归一化后只占一个字符。
+      prefixLengths.push(prefixLengths[prefixLengths.length - 1] + 2);
+      i += 2;
+      continue;
+    }
+
+    prefixLengths.push(prefixLengths[prefixLengths.length - 1] + 1);
+    i++;
+  }
+  return prefixLengths;
+};
 
 /**
  * TextScanner 索引构建诊断（仅供 benchmark / 单测观测使用）。
@@ -42,12 +97,21 @@ export interface CharPosition {
 }
 
 /**
- * 文本扫描器，消除规则中重复的位置计算和迭代模板
+ * 文本扫描器，消除规则中重复的位置计算和迭代模板。
+ *
+ * 关键约定（见 issue #155）：规则匹配基于解析器返回的「归一化」文本
+ * `node.value`，但 fix 的 offset 必须指向「原始」 markdown。因此 scanner
+ * 同时持有 `node.value`（用于匹配）和原始文本切片（用于位置换算），通过
+ * `decodePrefixLengths` 把归一化索引对齐到原始文档 offset / 行列号。
  *
  * 用法：
- *   const scanner = new TextScanner(node)
+ *   const scanner = new TextScanner(node, markdown)
  *   const matches = scanner.findAllMatches(/[０-９]+/g)
  *   matches.forEach(m => context.report({ loc: m.loc, ... }))
+ *
+ * @param node     文本节点（含归一化 value 与原始 position）
+ * @param markdown 原始 markdown 文本，用于把归一化索引换算回原始 offset。
+ *                省略时退化为旧行为（value 即原始文本，映射为恒等）。
  */
 export class TextScanner {
   private readonly _value: string;
@@ -55,34 +119,61 @@ export class TextScanner {
   private readonly _startLine: number;
   private readonly _startColumn: number;
   private readonly _startOffset: number;
-  private _lineBreakIndices?: number[];
+  /** 原始文本切片（node 对应区间），用于位置换算。 */
+  private readonly _raw: string;
+  /** 原始切片内的换行索引，用于行列号换算。 */
+  private _rawLineBreakIndices?: number[];
+  /** value 索引 -> 原始文档前缀长度映射（见 buildDecodePrefixLengths）。 */
+  private _decodePrefixLengths?: number[];
 
-  constructor(node: MarkdownTextNode) {
+  constructor(node: MarkdownTextNode, markdown?: string) {
     this._node = node;
     this._value = node.value;
     this._startLine = node.position.start.line;
     this._startColumn = node.position.start.column;
     this._startOffset = node.position.start.offset;
+
+    const rawSlice = markdown?.slice(node.position.start.offset, node.position.end.offset);
+    // 无 markdown 或切片长度异常时退回 node.value，保持旧行为。
+    this._raw = (rawSlice && rawSlice.length > 0) ? rawSlice : this._value;
   }
 
-  /** 换行索引，首次需要时构建（并累计诊断计数/耗时） */
-  private get lineBreakIndices(): number[] {
-    if (!this._lineBreakIndices) {
+  /**
+   * 原始切片换行索引，首次需要时构建（并累计诊断计数/耗时，见 issue #176）。
+   */
+  private get rawLineBreakIndices(): number[] {
+    if (!this._rawLineBreakIndices) {
       const buildStart = now();
       const indices: number[] = [];
-      for (let i = 0; i < this._value.length; i++) {
-        if (this._value[i] === '\n') {
+      for (let i = 0; i < this._raw.length; i++) {
+        if (this._raw[i] === '\n') {
           indices.push(i);
         }
       }
-      this._lineBreakIndices = indices;
+      this._rawLineBreakIndices = indices;
       scannerIndexBuilds++;
       scannerIndexBuildWallTimeMs += now() - buildStart;
     }
-    return this._lineBreakIndices;
+    return this._rawLineBreakIndices;
   }
 
-  /** 文本内容 */
+  /** 归一化索引 -> 原始文档前缀长度映射，首次需要时构建（见 issue #155）。 */
+  private get decodePrefixLengths(): number[] {
+    if (!this._decodePrefixLengths) {
+      this._decodePrefixLengths = buildDecodePrefixLengths(this._raw);
+    }
+    return this._decodePrefixLengths;
+  }
+
+  /** 将「归一化 value 的索引」换算为「原始文档 offset」。 */
+  private rawOffsetAt(index: number): number {
+    const prefixLengths = this.decodePrefixLengths;
+    const len = prefixLengths.length - 1;
+    const clamped = index < 0 ? 0 : index > len ? len : index;
+    return this._startOffset + prefixLengths[clamped];
+  }
+
+  /** 文本内容（归一化，用于匹配） */
   get value(): string {
     return this._value;
   }
@@ -93,52 +184,56 @@ export class TextScanner {
   }
 
   /**
-   * 计算文本内某个 index 对应的文档位置
+   * 计算归一化文本内某个 index 对应的「原始文档」位置。
    *
-   * 使用预计算的换行索引 + 二分查找，复杂度 O(log k)，k = 换行数。
+   * 通过前缀长度映射得到原始切片内的偏移，再基于原始切片换行索引换算行列号。
    */
   private positionAt(index: number): CharPosition {
-    const lb = this.lineBreakIndices;
+    const rawRel = this.rawOffsetAt(index) - this._startOffset;
+    const lb = this.rawLineBreakIndices;
     let lo = 0;
     let hi = lb.length;
     while (lo < hi) {
       const mid = (lo + hi) >> 1;
-      if (lb[mid] < index) {
+      if (lb[mid] < rawRel) {
         lo = mid + 1;
       }
       else {
         hi = mid;
       }
     }
-    // lo = 换行符在 index 之前的数量（index 处的换行符不算）
+    // lo = 换行符在 rawRel 之前的数量（rawRel 处的换行符不算）
     const line = this._startLine + lo;
     const column = lo === 0
-      ? this._startColumn + index
-      : index - lb[lo - 1];
+      ? this._startColumn + rawRel
+      : rawRel - lb[lo - 1];
+
+    const clampedIndex = Math.max(0, Math.min(index, this.decodePrefixLengths.length - 1));
 
     return {
       line,
       column,
-      offset: this._startOffset + index
+      offset: this._startOffset + this.decodePrefixLengths[clampedIndex]
     };
   }
 
   /**
-   * 将文本内相对 index + length 转换为绝对位置信息
+   * 将文本内相对 index + length 转换为绝对位置信息（基于原始文档）。
    */
   matchAt(index: number, length: number): TextMatch {
     const start = this.positionAt(index);
-    const end = this.positionAt(index + length);
-    const endOffset = start.offset + length;
+    const endPos = this.positionAt(index + length);
+    const startOffset = this.rawOffsetAt(index);
+    const endOffset = this.rawOffsetAt(index + length);
 
     return {
       index,
       length,
       loc: {
-        start: { line: start.line, column: start.column, offset: start.offset },
-        end: { line: end.line, column: end.column, offset: endOffset }
+        start: { line: start.line, column: start.column, offset: startOffset },
+        end: { line: endPos.line, column: endPos.column, offset: endOffset }
       },
-      absoluteRange: [start.offset, endOffset]
+      absoluteRange: [startOffset, endOffset]
     };
   }
 
@@ -193,7 +288,10 @@ export class TextScanner {
   }
 
   /**
-   * 逐字符迭代，自动跟踪 line/column
+   * 逐字符迭代，自动跟踪 line/column（均基于原始文档）。
+   *
+   * 注意：回调收到的 `offset` 是原始文档 offset，`index` 仍是归一化 value
+   * 索引，便于规则基于 `value` 做字符判断。
    *
    * @example
    * scanner.forEachChar((char, i, pos) => {
@@ -206,23 +304,27 @@ export class TextScanner {
    * })
    */
   forEachChar(callback: (char: string, index: number, pos: CharPosition) => void): void {
+    const prefixLengths = this.decodePrefixLengths;
     let line = this._startLine;
     let column = this._startColumn;
 
     for (let i = 0; i < this._value.length; i++) {
       const char = this._value[i];
-      callback(char, i, {
-        line,
-        column,
-        offset: this._startOffset + i
-      });
+      const runStart = prefixLengths[i];
+      const runEnd = prefixLengths[i + 1];
+      const offset = this._startOffset + runStart;
 
-      if (char === '\n') {
-        line++;
-        column = 1;
-      }
-      else {
-        column++;
+      callback(char, i, { line, column, offset });
+
+      // 沿原始切片推进行列号（不构建二分换行索引，保持 issue #176 诊断行为）。
+      for (let r = runStart; r < runEnd; r++) {
+        if (this._raw[r] === '\n') {
+          line++;
+          column = 1;
+        }
+        else {
+          column++;
+        }
       }
     }
   }

--- a/src/utils/text-scanner.ts
+++ b/src/utils/text-scanner.ts
@@ -23,27 +23,54 @@ const ESCAPABLE_PUNCTUATION = new Set('!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'.split
  *
  * @see issue #155
  */
-const buildDecodePrefixLengths = (raw: string): number[] => {
+interface EntityReference {
+  decoded: string
+  endOffset: number
+}
+
+const collectEntityReferences = (raw: string): Map<number, EntityReference> => {
+  const references = new Map<number, EntityReference>();
+  const reference = (
+    decoded: string,
+    location: { start: { offset: number }; end: { offset: number } }
+  ) => {
+    references.set(location.start.offset, {
+      decoded,
+      endOffset: location.end.offset
+    });
+  };
+
+  // 单次解析整个原始切片，避免为每个 `&` 重复扫描剩余文本。
+  parseEntities(raw, { text: () => {}, reference: reference as never });
+  return references;
+};
+
+const buildDecodePrefixLengths = (raw: string, value: string): number[] => {
   const prefixLengths: number[] = [0];
+  const entityReferences = collectEntityReferences(raw);
   let i = 0;
+  let valueIndex = 0;
   while (i < raw.length) {
     const char = raw[i];
 
-    if (char === '&') {
-      // 注意：parse-entities 的 reference 回调第三个参数类型声明为 Location，
-      // 但运行时实际传入的是该字符引用的原始源片段字符串（见 micromark 实现）。
-      let entityRaw: string | '' = '';
-      const refHandler = (_value: string, _pos: unknown, full: unknown) => {
-        entityRaw = typeof full === 'string' ? full : '';
-      };
-      parseEntities(raw.slice(i), { text: () => {}, reference: refHandler as never });
-      if (entityRaw !== '' && raw.startsWith(entityRaw, i)) {
-        prefixLengths.push(prefixLengths[prefixLengths.length - 1] + entityRaw.length);
-        i += entityRaw.length;
-        continue;
+    const entityReference = entityReferences.get(i);
+    if (entityReference) {
+      const rawLength = entityReference.endOffset - i;
+      // 大多数实体的解码结果可直接和 node.value 对齐。旧版解析器对部分
+      // astral numeric reference 只保留一个 UTF-16 code unit，因此不一致时
+      // 以 node.value 的一个 code unit 为准。
+      const decodedLength = value.startsWith(entityReference.decoded, valueIndex)
+        ? entityReference.decoded.length
+        : 1;
+
+      for (let unit = 0; unit < decodedLength; unit++) {
+        // 一个实体产生多个 code unit 时，它们都起始于同一原始位置；只有
+        // 最后一个 unit 的结束边界越过完整实体源文本。
+        prefixLengths.push(prefixLengths[prefixLengths.length - 1]
+          + (unit === decodedLength - 1 ? rawLength : 0));
       }
-      prefixLengths.push(prefixLengths[prefixLengths.length - 1] + 1);
-      i++;
+      i = entityReference.endOffset;
+      valueIndex += decodedLength;
       continue;
     }
 
@@ -51,11 +78,13 @@ const buildDecodePrefixLengths = (raw: string): number[] => {
       // 转义序列占两个原始字符，但归一化后只占一个字符。
       prefixLengths.push(prefixLengths[prefixLengths.length - 1] + 2);
       i += 2;
+      valueIndex++;
       continue;
     }
 
     prefixLengths.push(prefixLengths[prefixLengths.length - 1] + 1);
     i++;
+    valueIndex++;
   }
   return prefixLengths;
 };
@@ -164,7 +193,7 @@ export class TextScanner {
   /** 归一化索引 -> 原始文档前缀长度映射，首次需要时构建（见 issue #155）。 */
   private get decodePrefixLengths(): number[] {
     if (!this._decodePrefixLengths) {
-      this._decodePrefixLengths = buildDecodePrefixLengths(this._raw);
+      this._decodePrefixLengths = buildDecodePrefixLengths(this._raw, this._value);
     }
     return this._decodePrefixLengths;
   }

--- a/src/utils/text-scanner.ts
+++ b/src/utils/text-scanner.ts
@@ -59,6 +59,26 @@ const getLegacyNumericEntityDecode = (source: string): string | undefined => {
   return Number.isNaN(codePoint) ? undefined : String.fromCharCode(codePoint);
 };
 
+const getParserNumericEntityDecode = (source: string): string | undefined => {
+  const match = /^&#(?:([0-9]+)|[xX]([0-9A-Fa-f]+));$/.exec(source);
+  if (!match) {
+    return undefined;
+  }
+
+  const codePoint = Number.parseInt(match[1] ?? match[2], match[1] ? 10 : 16);
+  const invalid = codePoint < 0x09
+    || codePoint === 0x0B
+    || (codePoint > 0x0D && codePoint < 0x20)
+    || (codePoint > 0x7E && codePoint < 0xA0)
+    || (codePoint > 0xD7FF && codePoint < 0xE000)
+    || (codePoint > 0xFDCF && codePoint < 0xFDF0)
+    || (codePoint & 0xFFFF) === 0xFFFF
+    || (codePoint & 0xFFFF) === 0xFFFE
+    || codePoint > 0x10FFFF;
+
+  return invalid ? '\uFFFD' : String.fromCharCode(codePoint);
+};
+
 const collectEntityReferences = (raw: string): Map<number, EntityReference> => {
   const references = new Map<number, EntityReference>();
   const reference = (
@@ -134,7 +154,11 @@ const buildDecodePrefixLengths = (raw: string, value: string): number[] => {
     const entityReference = entityReferences.get(rawIndex);
     if (entityReference) {
       const source = raw.slice(rawIndex, entityReference.endOffset);
-      const decodedCandidates = new Set([entityReference.decoded, getLegacyNumericEntityDecode(source)]);
+      const decodedCandidates = new Set([
+        entityReference.decoded,
+        getLegacyNumericEntityDecode(source),
+        getParserNumericEntityDecode(source)
+      ]);
       for (const decoded of decodedCandidates) {
         if (decoded && value.startsWith(decoded, valueIndex)) {
           enqueue(rawIndex, valueIndex, entityReference.endOffset, valueIndex + decoded.length);

--- a/src/utils/text-scanner.ts
+++ b/src/utils/text-scanner.ts
@@ -41,7 +41,11 @@ const collectEntityReferences = (raw: string): Map<number, EntityReference> => {
   };
 
   // 单次解析整个原始切片，避免为每个 `&` 重复扫描剩余文本。
-  parseEntities(raw, { text: () => {}, reference: reference as never });
+  parseEntities(raw, {
+    nonTerminated: false,
+    text: () => {},
+    reference: reference as never
+  });
   return references;
 };
 
@@ -86,6 +90,11 @@ const buildDecodePrefixLengths = (raw: string, value: string): number[] => {
     i++;
     valueIndex++;
   }
+
+  if (prefixLengths.length !== value.length + 1
+    || prefixLengths[prefixLengths.length - 1] !== raw.length) {
+    throw new RangeError('TextScanner raw/normalized offset mapping is inconsistent');
+  }
   return prefixLengths;
 };
 
@@ -123,10 +132,15 @@ export interface TextMatch {
 }
 
 /** 逐字符迭代时的位置信息 */
-export interface CharPosition {
+interface DocumentPosition {
   line: number
   column: number
   offset: number
+}
+
+export interface CharPosition extends DocumentPosition {
+  /** 当前归一化字符在原始文档中的结束 offset */
+  endOffset: number
 }
 
 /**
@@ -201,9 +215,10 @@ export class TextScanner {
   /** 将「归一化 value 的索引」换算为「原始文档 offset」。 */
   private rawOffsetAt(index: number): number {
     const prefixLengths = this.decodePrefixLengths;
-    const len = prefixLengths.length - 1;
-    const clamped = index < 0 ? 0 : index > len ? len : index;
-    return this._startOffset + prefixLengths[clamped];
+    if (!Number.isInteger(index) || index < 0 || index >= prefixLengths.length) {
+      throw new RangeError(`TextScanner index out of range: ${index}`);
+    }
+    return this._startOffset + prefixLengths[index];
   }
 
   /** 文本内容（归一化，用于匹配） */
@@ -221,7 +236,7 @@ export class TextScanner {
    *
    * 通过前缀长度映射得到原始切片内的偏移，再基于原始切片换行索引换算行列号。
    */
-  private positionAt(index: number): CharPosition {
+  private positionAt(index: number): DocumentPosition {
     const rawRel = this.rawOffsetAt(index) - this._startOffset;
     const lb = this.rawLineBreakIndices;
     let lo = 0;
@@ -241,12 +256,10 @@ export class TextScanner {
       ? this._startColumn + rawRel
       : rawRel - lb[lo - 1];
 
-    const clampedIndex = Math.max(0, Math.min(index, this.decodePrefixLengths.length - 1));
-
     return {
       line,
       column,
-      offset: this._startOffset + this.decodePrefixLengths[clampedIndex]
+      offset: this._startOffset + this.decodePrefixLengths[index]
     };
   }
 
@@ -347,7 +360,12 @@ export class TextScanner {
       const runEnd = prefixLengths[i + 1];
       const offset = this._startOffset + runStart;
 
-      callback(char, i, { line, column, offset });
+      callback(char, i, {
+        line,
+        column,
+        offset,
+        endOffset: this._startOffset + runEnd
+      });
 
       // 沿原始切片推进行列号（不构建二分换行索引，保持 issue #176 诊断行为）。
       for (let r = runStart; r < runEnd; r++) {

--- a/src/utils/text-scanner.ts
+++ b/src/utils/text-scanner.ts
@@ -28,16 +28,50 @@ interface EntityReference {
   endOffset: number
 }
 
+interface AlignmentTransition {
+  previousKey: string
+  rawStart: number
+  rawEnd: number
+  valueLength: number
+}
+
+const isCommonMarkNumericEntity = (source: string): boolean => {
+  const decimal = /^&#([0-9]+);$/.exec(source);
+  if (decimal) {
+    return decimal[1].length <= 7;
+  }
+
+  const hexadecimal = /^&#[xX]([0-9A-Fa-f]+);$/.exec(source);
+  if (hexadecimal) {
+    return hexadecimal[1].length <= 6;
+  }
+
+  return true;
+};
+
+const getLegacyNumericEntityDecode = (source: string): string | undefined => {
+  const match = /^&#(?:([0-9]+)|[xX]([0-9A-Fa-f]+));$/.exec(source);
+  if (!match) {
+    return undefined;
+  }
+
+  const codePoint = Number.parseInt(match[1] ?? match[2], match[1] ? 10 : 16);
+  return Number.isNaN(codePoint) ? undefined : String.fromCharCode(codePoint);
+};
+
 const collectEntityReferences = (raw: string): Map<number, EntityReference> => {
   const references = new Map<number, EntityReference>();
   const reference = (
     decoded: string,
     location: { start: { offset: number }; end: { offset: number } }
   ) => {
-    references.set(location.start.offset, {
-      decoded,
-      endOffset: location.end.offset
-    });
+    const source = raw.slice(location.start.offset, location.end.offset);
+    if (isCommonMarkNumericEntity(source)) {
+      references.set(location.start.offset, {
+        decoded,
+        endOffset: location.end.offset
+      });
+    }
   };
 
   // 单次解析整个原始切片，避免为每个 `&` 重复扫描剩余文本。
@@ -50,51 +84,86 @@ const collectEntityReferences = (raw: string): Map<number, EntityReference> => {
 };
 
 const buildDecodePrefixLengths = (raw: string, value: string): number[] => {
-  const prefixLengths: number[] = [0];
   const entityReferences = collectEntityReferences(raw);
-  let i = 0;
-  let valueIndex = 0;
-  while (i < raw.length) {
-    const char = raw[i];
+  const stateKey = (rawIndex: number, valueIndex: number) => `${rawIndex}:${valueIndex}`;
+  const startKey = stateKey(0, 0);
+  const targetKey = stateKey(raw.length, value.length);
+  const visited = new Set<string>([startKey]);
+  const transitions = new Map<string, AlignmentTransition>();
+  const queue: Array<{ rawIndex: number; valueIndex: number }> = [{ rawIndex: 0, valueIndex: 0 }];
 
-    const entityReference = entityReferences.get(i);
+  const enqueue = (
+    rawStart: number,
+    valueStart: number,
+    rawEnd: number,
+    valueEnd: number
+  ) => {
+    const key = stateKey(rawEnd, valueEnd);
+    if (visited.has(key)) {
+      return;
+    }
+
+    visited.add(key);
+    transitions.set(key, {
+      previousKey: stateKey(rawStart, valueStart),
+      rawStart,
+      rawEnd,
+      valueLength: valueEnd - valueStart
+    });
+    queue.push({ rawIndex: rawEnd, valueIndex: valueEnd });
+  };
+
+  for (let cursor = 0; cursor < queue.length; cursor++) {
+    const { rawIndex, valueIndex } = queue[cursor];
+    if (rawIndex === raw.length && valueIndex === value.length) {
+      break;
+    }
+
+    if (rawIndex < raw.length && valueIndex < value.length && raw[rawIndex] === value[valueIndex]) {
+      enqueue(rawIndex, valueIndex, rawIndex + 1, valueIndex + 1);
+    }
+
+    if (raw[rawIndex] === '\\'
+      && rawIndex + 1 < raw.length
+      && valueIndex < value.length
+      && ESCAPABLE_PUNCTUATION.has(raw[rawIndex + 1])
+      && raw[rawIndex + 1] === value[valueIndex]) {
+      enqueue(rawIndex, valueIndex, rawIndex + 2, valueIndex + 1);
+    }
+
+    const entityReference = entityReferences.get(rawIndex);
     if (entityReference) {
-      const rawLength = entityReference.endOffset - i;
-      // 大多数实体的解码结果可直接和 node.value 对齐。旧版解析器对部分
-      // astral numeric reference 只保留一个 UTF-16 code unit，因此不一致时
-      // 以 node.value 的一个 code unit 为准。
-      const decodedLength = value.startsWith(entityReference.decoded, valueIndex)
-        ? entityReference.decoded.length
-        : 1;
-
-      for (let unit = 0; unit < decodedLength; unit++) {
-        // 一个实体产生多个 code unit 时，它们都起始于同一原始位置；只有
-        // 最后一个 unit 的结束边界越过完整实体源文本。
-        prefixLengths.push(prefixLengths[prefixLengths.length - 1]
-          + (unit === decodedLength - 1 ? rawLength : 0));
+      const source = raw.slice(rawIndex, entityReference.endOffset);
+      const decodedCandidates = new Set([entityReference.decoded, getLegacyNumericEntityDecode(source)]);
+      for (const decoded of decodedCandidates) {
+        if (decoded && value.startsWith(decoded, valueIndex)) {
+          enqueue(rawIndex, valueIndex, entityReference.endOffset, valueIndex + decoded.length);
+        }
       }
-      i = entityReference.endOffset;
-      valueIndex += decodedLength;
-      continue;
     }
-
-    if (char === '\\' && i + 1 < raw.length && ESCAPABLE_PUNCTUATION.has(raw[i + 1])) {
-      // 转义序列占两个原始字符，但归一化后只占一个字符。
-      prefixLengths.push(prefixLengths[prefixLengths.length - 1] + 2);
-      i += 2;
-      valueIndex++;
-      continue;
-    }
-
-    prefixLengths.push(prefixLengths[prefixLengths.length - 1] + 1);
-    i++;
-    valueIndex++;
   }
 
-  if (prefixLengths.length !== value.length + 1
-    || prefixLengths[prefixLengths.length - 1] !== raw.length) {
+  if (!visited.has(targetKey)) {
     throw new RangeError('TextScanner raw/normalized offset mapping is inconsistent');
   }
+
+  const matchedTransitions: AlignmentTransition[] = [];
+  for (let key = targetKey; key !== startKey;) {
+    const transition = transitions.get(key);
+    if (!transition) {
+      throw new RangeError('TextScanner offset mapping is missing an alignment transition');
+    }
+    matchedTransitions.push(transition);
+    key = transition.previousKey;
+  }
+
+  const prefixLengths: number[] = [0];
+  for (const transition of matchedTransitions.reverse()) {
+    for (let unit = 1; unit <= transition.valueLength; unit++) {
+      prefixLengths.push(unit === transition.valueLength ? transition.rawEnd : transition.rawStart);
+    }
+  }
+
   return prefixLengths;
 };
 


### PR DESCRIPTION
## Summary

修复 `TextScanner` 在 Markdown 转义字符和 HTML character reference 场景下，报告位置与自动修复范围发生偏移的问题。

解析器返回的 `node.value` 已经过归一化处理，例如：

* `\(` → `(`
* `\\` → `\`
* `&amp;` → `&`
* `&#40;` → `(`

但 `node.position.offset` 仍然指向原始 Markdown。此前 `TextScanner` 直接使用 `node.value` 的索引计算位置，而 fixer 操作的是原始文档，因此两者长度不一致时会出现：

* 报告位置错误；
* fix 替换到错误字符；
* fix 只替换实体或转义序列的一部分；
* 在部分输入中 fix 成为空操作。

该问题可由 issue #155 中包含转义反斜杠和半角括号的文本复现。

## Changes

### Raw-to-normalized offset alignment

`TextScanner` 现在同时持有：

* 解析器提供的归一化文本 `node.value`；
* 从原始 Markdown 中截取的节点源文本。

新增对齐逻辑，在两者之间构建：

```text
normalized text index → raw Markdown offset
```

映射过程支持：

* 普通字符一对一映射；
* CommonMark 反斜杠转义；
* 命名 character reference；
* 十进制和十六进制 numeric character reference；
* 解码为多个 UTF-16 code unit 的 character reference；
* parser 与 `parse-entities` 在非法码点、控制字符及旧版本行为上的差异。

由于相同的原始文本在不同 Markdown 上下文中不一定会被解码，例如 autolink 中的 `&amp;`，对齐实现不会预设实体一定已解码，而是通过状态搜索选择能够完整匹配实际 `node.value` 的路径。

### Complete raw character ranges

`CharPosition` 新增 `endOffset`，表示当前归一化字符在原始 Markdown 中的结束位置。

使用 `TextScanner` 的规则现在可以操作完整原始范围，而不再假设一个归一化字符始终对应一个原始字符。

例如：

```md
中文\(test\)中文
中文&#40;test&#41;中文
```

半角括号修复后均能正确得到：

```md
中文（test）中文
```

### Rule updates

以下规则现在向 `TextScanner` 传入 `context.markdown`，以使用原始文档坐标：

* `no-half-width-punctuation`
* `no-full-width-number`
* `use-standard-ellipsis`
* `space-around-number`
* `no-special-characters`

其中：

* 字符替换使用完整的 `[offset, endOffset]` 范围；
* 字符后的插入操作使用 `endOffset`；
* 报告的 `loc` 通过 `TextScanner.matchAt()` 生成。

### Dependency

将 `parse-entities` 声明为直接依赖，用于收集可能的 character reference 候选。

## Test plan

新增回归测试覆盖：

* issue #155 中转义反斜杠与全角、半角括号混合的场景；
* 普通命名 character reference；
* 连续多个不同 character reference；
* 解码为多个 UTF-16 code unit 的 character reference；
* 被修复字符自身由反斜杠转义产生；
* 被修复字符自身由 numeric character reference 产生；
* numeric character reference 前后的空格插入；
* 无分号的 entity-like 文本；
* URI autolink 和 GFM autolink 中未被解析器解码的实体文本；
* 超过 CommonMark 长度限制的 numeric character reference；
* 控制字符、surrogate、noncharacter 等被 parser 归一化为 replacement character 的 numeric character reference；
* fix 后再次 lint 不再产生相同错误。

CI 已在 Node.js 20、22 和 24 上通过：

* lint
* typecheck
* test
* build
* package contract check

Closes #155
