### PR TITLE
feat(core): consume parser source maps

### DIFF
--- a/__tests__/unit/source-map-integration.spec.ts
+++ b/__tests__/unit/source-map-integration.spec.ts
@@ -1,13 +1,51 @@
 import { runLint } from '../../src/core/run-lint';
 import { lintMarkdownInternal } from '../../src/core/lint-markdown';
 import { RuleExecutionFailure } from '../../src/utils/rule-execution-errors';
-import { TextScanner } from '../../src/utils/text-scanner';
+import { parseMdWithSourceMap } from '@lint-md/parser';
+import { TextScanner, registerTextNodeSourceMap } from '../../src/utils/text-scanner';
 import noHalfWidthPunctuation from '../../src/rules/no-half-width-punctuation';
 import type { LintMdRule } from '../../src/types';
 
 const halfWidthConfig = [{ rule: noHalfWidthPunctuation }];
 
 describe('parser source-map integration', () => {
+  test('does not resolve source ranges for uninspected code points', () => {
+    const node = {
+      type: 'text',
+      value: 'abc',
+      position: {
+        start: { line: 1, column: 1, offset: 0 },
+        end: { line: 1, column: 4, offset: 3 }
+      }
+    };
+    const getSourceRange = jest.fn((_node: unknown, _start: number, _end: number) => node.position);
+    registerTextNodeSourceMap(
+      { type: 'root', children: [node], position: node.position } as any,
+      { getSourceRange } as any
+    );
+
+    new TextScanner(node as any).forEachChar(() => {});
+    expect(getSourceRange).not.toHaveBeenCalled();
+
+    const positions: Array<{ endOffset: number }> = [];
+    new TextScanner(node as any).forEachChar((_char, _index, pos) => {
+      positions.push(pos);
+    });
+    expect(getSourceRange).not.toHaveBeenCalled();
+    positions.forEach(pos => void pos.endOffset);
+    expect(getSourceRange).toHaveBeenCalledTimes(3);
+    expect(getSourceRange.mock.calls.map(([, start, end]) => [start, end]))
+      .toEqual([[0, 1], [1, 2], [2, 3]]);
+  });
+
+  test('keeps inlineCode on the identity fallback instead of registering an unsupported source map', () => {
+    const { ast, sourceMap } = parseMdWithSourceMap('`code`');
+    registerTextNodeSourceMap(ast, sourceMap);
+    const inlineCode = (ast.children[0] as any).children[0];
+    expect(inlineCode.type).toBe('inlineCode');
+    expect(new TextScanner(inlineCode).matchAt(0, 1).absoluteRange).toEqual([0, 1]);
+  });
+
   test.each([
     ['escaped', '中文\\(test\\)中文', '中文（test）中文'],
     ['numeric entity', '中文&#40;test&#41;中文', '中文（test）中文']

--- a/__tests__/unit/source-map-integration.spec.ts
+++ b/__tests__/unit/source-map-integration.spec.ts
@@ -1,0 +1,95 @@
+import { runLint } from '../../src/core/run-lint';
+import { lintMarkdownInternal } from '../../src/core/lint-markdown';
+import { RuleExecutionFailure } from '../../src/utils/rule-execution-errors';
+import { TextScanner } from '../../src/utils/text-scanner';
+import noHalfWidthPunctuation from '../../src/rules/no-half-width-punctuation';
+import type { LintMdRule } from '../../src/types';
+
+const halfWidthConfig = [{ rule: noHalfWidthPunctuation }];
+
+describe('parser source-map integration', () => {
+  test.each([
+    ['escaped', '中文\\(test\\)中文', '中文（test）中文'],
+    ['numeric entity', '中文&#40;test&#41;中文', '中文（test）中文']
+  ])('%s fixes the complete source construct and converges', (_name, input, expected) => {
+    const first = lintMarkdownInternal(input, halfWidthConfig, true);
+    expect(first.fixedResult?.result).toBe(expected);
+
+    const second = lintMarkdownInternal(first.fixedResult!.result, halfWidthConfig, false);
+    expect(second.lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+
+  test('diagnostic offsets and fix ranges are resolved by the same source-map range', () => {
+    const input = '中文&#40;test&#41;中文';
+    const { ruleManager } = runLint(input, halfWidthConfig);
+    const reports = ruleManager.getReportData();
+    const fixes = ruleManager.getAllFixes();
+
+    expect(reports).toHaveLength(2);
+    expect(fixes).toHaveLength(2);
+    for (let i = 0; i < reports.length; i++) {
+      expect(reports[i].loc.start.offset).toBe(fixes[i].range[0]);
+      expect(reports[i].loc.end.offset).toBe(fixes[i].range[1]);
+    }
+  });
+
+  test.each([
+    ['CR', '\r', 4],
+    ['CRLF', '\r\n', 5],
+    ['LF', '\n', 4]
+  ])('%s uses parser line/column positions and raw fix offsets', (_name, newline, expectedOffset) => {
+    const input = `a${newline}中文(test)中文`;
+    const { ruleManager } = runLint(input, halfWidthConfig);
+    const [report] = ruleManager.getReportData();
+    const [fix] = ruleManager.getAllFixes();
+
+    expect(report.loc.start).toMatchObject({ line: 2, column: 3, offset: expectedOffset });
+    expect(fix.range).toEqual([report.loc.start.offset, report.loc.end.offset]);
+  });
+
+  test('an entity decoded to two UTF-16 units is scanned and fixed once as an atomic source range', () => {
+    const atomicRule: LintMdRule = {
+      meta: { name: 'atomic-entity' },
+      create: context => ({
+        text: node => {
+          const scanner = new TextScanner(node as any);
+          scanner.forEachChar((char, index) => {
+            if (char === '𝔄') {
+              const match = scanner.matchAt(index, char.length);
+              context.report({
+                loc: match.loc,
+                message: 'replace atomic entity',
+                fix: fixer => fixer.replaceTextRange(match.absoluteRange, 'A')
+              });
+            }
+          });
+        }
+      })
+    };
+    const result = lintMarkdownInternal('中文&Afr;中文', [{ rule: atomicRule }], true);
+    expect(result.lintResult.ruleManager.getReportData()).toHaveLength(1);
+    expect(result.fixedResult?.result).toBe('中文A中文');
+  });
+
+  test('source-map consistency errors are collected and do not produce fixes', () => {
+    const mutatingRule: LintMdRule = {
+      meta: { name: 'mutate-text-node' },
+      create: context => ({
+        text: node => {
+          (node as { value: string }).value = 'changed';
+          new TextScanner(node as any).matchAt(0, 1);
+          context.report({ loc: node.position, message: 'unreachable' });
+        }
+      })
+    };
+    const input = '中文(test)中文';
+    const result = runLint(input, [{ rule: mutatingRule }]);
+    expect(result.executionErrors).toEqual([
+      expect.objectContaining({ ruleName: 'mutate-text-node', phase: 'selector' })
+    ]);
+    expect(result.ruleManager.getAllFixes()).toEqual([]);
+    expect(input).toBe('中文(test)中文');
+    expect(() => runLint(input, [{ rule: mutatingRule }], { ruleErrorPolicy: 'strict' }))
+      .toThrow(RuleExecutionFailure);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "chinese"
   ],
   "dependencies": {
-    "@lint-md/parser": "~0.1.2",
-    "parse-entities": "^2.0.0"
+    "@lint-md/parser": "~0.1.3"
   },
   "devDependencies": {
     "@attachments/eslint-config": "^0.3.3",

--- a/scripts/benchmark-memory.mjs
+++ b/scripts/benchmark-memory.mjs
@@ -14,7 +14,8 @@
  * CLI params (parent mode):
  *   --bytes <n>       Input size in bytes per case (default: 65536)
  *   --shape <name>    Input shape: long-paragraph | many-paragraphs | mixed-markdown |
- *                     high-match-density | low-match-density | overlapping-fixes
+ *                     high-match-density | low-match-density | overlapping-fixes |
+ *                     entity-dense | escape-dense
  *                     (default: long-paragraph)
  *   --runs <n>        Measured runs per case (default: 5)
  *   --warmup <n>      Warmup runs before measurement (default: 2)
@@ -288,6 +289,7 @@ function runChildCase(opts) {
 const ALL_SHAPES = [
   'long-paragraph', 'many-paragraphs', 'mixed-markdown',
   'high-match-density', 'low-match-density', 'overlapping-fixes',
+  'entity-dense', 'escape-dense',
 ];
 const ALL_SIZES = [64 * 1024, 256 * 1024, 1024 * 1024];
 
@@ -391,6 +393,16 @@ function generateOverlappingFixes(targetBytes) {
   return repeatToSize(base, targetBytes);
 }
 
+// Every entity / escape becomes a distinct parser source-map segment. These
+// shapes guard against accidentally resolving a range for every scanned unit.
+function generateEntityDense(targetBytes) {
+  return repeatToSize('中文&amp;文本', targetBytes);
+}
+
+function generateEscapeDense(targetBytes) {
+  return repeatToSize('中文\\(文本\\)中文', targetBytes);
+}
+
 function generateInput(shape, bytes) {
   const generators = {
     'long-paragraph': generateLongParagraph,
@@ -399,6 +411,8 @@ function generateInput(shape, bytes) {
     'high-match-density': generateHighMatchDensity,
     'low-match-density': generateLowMatchDensity,
     'overlapping-fixes': generateOverlappingFixes,
+    'entity-dense': generateEntityDense,
+    'escape-dense': generateEscapeDense,
   };
   const gen = generators[shape];
   if (!gen) throw new Error(`Unknown shape: ${shape}`);

--- a/scripts/benchmark-memory.mjs
+++ b/scripts/benchmark-memory.mjs
@@ -46,7 +46,7 @@ if (process.env.BENCHMARK_CHILD === '1') {
 
   // Use CJS build (ESM build has extensionless imports that break Node.js resolution)
   const require_ = createRequire(import.meta.url);
-  const { parseMd } = require_('@lint-md/parser');
+  const { parseMdWithSourceMap } = require_('@lint-md/parser');
   const core = require_('../lib/index.js');
   const { runLint } = require_('../lib/core/run-lint.js');
   const scannerDiag = require_('../lib/utils/text-scanner.js');
@@ -74,7 +74,7 @@ if (process.env.BENCHMARK_CHILD === '1') {
   }
 
   function runParserOnly() {
-    parseMd(input);
+    parseMdWithSourceMap(input);
     return { reportCount: 0, fixCount: 0, runLintCalls: 0 };
   }
 

--- a/src/core/run-lint.ts
+++ b/src/core/run-lint.ts
@@ -1,9 +1,10 @@
-import { parseMd } from '@lint-md/parser';
+import { parseMdWithSourceMap } from '@lint-md/parser';
 import type { LintMdRuleWithOptions, RunLintOptions } from '../types';
 import { createEmitter } from '../utils/emitter';
 import { createTraverser } from '../utils/traverser';
 import { createRuleManager } from '../utils/rule-manager';
 import { createRuleErrorCollector } from '../utils/rule-execution-errors';
+import { registerTextNodeSourceMap } from '../utils/text-scanner';
 
 /**
  * 基于各种 rules 对 Markdown 文本进行校验
@@ -29,8 +30,10 @@ export const runLint = (
   // 先创建收集器，再创建 ruleManager：getAllFixes() 内的 fix() 阶段错误才能接入收集器。
   const collector = createRuleErrorCollector(policy, round);
 
-  // 将 markdown 转换成 ast
-  const ast = parseMd(markdown);
+  // Parser owns normalized-text -> original-Markdown mapping.  Register it
+  // internally for TextScanner without changing the third-party rule context.
+  const { ast, sourceMap } = parseMdWithSourceMap(markdown);
+  registerTextNodeSourceMap(ast, sourceMap);
 
   // 全局规则管理器（传入 collector，使 fix 阶段捕获生效）
   const ruleManager = createRuleManager(markdown, collector);

--- a/src/rules/no-full-width-number.ts
+++ b/src/rules/no-full-width-number.ts
@@ -21,7 +21,7 @@ const noFullWidthNumber: LintMdRule = {
   create: (context) => {
     return {
       text: (node: PositionedTextNode) => {
-        const scanner = new TextScanner(node, context.markdown);
+        const scanner = new TextScanner(node);
         const matches = scanner.findAllMatches(/[０-９]+/g);
 
         matches.forEach((m) => {

--- a/src/rules/no-half-width-punctuation.ts
+++ b/src/rules/no-half-width-punctuation.ts
@@ -66,7 +66,7 @@ const noHalfWidthPunctuation: LintMdRule = {
   create: (context) => {
     return {
       text: (node: PositionedTextNode) => {
-        const scanner = new TextScanner(node, context.markdown);
+        const scanner = new TextScanner(node);
         const { value } = scanner;
 
         // 预处理：找出需要转换的括号对
@@ -81,7 +81,7 @@ const noHalfWidthPunctuation: LintMdRule = {
         }
 
         // 逐字符扫描
-        scanner.forEachChar((char, i, pos) => {
+        scanner.forEachChar((char, i) => {
           const fullChar = HALF_TO_FULL[char];
           if (!fullChar)
             return;
@@ -96,7 +96,7 @@ const noHalfWidthPunctuation: LintMdRule = {
             context.report({
               loc: match.loc,
               message: `不应在中文中使用半角标点"${char}"，请使用全角"${fullChar}"`,
-              fix: fixer => fixer.replaceTextRange([pos.offset, pos.endOffset], fullChar)
+              fix: fixer => fixer.replaceTextRange(match.absoluteRange, fullChar)
             });
           }
         });

--- a/src/rules/no-special-characters.ts
+++ b/src/rules/no-special-characters.ts
@@ -11,7 +11,7 @@ const noSpecialCharacters: LintMdRule = {
   create: (context) => {
     return {
       text: (node: PositionedTextNode) => {
-        const scanner = new TextScanner(node, context.markdown);
+        const scanner = new TextScanner(node);
 
         SPECIAL_CHARACTERS.forEach((sc) => {
           const matches = scanner.findAllOccurrences(sc);

--- a/src/rules/space-around-number.ts
+++ b/src/rules/space-around-number.ts
@@ -26,7 +26,7 @@ const spaceAroundNumber: LintMdRule = {
   create: (context) => {
     return {
       text: (node: PositionedTextNode) => {
-        const scanner = new TextScanner(node, context.markdown);
+        const scanner = new TextScanner(node);
         const { value } = scanner;
 
         scanner.forEachChar((char, i, pos) => {

--- a/src/rules/use-standard-ellipsis.ts
+++ b/src/rules/use-standard-ellipsis.ts
@@ -8,7 +8,7 @@ const useStandardEllipsis: LintMdRule = {
   create: (context) => {
     return {
       text: (node: PositionedTextNode) => {
-        const scanner = new TextScanner(node, context.markdown);
+        const scanner = new TextScanner(node);
 
         // 找到所有的 . 组成的省略号
         const dotMatches = scanner.findAllMatches(/\.{4,}/g);

--- a/src/utils/text-scanner.ts
+++ b/src/utils/text-scanner.ts
@@ -19,7 +19,12 @@ export const registerTextNodeSourceMap = (
   sourceMap: MarkdownSourceMap
 ): void => {
   for (const node of getTextNodes(ast)) {
-    sourceMaps.set(node, sourceMap);
+    // Parser 0.1.3 maps text nodes only. inlineCode remains supported by the
+    // scanner's identity fallback, rather than being registered to a map that
+    // would reject it with SourceMapUnavailableError.
+    if (node.type === 'text') {
+      sourceMaps.set(node, sourceMap);
+    }
   }
 };
 
@@ -191,18 +196,27 @@ export class TextScanner {
   forEachChar(callback: (char: string, index: number, pos: CharPosition) => void): void {
     for (let index = 0; index < this._value.length;) {
       const char = String.fromCodePoint(this._value.codePointAt(index)!);
-      const range = this._sourceMap
-        ? this.sourceRange(index, index + char.length)
-        : {
-            start: this.fallbackPointAtLinear(index),
-            end: this.fallbackPointAtLinear(index + char.length)
-          };
-      callback(char, index, {
-        line: range.start.line,
-        column: range.start.column,
-        offset: range.start.offset,
-        endOffset: range.end.offset
-      });
+      const charIndex = index;
+      const charLength = char.length;
+      let range: ReturnType<TextScanner['sourceRange']> | undefined;
+      const getRange = () => {
+        range ??= this._sourceMap
+          ? this.sourceRange(charIndex, charIndex + charLength)
+          : {
+              start: this.fallbackPointAtLinear(charIndex),
+              end: this.fallbackPointAtLinear(charIndex + charLength)
+            };
+        return range;
+      };
+      // Position lookup is deliberately lazy. Most rules inspect the character
+      // first and only need a source range after deciding to report it.
+      const pos = Object.defineProperties({}, {
+        line: { enumerable: true, get: () => getRange().start.line },
+        column: { enumerable: true, get: () => getRange().start.column },
+        offset: { enumerable: true, get: () => getRange().start.offset },
+        endOffset: { enumerable: true, get: () => getRange().end.offset }
+      }) as CharPosition;
+      callback(char, index, pos);
       index += char.length;
     }
   }

--- a/src/utils/text-scanner.ts
+++ b/src/utils/text-scanner.ts
@@ -1,201 +1,28 @@
-import * as parseEntitiesNs from 'parse-entities';
+import type {
+  MarkdownSourceMap,
+  MarkdownTextNode as ParserMarkdownTextNode,
+  PositionedMarkdownRoot
+} from '@lint-md/parser';
 import type { MarkdownTextNode } from './get-text-nodes';
+import { getTextNodes } from './get-text-nodes';
 import { now } from './time';
 
-// parse-entities 使用 `export =`，需兼容 CommonJS 与 ESM 两种产物：
-// 在 ESM 构建下命名空间对象本身不可调用，需取 .default。
-const parseEntities = (parseEntitiesNs as { default?: typeof parseEntitiesNs }).default ?? parseEntitiesNs;
-
-/** CommonMark 可转义标点集合（与解析器一致）。 */
-const ESCAPABLE_PUNCTUATION = new Set('!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'.split(''));
-
 /**
- * 构建「归一化文本索引 -> 原始文档偏移」的前缀长度映射。
- *
- * 解析器返回的 `node.value` 是**已解码/去转义**的文本（如 `\\` -> `\`、
- * `\(` -> `(`、`&amp;` -> `&`），而 `node.position` 的 offset 指向**原始**
- * markdown 文本。两者在出现转义/实体的文本上长度不一致，导致基于
- * `value` 索引推算出的 fix offset 与 `applyFix` 实际操作的原始文档错位。
- *
- * 映射约定：`prefixLengths[k]` = `value[0..k)` 对应的原始文档字符数
- * （含第 0 项 0）。于是 `value[k]` 在原始文档中的字节起点偏移为
- * `node.position.start.offset + prefixLengths[k]`。
- *
- * @see issue #155
+ * The source map is deliberately kept out of LintMdRuleContext.  Rules keep
+ * receiving the same public context, while TextScanner can resolve ranges for
+ * nodes belonging to the AST currently being linted.
  */
-interface EntityReference {
-  decoded: string
-  endOffset: number
-}
+const sourceMaps = new WeakMap<object, MarkdownSourceMap>();
 
-interface AlignmentTransition {
-  previousKey: string
-  rawStart: number
-  rawEnd: number
-  valueLength: number
-}
-
-const isCommonMarkNumericEntity = (source: string): boolean => {
-  const decimal = /^&#([0-9]+);$/.exec(source);
-  if (decimal) {
-    return decimal[1].length <= 7;
+export const registerTextNodeSourceMap = (
+  ast: PositionedMarkdownRoot,
+  sourceMap: MarkdownSourceMap
+): void => {
+  for (const node of getTextNodes(ast)) {
+    sourceMaps.set(node, sourceMap);
   }
-
-  const hexadecimal = /^&#[xX]([0-9A-Fa-f]+);$/.exec(source);
-  if (hexadecimal) {
-    return hexadecimal[1].length <= 6;
-  }
-
-  return true;
 };
 
-const getLegacyNumericEntityDecode = (source: string): string | undefined => {
-  const match = /^&#(?:([0-9]+)|[xX]([0-9A-Fa-f]+));$/.exec(source);
-  if (!match) {
-    return undefined;
-  }
-
-  const codePoint = Number.parseInt(match[1] ?? match[2], match[1] ? 10 : 16);
-  return Number.isNaN(codePoint) ? undefined : String.fromCharCode(codePoint);
-};
-
-const getParserNumericEntityDecode = (source: string): string | undefined => {
-  const match = /^&#(?:([0-9]+)|[xX]([0-9A-Fa-f]+));$/.exec(source);
-  if (!match) {
-    return undefined;
-  }
-
-  const codePoint = Number.parseInt(match[1] ?? match[2], match[1] ? 10 : 16);
-  const invalid = codePoint < 0x09
-    || codePoint === 0x0B
-    || (codePoint > 0x0D && codePoint < 0x20)
-    || (codePoint > 0x7E && codePoint < 0xA0)
-    || (codePoint > 0xD7FF && codePoint < 0xE000)
-    || (codePoint > 0xFDCF && codePoint < 0xFDF0)
-    || (codePoint & 0xFFFF) === 0xFFFF
-    || (codePoint & 0xFFFF) === 0xFFFE
-    || codePoint > 0x10FFFF;
-
-  return invalid ? '\uFFFD' : String.fromCharCode(codePoint);
-};
-
-const collectEntityReferences = (raw: string): Map<number, EntityReference> => {
-  const references = new Map<number, EntityReference>();
-  const reference = (
-    decoded: string,
-    location: { start: { offset: number }; end: { offset: number } }
-  ) => {
-    const source = raw.slice(location.start.offset, location.end.offset);
-    if (isCommonMarkNumericEntity(source)) {
-      references.set(location.start.offset, {
-        decoded,
-        endOffset: location.end.offset
-      });
-    }
-  };
-
-  // 单次解析整个原始切片，避免为每个 `&` 重复扫描剩余文本。
-  parseEntities(raw, {
-    nonTerminated: false,
-    text: () => {},
-    reference: reference as never
-  });
-  return references;
-};
-
-const buildDecodePrefixLengths = (raw: string, value: string): number[] => {
-  const entityReferences = collectEntityReferences(raw);
-  const stateKey = (rawIndex: number, valueIndex: number) => `${rawIndex}:${valueIndex}`;
-  const startKey = stateKey(0, 0);
-  const targetKey = stateKey(raw.length, value.length);
-  const visited = new Set<string>([startKey]);
-  const transitions = new Map<string, AlignmentTransition>();
-  const queue: Array<{ rawIndex: number; valueIndex: number }> = [{ rawIndex: 0, valueIndex: 0 }];
-
-  const enqueue = (
-    rawStart: number,
-    valueStart: number,
-    rawEnd: number,
-    valueEnd: number
-  ) => {
-    const key = stateKey(rawEnd, valueEnd);
-    if (visited.has(key)) {
-      return;
-    }
-
-    visited.add(key);
-    transitions.set(key, {
-      previousKey: stateKey(rawStart, valueStart),
-      rawStart,
-      rawEnd,
-      valueLength: valueEnd - valueStart
-    });
-    queue.push({ rawIndex: rawEnd, valueIndex: valueEnd });
-  };
-
-  for (let cursor = 0; cursor < queue.length; cursor++) {
-    const { rawIndex, valueIndex } = queue[cursor];
-    if (rawIndex === raw.length && valueIndex === value.length) {
-      break;
-    }
-
-    if (rawIndex < raw.length && valueIndex < value.length && raw[rawIndex] === value[valueIndex]) {
-      enqueue(rawIndex, valueIndex, rawIndex + 1, valueIndex + 1);
-    }
-
-    if (raw[rawIndex] === '\\'
-      && rawIndex + 1 < raw.length
-      && valueIndex < value.length
-      && ESCAPABLE_PUNCTUATION.has(raw[rawIndex + 1])
-      && raw[rawIndex + 1] === value[valueIndex]) {
-      enqueue(rawIndex, valueIndex, rawIndex + 2, valueIndex + 1);
-    }
-
-    const entityReference = entityReferences.get(rawIndex);
-    if (entityReference) {
-      const source = raw.slice(rawIndex, entityReference.endOffset);
-      const decodedCandidates = new Set([
-        entityReference.decoded,
-        getLegacyNumericEntityDecode(source),
-        getParserNumericEntityDecode(source)
-      ]);
-      for (const decoded of decodedCandidates) {
-        if (decoded && value.startsWith(decoded, valueIndex)) {
-          enqueue(rawIndex, valueIndex, entityReference.endOffset, valueIndex + decoded.length);
-        }
-      }
-    }
-  }
-
-  if (!visited.has(targetKey)) {
-    throw new RangeError('TextScanner raw/normalized offset mapping is inconsistent');
-  }
-
-  const matchedTransitions: AlignmentTransition[] = [];
-  for (let key = targetKey; key !== startKey;) {
-    const transition = transitions.get(key);
-    if (!transition) {
-      throw new RangeError('TextScanner offset mapping is missing an alignment transition');
-    }
-    matchedTransitions.push(transition);
-    key = transition.previousKey;
-  }
-
-  const prefixLengths: number[] = [0];
-  for (const transition of matchedTransitions.reverse()) {
-    for (let unit = 1; unit <= transition.valueLength; unit++) {
-      prefixLengths.push(unit === transition.valueLength ? transition.rawEnd : transition.rawStart);
-    }
-  }
-
-  return prefixLengths;
-};
-
-/**
- * TextScanner 索引构建诊断（仅供 benchmark / 单测观测使用）。
- * 仅记录「换行索引首次构建」的重复成本，用于判断是否有必要引入
- * 跨 scanner 的索引缓存（见 issue #176）。不涉及规则公共 API。
- */
 let scannerIndexBuilds = 0;
 let scannerIndexBuildWallTimeMs = 0;
 
@@ -209,267 +36,174 @@ export const resetScannerDiagnostics = () => {
   scannerIndexBuildWallTimeMs = 0;
 };
 
-/** 文本匹配结果，包含相对位置和绝对位置 */
 export interface TextMatch {
-  /** 文本内相对 index */
   index: number
-  /** 匹配长度 */
   length: number
-  /** 文档内绝对位置 */
   loc: {
     start: { line: number; column: number; offset: number }
     end: { line: number; column: number; offset: number }
   }
-  /** 文档内绝对 offset 范围 */
   absoluteRange: [number, number]
 }
 
-/** 逐字符迭代时的位置信息 */
-interface DocumentPosition {
+export interface CharPosition {
   line: number
   column: number
   offset: number
-}
-
-export interface CharPosition extends DocumentPosition {
-  /** 当前归一化字符在原始文档中的结束 offset */
   endOffset: number
 }
 
 /**
- * 文本扫描器，消除规则中重复的位置计算和迭代模板。
- *
- * 关键约定（见 issue #155）：规则匹配基于解析器返回的「归一化」文本
- * `node.value`，但 fix 的 offset 必须指向「原始」 markdown。因此 scanner
- * 同时持有 `node.value`（用于匹配）和原始文本切片（用于位置换算），通过
- * `decodePrefixLengths` 把归一化索引对齐到原始文档 offset / 行列号。
- *
- * 用法：
- *   const scanner = new TextScanner(node, markdown)
- *   const matches = scanner.findAllMatches(/[０-９]+/g)
- *   matches.forEach(m => context.report({ loc: m.loc, ... }))
- *
- * @param node     文本节点（含归一化 value 与原始 position）
- * @param markdown 原始 markdown 文本，用于把归一化索引换算回原始 offset。
- *                省略时退化为旧行为（value 即原始文本，映射为恒等）。
+ * Scans a normalized text node and resolves every diagnostic/fix range through
+ * parser's source map.  The fallback is intentionally an identity mapping for
+ * manually-created nodes and legacy direct consumers; it never attempts to
+ * decode Markdown itself.
  */
 export class TextScanner {
   private readonly _value: string;
   private readonly _node: MarkdownTextNode;
-  private readonly _startLine: number;
-  private readonly _startColumn: number;
-  private readonly _startOffset: number;
-  /** 原始文本切片（node 对应区间），用于位置换算。 */
-  private readonly _raw: string;
-  /** 原始切片内的换行索引，用于行列号换算。 */
-  private _rawLineBreakIndices?: number[];
-  /** value 索引 -> 原始文档前缀长度映射（见 buildDecodePrefixLengths）。 */
-  private _decodePrefixLengths?: number[];
+  private readonly _sourceMap?: MarkdownSourceMap;
+  private _lineBreakIndices?: number[];
 
-  constructor(node: MarkdownTextNode, markdown?: string) {
+  constructor(node: MarkdownTextNode) {
     this._node = node;
     this._value = node.value;
-    this._startLine = node.position.start.line;
-    this._startColumn = node.position.start.column;
-    this._startOffset = node.position.start.offset;
-
-    const rawSlice = markdown?.slice(node.position.start.offset, node.position.end.offset);
-    // 无 markdown 或切片长度异常时退回 node.value，保持旧行为。
-    this._raw = (rawSlice && rawSlice.length > 0) ? rawSlice : this._value;
+    this._sourceMap = sourceMaps.get(node);
   }
 
-  /**
-   * 原始切片换行索引，首次需要时构建（并累计诊断计数/耗时，见 issue #176）。
-   */
-  private get rawLineBreakIndices(): number[] {
-    if (!this._rawLineBreakIndices) {
-      const buildStart = now();
-      const indices: number[] = [];
-      for (let i = 0; i < this._raw.length; i++) {
-        if (this._raw[i] === '\n') {
-          indices.push(i);
-        }
-      }
-      this._rawLineBreakIndices = indices;
-      scannerIndexBuilds++;
-      scannerIndexBuildWallTimeMs += now() - buildStart;
-    }
-    return this._rawLineBreakIndices;
-  }
-
-  /** 归一化索引 -> 原始文档前缀长度映射，首次需要时构建（见 issue #155）。 */
-  private get decodePrefixLengths(): number[] {
-    if (!this._decodePrefixLengths) {
-      this._decodePrefixLengths = buildDecodePrefixLengths(this._raw, this._value);
-    }
-    return this._decodePrefixLengths;
-  }
-
-  /** 将「归一化 value 的索引」换算为「原始文档 offset」。 */
-  private rawOffsetAt(index: number): number {
-    const prefixLengths = this.decodePrefixLengths;
-    if (!Number.isInteger(index) || index < 0 || index >= prefixLengths.length) {
-      throw new RangeError(`TextScanner index out of range: ${index}`);
-    }
-    return this._startOffset + prefixLengths[index];
-  }
-
-  /** 文本内容（归一化，用于匹配） */
   get value(): string {
     return this._value;
   }
 
-  /** 原始节点 */
   get node(): MarkdownTextNode {
     return this._node;
   }
 
-  /**
-   * 计算归一化文本内某个 index 对应的「原始文档」位置。
-   *
-   * 通过前缀长度映射得到原始切片内的偏移，再基于原始切片换行索引换算行列号。
-   */
-  private positionAt(index: number): DocumentPosition {
-    const rawRel = this.rawOffsetAt(index) - this._startOffset;
-    const lb = this.rawLineBreakIndices;
-    let lo = 0;
-    let hi = lb.length;
-    while (lo < hi) {
-      const mid = (lo + hi) >> 1;
-      if (lb[mid] < rawRel) {
-        lo = mid + 1;
+  private get lineBreakIndices(): number[] {
+    if (!this._lineBreakIndices) {
+      const buildStart = now();
+      const indices: number[] = [];
+      for (let i = 0; i < this._value.length; i++) {
+        if (this._value[i] === '\n') {
+          indices.push(i);
+        }
       }
-      else {
-        hi = mid;
-      }
+      this._lineBreakIndices = indices;
+      scannerIndexBuilds++;
+      scannerIndexBuildWallTimeMs += now() - buildStart;
     }
-    // lo = 换行符在 rawRel 之前的数量（rawRel 处的换行符不算）
-    const line = this._startLine + lo;
-    const column = lo === 0
-      ? this._startColumn + rawRel
-      : rawRel - lb[lo - 1];
-
-    return {
-      line,
-      column,
-      offset: this._startOffset + this.decodePrefixLengths[index]
-    };
+    return this._lineBreakIndices;
   }
 
-  /**
-   * 将文本内相对 index + length 转换为绝对位置信息（基于原始文档）。
-   */
-  matchAt(index: number, length: number): TextMatch {
-    const start = this.positionAt(index);
-    const endPos = this.positionAt(index + length);
-    const startOffset = this.rawOffsetAt(index);
-    const endOffset = this.rawOffsetAt(index + length);
+  private fallbackRange(start: number, end: number) {
+    const pointAt = (index: number) => {
+      const breaks = this.lineBreakIndices;
+      let lo = 0;
+      let hi = breaks.length;
+      while (lo < hi) {
+        const mid = (lo + hi) >> 1;
+        if (breaks[mid] < index) {
+          lo = mid + 1;
+        }
+        else {
+          hi = mid;
+        }
+      }
+      return {
+        line: this._node.position.start.line + lo,
+        column: lo === 0
+          ? this._node.position.start.column + index
+          : index - breaks[lo - 1],
+        offset: this._node.position.start.offset + index
+      };
+    };
+    return { start: pointAt(start), end: pointAt(end) };
+  }
 
+  private fallbackPointAtLinear(index: number) {
+    let line = this._node.position.start.line;
+    let column = this._node.position.start.column;
+    for (let i = 0; i < index; i++) {
+      if (this._value[i] === '\n') {
+        line++;
+        column = 1;
+      }
+      else {
+        column++;
+      }
+    }
+    return { line, column, offset: this._node.position.start.offset + index };
+  }
+
+  private sourceRange(start: number, end: number) {
+    if (!Number.isInteger(start) || !Number.isInteger(end)
+      || start < 0 || end < start || end > this._value.length) {
+      throw new RangeError(`TextScanner range out of bounds: [${start}, ${end}]`);
+    }
+    return this._sourceMap
+      ? this._sourceMap.getSourceRange(this._node as ParserMarkdownTextNode, start, end)
+      : this.fallbackRange(start, end);
+  }
+
+  matchAt(index: number, length: number): TextMatch {
+    const range = this.sourceRange(index, index + length);
     return {
       index,
       length,
-      loc: {
-        start: { line: start.line, column: start.column, offset: startOffset },
-        end: { line: endPos.line, column: endPos.column, offset: endOffset }
-      },
-      absoluteRange: [startOffset, endOffset]
+      loc: range,
+      absoluteRange: [range.start.offset, range.end.offset]
     };
   }
 
-  /**
-   * 正则匹配所有结果，替代 while+exec 模板
-   *
-   * @example
-   * const matches = scanner.findAllMatches(/[０-９]+/g)
-   */
   findAllMatches(regex: RegExp): TextMatch[] {
     const results: TextMatch[] = [];
-    // 确保正则有 g 标志
     const re = new RegExp(regex.source, regex.flags.includes('g') ? regex.flags : `${regex.flags}g`);
-
     let matched = re.exec(this._value);
     while (matched !== null) {
-      // 防止零长度匹配导致死循环（如 /\b/g、/^/gm）
       if (matched[0].length === 0) {
         re.lastIndex++;
-        matched = re.exec(this._value);
-        continue;
       }
-      results.push(this.matchAt(matched.index, matched[0].length));
+      else {
+        results.push(this.matchAt(matched.index, matched[0].length));
+      }
       matched = re.exec(this._value);
     }
     return results;
   }
 
-  /**
-   * 查找字符串所有出现位置，替代 indexOf 循环
-   *
-   * @example
-   * const matches = scanner.findAllOccurrences('×')
-   */
   findAllOccurrences(searchStr: string): TextMatch[] {
-    if (searchStr.length === 0) {
+    if (!searchStr) {
       return [];
     }
-
     const results: TextMatch[] = [];
-    let startIndex = 0;
-
-    while (startIndex < this._value.length) {
-      const idx = this._value.indexOf(searchStr, startIndex);
-      if (idx === -1)
+    for (let start = 0; start < this._value.length;) {
+      const index = this._value.indexOf(searchStr, start);
+      if (index === -1) {
         break;
-      results.push(this.matchAt(idx, searchStr.length));
-      // Advance by 1 to allow overlapping occurrences
-      startIndex = idx + 1;
+      }
+      results.push(this.matchAt(index, searchStr.length));
+      start = index + 1;
     }
     return results;
   }
 
-  /**
-   * 逐字符迭代，自动跟踪 line/column（均基于原始文档）。
-   *
-   * 注意：回调收到的 `offset` 是原始文档 offset，`index` 仍是归一化 value
-   * 索引，便于规则基于 `value` 做字符判断。
-   *
-   * @example
-   * scanner.forEachChar((char, i, pos) => {
-   *   if (shouldReport(char)) {
-   *     context.report({
-   *       loc: { start: pos, end: { line: pos.line, column: pos.column + 1 } },
-   *       ...
-   *     })
-   *   }
-   * })
-   */
+  /** Iterates Unicode code points so an atomic two-unit entity is visited once. */
   forEachChar(callback: (char: string, index: number, pos: CharPosition) => void): void {
-    const prefixLengths = this.decodePrefixLengths;
-    let line = this._startLine;
-    let column = this._startColumn;
-
-    for (let i = 0; i < this._value.length; i++) {
-      const char = this._value[i];
-      const runStart = prefixLengths[i];
-      const runEnd = prefixLengths[i + 1];
-      const offset = this._startOffset + runStart;
-
-      callback(char, i, {
-        line,
-        column,
-        offset,
-        endOffset: this._startOffset + runEnd
+    for (let index = 0; index < this._value.length;) {
+      const char = String.fromCodePoint(this._value.codePointAt(index)!);
+      const range = this._sourceMap
+        ? this.sourceRange(index, index + char.length)
+        : {
+            start: this.fallbackPointAtLinear(index),
+            end: this.fallbackPointAtLinear(index + char.length)
+          };
+      callback(char, index, {
+        line: range.start.line,
+        column: range.start.column,
+        offset: range.start.offset,
+        endOffset: range.end.offset
       });
-
-      // 沿原始切片推进行列号（不构建二分换行索引，保持 issue #176 诊断行为）。
-      for (let r = runStart; r < runEnd; r++) {
-        if (this._raw[r] === '\n') {
-          line++;
-          column = 1;
-        }
-        else {
-          column++;
-        }
-      }
+      index += char.length;
     }
   }
 }


### PR DESCRIPTION
## Summary

- upgrade `@lint-md/parser` to `~0.1.3` and parse through `parseMdWithSourceMap()`
- make `TextScanner` consume parser-owned raw ranges while preserving the existing public `LintMdRuleContext`
- remove core's decode-prefix and direct `parse-entities` implementation
- add regression coverage for escaped/entity fixes, atomic entities, line endings, aligned report/fix ranges, and source-map failures
- update the memory benchmark parser-only path to include source-map construction

## Root cause

Rules scanned parser-normalized text but core independently reconstructed raw offsets. This could yield correct diagnostics with empty or partial raw-Markdown fixes.

Closes #196

## Validation

- `npm test -- --runInBand`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run package-contract`
- `npm run smoke-test`
- `npm run benchmark`