### PR TITLE
fix(core): map inline code source ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.1.6](https://github.com/lint-md/lint-md/compare/v2.1.5...v2.1.6) - 2026-07-19
+
+### Bug Fixes
+
+- **text-scanner**: use parser source maps for inline-code value ranges, correctly handling padding normalization and multi-backtick delimiters (#198)
+- **deps**: bump `@lint-md/parser` to `~0.2.0` (#198)
+
 ## [2.1.5](https://github.com/lint-md/lint-md/compare/v2.1.4...v2.1.5) - 2026-07-13
 
 ### Features

--- a/__tests__/unit/source-map-integration.spec.ts
+++ b/__tests__/unit/source-map-integration.spec.ts
@@ -87,6 +87,23 @@ describe('parser source-map integration', () => {
     expect(second.lintResult.ruleManager.getReportData()).toHaveLength(0);
   });
 
+  test.each([
+    [
+      'blockquote continuations',
+      ['> 中文(test)', '> 中文(test)'].join('\n'),
+      ['> 中文（test）', '> 中文（test）'].join('\n')
+    ],
+    [
+      'list continuation indentation',
+      ['- 中文(test)', '  中文(test)'].join('\n'),
+      ['- 中文（test）', '  中文（test）'].join('\n')
+    ]
+  ])('%s preserves container syntax while fixing mapped punctuation', (_name, input, expected) => {
+    const result = lintMarkdownInternal(input, halfWidthConfig, true);
+
+    expect(result.fixedResult?.result).toBe(expected);
+  });
+
   test('diagnostic offsets and fix ranges are resolved by the same source-map range', () => {
     const input = '中文&#40;test&#41;中文';
     const { ruleManager } = runLint(input, halfWidthConfig);

--- a/__tests__/unit/source-map-integration.spec.ts
+++ b/__tests__/unit/source-map-integration.spec.ts
@@ -38,12 +38,17 @@ describe('parser source-map integration', () => {
       .toEqual([[0, 1], [1, 2], [2, 3]]);
   });
 
-  test('keeps inlineCode on the identity fallback instead of registering an unsupported source map', () => {
-    const { ast, sourceMap } = parseMdWithSourceMap('`code`');
+  test.each([
+    ['padding normalization', '` a `', 'a', [2, 3]],
+    ['multiple backtick delimiters', '`` `value` ``', '`value`', [3, 10]]
+  ])('%s resolves inlineCode ranges with the parser source map', (_name, markdown, value, expectedRange) => {
+    const { ast, sourceMap } = parseMdWithSourceMap(markdown);
     registerTextNodeSourceMap(ast, sourceMap);
     const inlineCode = (ast.children[0] as any).children[0];
-    expect(inlineCode.type).toBe('inlineCode');
-    expect(new TextScanner(inlineCode).matchAt(0, 1).absoluteRange).toEqual([0, 1]);
+
+    expect(inlineCode).toMatchObject({ type: 'inlineCode', value });
+    expect(new TextScanner(inlineCode).matchAt(0, value.length).absoluteRange)
+      .toEqual(expectedRange);
   });
 
   test.each([

--- a/__tests__/unit/source-map-integration.spec.ts
+++ b/__tests__/unit/source-map-integration.spec.ts
@@ -51,6 +51,31 @@ describe('parser source-map integration', () => {
       .toEqual(expectedRange);
   });
 
+  test('runLint resolves an inlineCode selector fix through the source map', () => {
+    const inlineCodeRule: LintMdRule = {
+      meta: { name: 'inline-code-source-map' },
+      create: context => ({
+        inlineCode: node => {
+          const match = new TextScanner(node as any).matchAt(0, 1);
+          context.report({
+            loc: match.loc,
+            message: 'replace inline code value',
+            fix: fixer => fixer.replaceTextRange(match.absoluteRange, 'b')
+          });
+        }
+      })
+    };
+
+    const result = lintMarkdownInternal('` a `', [{ rule: inlineCodeRule }], true);
+    const [report] = result.lintResult.ruleManager.getReportData();
+
+    expect(report.loc).toMatchObject({
+      start: { offset: 2 },
+      end: { offset: 3 }
+    });
+    expect(result.fixedResult?.result).toBe('` b `');
+  });
+
   test.each([
     ['escaped', '中文\\(test\\)中文', '中文（test）中文'],
     ['numeric entity', '中文&#40;test&#41;中文', '中文（test）中文']

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lint-md/core",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Core of lint-md which used to lint your markdown file for Chinese.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "chinese"
   ],
   "dependencies": {
-    "@lint-md/parser": "~0.1.3"
+    "@lint-md/parser": "~0.2.0"
   },
   "devDependencies": {
     "@attachments/eslint-config": "^0.3.3",

--- a/src/utils/text-scanner.ts
+++ b/src/utils/text-scanner.ts
@@ -1,4 +1,5 @@
 import type {
+  MarkdownInlineCodeNode,
   MarkdownSourceMap,
   MarkdownTextNode as ParserMarkdownTextNode,
   PositionedMarkdownRoot
@@ -19,10 +20,7 @@ export const registerTextNodeSourceMap = (
   sourceMap: MarkdownSourceMap
 ): void => {
   for (const node of getTextNodes(ast)) {
-    // Parser 0.1.3 maps text nodes only. inlineCode remains supported by the
-    // scanner's identity fallback, rather than being registered to a map that
-    // would reject it with SourceMapUnavailableError.
-    if (node.type === 'text') {
+    if (node.type === 'text' || node.type === 'inlineCode') {
       sourceMaps.set(node, sourceMap);
     }
   }
@@ -146,7 +144,11 @@ export class TextScanner {
       throw new RangeError(`TextScanner range out of bounds: [${start}, ${end}]`);
     }
     return this._sourceMap
-      ? this._sourceMap.getSourceRange(this._node as ParserMarkdownTextNode, start, end)
+      ? this._sourceMap.getSourceRange(
+        this._node as ParserMarkdownTextNode | MarkdownInlineCodeNode,
+        start,
+        end
+      )
       : this.fallbackRange(start, end);
   }
 


### PR DESCRIPTION
## Summary

- Upgrade `@lint-md/parser` to 0.2.0.
- Register `inlineCode` nodes with the internal parser source map used by `TextScanner`.
- Cover inline-code padding normalization and multi-backtick delimiters with integration tests.

## Why

The identity fallback starts at `node.position.start`, which points to the opening backtick. It produces incorrect diagnostic and fix offsets when `inlineCode.value` is normalized by the parser.

## Validation

- `npm test -- --runInBand __tests__/unit/source-map-integration.spec.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`

Fixes #195
