### PR TITLE
fix: preserve Markdown syntax in alphabet spacing

### DIFF
--- a/__tests__/unit/rules/space-around-alphabet.spec.ts
+++ b/__tests__/unit/rules/space-around-alphabet.spec.ts
@@ -44,13 +44,15 @@ describe('test space-around-alphabet', () => {
     expect(fixedResult?.result).toStrictEqual(expectedFix);
   });
 
-  test.each(['\n', '\r\n'])('fixes list continuation text with %p line endings', (lineEnding) => {
+  test.each(['\n', '\r\n'])(
+    'preserves list continuation when alphabet and number fixes share a text node',
+    (lineEnding) => {
     const input = [
-      '- Cache-Control：这是 English 内容',
+      '- 中文English',
       '  表示资源可以被缓存1小时。'
     ].join(lineEnding);
-    const expectedFix = [
-      '- Cache-Control：这是 English 内容',
+    const expected = [
+      '- 中文 English',
       '  表示资源可以被缓存 1 小时。'
     ].join(lineEnding);
     const combinedFixer = createFixer([
@@ -58,8 +60,32 @@ describe('test space-around-alphabet', () => {
       { rule: spaceAroundNumber }
     ]);
 
-    const { fixedResult } = combinedFixer(input);
-    expect(fixedResult?.result).toStrictEqual(expectedFix);
-    expect(combinedFixer(fixedResult!.result).lintResult.ruleManager.getReportData()).toHaveLength(0);
+    const first = combinedFixer(input);
+    expect(first.fixedResult?.result).toBe(expected);
+    expect(first.lintResult.ruleManager.getReportData().map(report => report.name))
+      .toEqual(expect.arrayContaining([
+        'space-around-alphabet',
+        'space-around-number'
+      ]));
+    expect(combinedFixer(first.fixedResult!.result).lintResult.ruleManager.getReportData())
+      .toHaveLength(0);
+    }
+  );
+
+  test('fixes the complete Markdown from issue 103', () => {
+    const input = [
+      '- Cache-Control：这是最重要的缓存头部字段，它提供了关于如何缓存响应的指令。例如，`Cache-Control: max-age=3600` ',
+      '  表示资源可以被缓存1小时。'
+    ].join('\r\n');
+    const expected = [
+      '- Cache-Control：这是最重要的缓存头部字段，它提供了关于如何缓存响应的指令。例如，`Cache-Control: max-age=3600` ',
+      '  表示资源可以被缓存 1 小时。'
+    ].join('\r\n');
+    const combinedFixer = createFixer([
+      { rule: spaceAroundAlphabet },
+      { rule: spaceAroundNumber }
+    ]);
+
+    expect(combinedFixer(input).fixedResult?.result).toBe(expected);
   });
 });

--- a/__tests__/unit/rules/space-around-alphabet.spec.ts
+++ b/__tests__/unit/rules/space-around-alphabet.spec.ts
@@ -17,6 +17,8 @@ describe('test space-around-alphabet', () => {
   test.each([
     ['中文abc', 1, '中文 abc'],
     ['abc中文', 1, 'abc 中文'],
+    ['𠀀English', 1, '𠀀 English'],
+    ['English𠀀', 1, 'English 𠀀'],
   ])('%s → %i report, fix to "%s"', (input, expectedReports, expectedFix) => {
     const { lintResult, fixedResult } = fixer(input);
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(expectedReports);
@@ -47,32 +49,32 @@ describe('test space-around-alphabet', () => {
   test.each(['\n', '\r\n'])(
     'preserves list continuation when alphabet and number fixes share a text node',
     (lineEnding) => {
-    const input = [
-      '- 中文English',
-      '  表示资源可以被缓存1小时。'
-    ].join(lineEnding);
-    const expected = [
-      '- 中文 English',
-      '  表示资源可以被缓存 1 小时。'
-    ].join(lineEnding);
-    const combinedFixer = createFixer([
-      { rule: spaceAroundAlphabet },
-      { rule: spaceAroundNumber }
-    ]);
+      const input = [
+        '- 中文English',
+        '  表示资源可以被缓存1小时。'
+      ].join(lineEnding);
+      const expected = [
+        '- 中文 English',
+        '  表示资源可以被缓存 1 小时。'
+      ].join(lineEnding);
+      const combinedFixer = createFixer([
+        { rule: spaceAroundAlphabet },
+        { rule: spaceAroundNumber }
+      ]);
 
-    const first = combinedFixer(input);
-    expect(first.fixedResult?.result).toBe(expected);
-    expect(first.lintResult.ruleManager.getReportData().map(report => report.name))
-      .toEqual(expect.arrayContaining([
-        'space-around-alphabet',
-        'space-around-number'
-      ]));
-    expect(combinedFixer(first.fixedResult!.result).lintResult.ruleManager.getReportData())
-      .toHaveLength(0);
+      const first = combinedFixer(input);
+      expect(first.fixedResult?.result).toBe(expected);
+      expect(first.lintResult.ruleManager.getReportData().map(report => report.name))
+        .toEqual(expect.arrayContaining([
+          'space-around-alphabet',
+          'space-around-number'
+        ]));
+      expect(combinedFixer(first.fixedResult!.result).lintResult.ruleManager.getReportData())
+        .toHaveLength(0);
     }
   );
 
-  test('fixes the complete Markdown from issue 103', () => {
+  test('preserves the complete Markdown from issue 103', () => {
     const input = [
       '- Cache-Control：这是最重要的缓存头部字段，它提供了关于如何缓存响应的指令。例如，`Cache-Control: max-age=3600` ',
       '  表示资源可以被缓存1小时。'

--- a/__tests__/unit/rules/space-around-alphabet.spec.ts
+++ b/__tests__/unit/rules/space-around-alphabet.spec.ts
@@ -1,5 +1,6 @@
 import { createFixer } from '../../utils/test-utils';
 import spaceAroundAlphabet from '../../../src/rules/space-around-alphabet';
+import spaceAroundNumber from '../../../src/rules/space-around-number';
 
 const fixer = createFixer([{
   rule: spaceAroundAlphabet
@@ -9,8 +10,8 @@ describe('test space-around-alphabet', () => {
   test('fix applied', () => {
     const content = '（有时称为 m\\-dots 或 m子域名）就是 - 托管在 website子域名中的的移动特定版本，通常是 `m` 子域名。';
     const { fixedResult, lintResult } = fixer(content);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
-    expect(fixedResult?.result).toStrictEqual('（有时称为 m-dots 或 m 子域名）就是 - 托管在 website 子域名中的的移动特定版本，通常是 `m` 子域名。');
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual('（有时称为 m\\-dots 或 m 子域名）就是 - 托管在 website 子域名中的的移动特定版本，通常是 `m` 子域名。');
   });
 
   test.each([
@@ -31,5 +32,34 @@ describe('test space-around-alphabet', () => {
   ])('"%s" does not report (already spaced or punctuation in between)', (input) => {
     const { lintResult } = fixer(input);
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+  });
+
+  test.each([
+    ['> 中文English\n> 后续内容', '> 中文 English\n> 后续内容'],
+    ['- 中文English\n  后续内容', '- 中文 English\n  后续内容'],
+    ['中文\\English中文', '中文\\English 中文'],
+    ['中文&amp;English', '中文&amp;English'],
+  ])('keeps Markdown syntax for "%s"', (input, expectedFix) => {
+    const { fixedResult } = fixer(input);
+    expect(fixedResult?.result).toStrictEqual(expectedFix);
+  });
+
+  test.each(['\n', '\r\n'])('fixes list continuation text with %p line endings', (lineEnding) => {
+    const input = [
+      '- Cache-Control：这是 English 内容',
+      '  表示资源可以被缓存1小时。'
+    ].join(lineEnding);
+    const expectedFix = [
+      '- Cache-Control：这是 English 内容',
+      '  表示资源可以被缓存 1 小时。'
+    ].join(lineEnding);
+    const combinedFixer = createFixer([
+      { rule: spaceAroundAlphabet },
+      { rule: spaceAroundNumber }
+    ]);
+
+    const { fixedResult } = combinedFixer(input);
+    expect(fixedResult?.result).toStrictEqual(expectedFix);
+    expect(combinedFixer(fixedResult!.result).lintResult.ruleManager.getReportData()).toHaveLength(0);
   });
 });

--- a/src/rules/space-around-alphabet.ts
+++ b/src/rules/space-around-alphabet.ts
@@ -18,7 +18,10 @@ const spaceAroundAlphabet: LintMdRule = {
         const { value } = scanner;
 
         scanner.forEachChar((char, index, pos) => {
-          const nextCharacter = value[index + char.length];
+          const nextCodePoint = value.codePointAt(index + char.length);
+          const nextCharacter = nextCodePoint === undefined
+            ? undefined
+            : String.fromCodePoint(nextCodePoint);
           if (nextCharacter && isChineseEnglishBoundary(char, nextCharacter)) {
             const match = scanner.matchAt(index, char.length + nextCharacter.length);
             context.report({

--- a/src/rules/space-around-alphabet.ts
+++ b/src/rules/space-around-alphabet.ts
@@ -1,5 +1,6 @@
 import type { LintMdRule, PositionedTextNode } from '../types';
 import { isChineseCharacter, isEnglishCharacter } from '../utils/char-helper';
+import { TextScanner } from '../utils/text-scanner';
 
 const isChineseEnglishBoundary = (a: string, b: string): boolean => {
   return (isChineseCharacter(a) && isEnglishCharacter(b))
@@ -13,37 +14,20 @@ const spaceAroundAlphabet: LintMdRule = {
   create: (context) => {
     return {
       text: (node: PositionedTextNode) => {
-        const { value } = node;
+        const scanner = new TextScanner(node);
+        const { value } = scanner;
 
-        const boundaries: number[] = [];
-        for (let i = 0; i < value.length - 1; i++) {
-          if (isChineseEnglishBoundary(value[i], value[i + 1])) {
-            boundaries.push(i);
+        scanner.forEachChar((char, index, pos) => {
+          const nextCharacter = value[index + char.length];
+          if (nextCharacter && isChineseEnglishBoundary(char, nextCharacter)) {
+            const match = scanner.matchAt(index, char.length + nextCharacter.length);
+            context.report({
+              loc: match.loc,
+              message: '中英文之间需要添加空格',
+              fix: fixer => fixer.insertTextAt(pos.endOffset, ' ')
+            });
           }
-        }
-
-        if (boundaries.length > 0) {
-          let pos = 0;
-
-          let newContent = boundaries.reduce((str, boundary) => {
-            const newContent = `${str}${value.slice(pos, boundary + 1)} `;
-            pos = boundary + 1;
-            return newContent;
-          }, '');
-
-          newContent += value.slice(pos);
-
-          context.report({
-            loc: node.position,
-            message: '中英文之间需要添加空格',
-            fix: (fixer) => {
-              return fixer.replaceTextRange([
-                node.position.start.offset,
-                node.position.end.offset
-              ], newContent);
-            }
-          });
-        }
+        });
       }
     };
   }


### PR DESCRIPTION
Related to #103.

## Summary

- Use TextScanner source maps for alphabet spacing fixes.
- Insert one space for each Chinese and English boundary.
- Support supplementary Han characters in both boundary directions.
- Preserve list indentation, blockquote markers, and escape characters.

## Root cause

The rule replaced full normalized text nodes. Node values can differ from Markdown source ranges.

## Issue relationship

Issue #103 shows a number-spacing position error. This PR does not claim to close that Issue.

## Validation

- npm test -- --runInBand
- npm run typecheck
- npm run lint
- git diff --check