### PR TITLE
fix(space-around-number): use codePointAt for supplementary Han characters

### DIFF
--- a/__tests__/unit/rules/space-around-number.spec.ts
+++ b/__tests__/unit/rules/space-around-number.spec.ts
@@ -42,4 +42,19 @@ describe('test space-around-number', () => {
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('中 &#49; 文');
   });
+
+  test.each([
+    ['𠀀123', '𠀀 123'],
+    ['123𠀀', '123 𠀀'],
+  ])('supports supplementary Han characters: "%s" → "%s"', (input, expectedFix) => {
+    const { fixedResult, lintResult } = fixer(input);
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(fixedResult?.result).toStrictEqual(expectedFix);
+  });
+
+  test('fixes 100% after supplementary Han', () => {
+    const { fixedResult, lintResult } = fixer('𠀀100%测试');
+    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(fixedResult?.result).toStrictEqual('𠀀 100% 测试');
+  });
 });

--- a/__tests__/unit/rules/space-around-number.spec.ts
+++ b/__tests__/unit/rules/space-around-number.spec.ts
@@ -52,9 +52,9 @@ describe('test space-around-number', () => {
     expect(fixedResult?.result).toStrictEqual(expectedFix);
   });
 
-  test('fixes 100% after supplementary Han', () => {
-    const { fixedResult, lintResult } = fixer('𠀀100%测试');
+  test('supports supplementary Han around percentages', () => {
+    const { fixedResult, lintResult } = fixer('𠀀100%𠀀');
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
-    expect(fixedResult?.result).toStrictEqual('𠀀 100% 测试');
+    expect(fixedResult?.result).toStrictEqual('𠀀 100% 𠀀');
   });
 });

--- a/src/rules/space-around-number.ts
+++ b/src/rules/space-around-number.ts
@@ -2,23 +2,6 @@ import type { LintMdRule, PositionedTextNode } from '../types';
 import { isChineseCharacter, isNumberCharacter } from '../utils/char-helper';
 import { TextScanner } from '../utils/text-scanner';
 
-const isPercentSuffixOfNumber = (value: string, index: number) => {
-  return value[index] === '%' && index > 0 && isNumberCharacter(value[index - 1]);
-};
-
-const shouldInsertSpaceBetween = (value: string, index: number) => {
-  const currentCharacter = value[index];
-  const nextCharacter = value[index + 1];
-
-  if (!currentCharacter || !nextCharacter) {
-    return false;
-  }
-
-  return (isChineseCharacter(currentCharacter) && isNumberCharacter(nextCharacter))
-    || (isNumberCharacter(currentCharacter) && isChineseCharacter(nextCharacter))
-    || (isPercentSuffixOfNumber(value, index) && isChineseCharacter(nextCharacter));
-};
-
 const spaceAroundNumber: LintMdRule = {
   meta: {
     name: 'space-around-number'
@@ -29,9 +12,26 @@ const spaceAroundNumber: LintMdRule = {
         const scanner = new TextScanner(node);
         const { value } = scanner;
 
-        scanner.forEachChar((char, i, pos) => {
-          if (i < value.length - 1 && shouldInsertSpaceBetween(value, i)) {
-            const match = scanner.matchAt(i, 2);
+        scanner.forEachChar((char, index, pos) => {
+          const nextCodePoint = value.codePointAt(index + char.length);
+          const nextCharacter = nextCodePoint === undefined
+            ? undefined
+            : String.fromCodePoint(nextCodePoint);
+
+          if (!nextCharacter) {
+            return;
+          }
+
+          const isChineseNumBoundary = (isChineseCharacter(char) && isNumberCharacter(nextCharacter))
+            || (isNumberCharacter(char) && isChineseCharacter(nextCharacter));
+
+          const isPercentBoundary = char === '%'
+            && index > 0
+            && isChineseCharacter(nextCharacter)
+            && isNumberCharacter(_prevCharAt(value, index));
+
+          if (isChineseNumBoundary || isPercentBoundary) {
+            const match = scanner.matchAt(index, char.length + nextCharacter.length);
             context.report({
               loc: match.loc,
               message: '中文与数字之间需要增加空格',
@@ -43,5 +43,10 @@ const spaceAroundNumber: LintMdRule = {
     };
   }
 };
+
+function _prevCharAt(value: string, index: number): string {
+  const codePoint = value.codePointAt(index - 1);
+  return codePoint === undefined ? '' : String.fromCodePoint(codePoint);
+}
 
 export default spaceAroundNumber;

--- a/src/rules/space-around-number.ts
+++ b/src/rules/space-around-number.ts
@@ -28,7 +28,8 @@ const spaceAroundNumber: LintMdRule = {
           const isPercentBoundary = char === '%'
             && index > 0
             && isChineseCharacter(nextCharacter)
-            && isNumberCharacter(_prevCharAt(value, index));
+            // Always safe: ASCII digits occupy a single UTF-16 code unit at index - 1
+            && isNumberCharacter(value[index - 1]);
 
           if (isChineseNumBoundary || isPercentBoundary) {
             const match = scanner.matchAt(index, char.length + nextCharacter.length);
@@ -43,10 +44,5 @@ const spaceAroundNumber: LintMdRule = {
     };
   }
 };
-
-function _prevCharAt(value: string, index: number): string {
-  const codePoint = value.codePointAt(index - 1);
-  return codePoint === undefined ? '' : String.fromCodePoint(codePoint);
-}
 
 export default spaceAroundNumber;


### PR DESCRIPTION
Closes #200.

## Problem

`space-around-number.ts` uses UTF-16 code unit indexing (`value[index]`, `value[index + 1]`) in `shouldInsertSpaceBetween` and `isPercentSuffixOfNumber`. This silently misses boundaries involving supplementary Han characters (e.g. `𠀀123` or `123𠀀`).

The same issue was fixed in `space-around-alphabet.ts`.

## Fix

- Removed `shouldInsertSpaceBetween` and `isPercentSuffixOfNumber` helpers that used raw UTF-16 indexing
- Inlined boundary checks inside the `forEachChar` callback using `value.codePointAt()` for proper code point resolution
- Changed `matchAt(i, 2)` to `matchAt(index, char.length + nextCharacter.length)` for correct length with supplementary characters
- Percent-suffix check uses inline `value[index - 1]` with a comment noting it is only called for ASCII digits (single code unit)

## Tests added

- `𠀀123` → `𠀀 123` (supplementary Han before digits)
- `123𠀀` → `123 𠀀` (supplementary Han after digits)
- `𠀀100%𠀀` → `𠀀 100% 𠀀` (supplementary Han on both sides of percent, covering both boundary directions)

Related PRs:
- #199 fixed the same UTF-16 indexing pattern in space-around-alphabet.
- #201 applies the same code-point-safe approach to space-around-number.

Related issue:
- #103 exposed incorrect character boundary handling in spacing rules.
- #200 tracks the supplementary Han character case fixed here.