### PR TITLE
feat(core): expose SourceCode API on rule context

### DIFF
--- a/__tests__/unit/rule-context.spec.ts
+++ b/__tests__/unit/rule-context.spec.ts
@@ -11,16 +11,23 @@ const fakeRule = {
 
 const fakeAst = { type: 'root', children: [] } as unknown as PositionedMarkdownRoot;
 
+const fakeSourceCode = {
+  text: '',
+  ast: fakeAst,
+  getRaw: () => '',
+  getTextRange: () => [0, 0] as [number, number]
+} as any;
+
 describe('test rule context', () => {
   test('test rule context creation', () => {
     const ctx = createRuleManager('');
     expect(ctx).toBeTruthy();
-    expect(typeof ctx.createRuleContext(fakeRule as any, { ast: fakeAst, markdown: '' }).report).toStrictEqual('function');
+    expect(typeof ctx.createRuleContext(fakeRule as any, { ast: fakeAst, markdown: '', sourceCode: fakeSourceCode }).report).toStrictEqual('function');
   });
 
   test('test rule context report() call', () => {
     const manager = createRuleManager('');
-    manager.createRuleContext(fakeRule as any, { ast: fakeAst, markdown: '' }).report({
+    manager.createRuleContext(fakeRule as any, { ast: fakeAst, markdown: '', sourceCode: fakeSourceCode }).report({
       message: 'message 1',
       loc: {
         start: {
@@ -33,7 +40,7 @@ describe('test rule context', () => {
         }
       }
     });
-    manager.createRuleContext(fakeRule as any, { ast: fakeAst, markdown: '' }).report({
+    manager.createRuleContext(fakeRule as any, { ast: fakeAst, markdown: '', sourceCode: fakeSourceCode }).report({
       message: 'message 2',
       loc: {
         start: {

--- a/__tests__/unit/source-code.spec.ts
+++ b/__tests__/unit/source-code.spec.ts
@@ -75,17 +75,22 @@ describe('LintSourceCode', () => {
   });
 
   test('getTextRange maps entity to complete source range', () => {
+    expect.assertions(2);
+
     const rule: LintMdRule = {
       meta: { name: 'entity-range-test' },
       create: (context: LintMdRuleContext) => ({
         text: node => {
-          if (node.type === 'text') {
-            const ampIndex = node.value.indexOf('&');
-            if (ampIndex === -1) return;
-            const range = context.sourceCode.getTextRange(node, ampIndex, ampIndex + 1);
-            // complete &#40; must be [2, 7] (6-char entity + preceding Chinese)
-            expect(range).toStrictEqual([2, 7]);
+          if (node.type !== 'text') {
+            return;
           }
+
+          const index = node.value.indexOf('(');
+          expect(index).toBe(2);
+
+          const range = context.sourceCode.getTextRange(node, index, index + 1);
+          // &#40; is 5 source characters spanning [2, 7)
+          expect(range).toStrictEqual([2, 7]);
         }
       })
     };

--- a/__tests__/unit/source-code.spec.ts
+++ b/__tests__/unit/source-code.spec.ts
@@ -1,0 +1,108 @@
+import type { LintMdRule, LintMdRuleContext, LintSourceCode, ReportOption } from '../../src/types';
+import { lintMarkdownInternal } from '../../src/core/lint-markdown';
+import { runLint } from '../../src/core/run-lint';
+
+describe('LintSourceCode', () => {
+  test('exposes sourceCode on rule context', () => {
+    const rule: LintMdRule = {
+      meta: { name: 'source-code-test' },
+      create: context => {
+        expect(context.sourceCode).toBeDefined();
+        expect(context.sourceCode.text).toBe('中文');
+        expect(context.sourceCode.ast).toBe(context.ast);
+        return {};
+      }
+    };
+
+    runLint('中文', [{ rule }]);
+  });
+
+  test('allows rules to fix a complete character reference', () => {
+    const rule: LintMdRule = {
+      meta: { name: 'source-code-range-test' },
+      create: (context: LintMdRuleContext) => ({
+        text: node => {
+          if (node.type === 'text') {
+            const index = node.value.indexOf('(');
+            if (index === -1) {
+              return;
+            }
+            const range = context.sourceCode.getTextRange(node, index, index + 1);
+            context.report({
+              loc: node.position,
+              message: 'replace parenthesis',
+              fix: fixer => fixer.replaceTextRange(range, '（')
+            });
+          }
+        }
+      })
+    };
+
+    const result = lintMarkdownInternal('中文&#40;test', [{ rule }], true);
+    expect(result.fixedResult?.result).toBe('中文（test');
+  });
+
+  test('all rules share the same SourceCode instance', () => {
+    const instances: LintSourceCode[] = [];
+
+    const makeRule = (name: string): LintMdRule => ({
+      meta: { name },
+      create: context => {
+        instances.push(context.sourceCode);
+        return {};
+      }
+    });
+
+    runLint('中文', [{ rule: makeRule('a') }, { rule: makeRule('b') }]);
+    expect(instances).toHaveLength(2);
+    expect(instances[0]).toBe(instances[1]);
+  });
+
+  test('getRaw returns original Markdown for a node', () => {
+    let capturedContext: LintMdRuleContext | undefined;
+    const rule: LintMdRule = {
+      meta: { name: 'getraw-test' },
+      create: context => {
+        capturedContext = context;
+        return {};
+      }
+    };
+
+    runLint('**bold**', [{ rule }]);
+    const sourceCode = capturedContext!.sourceCode;
+    const raw = sourceCode.getRaw(sourceCode.ast);
+    expect(raw).toBe('**bold**');
+  });
+
+  test('getTextRange maps entity to complete source range', () => {
+    const rule: LintMdRule = {
+      meta: { name: 'entity-range-test' },
+      create: (context: LintMdRuleContext) => ({
+        text: node => {
+          if (node.type === 'text') {
+            const ampIndex = node.value.indexOf('&');
+            if (ampIndex === -1) return;
+            const range = context.sourceCode.getTextRange(node, ampIndex, ampIndex + 1);
+            // complete &#40; must be [2, 7] (6-char entity + preceding Chinese)
+            expect(range).toStrictEqual([2, 7]);
+          }
+        }
+      })
+    };
+    runLint('中文&#40;', [{ rule }]);
+  });
+
+  test('context still exposes legacy ast and markdown fields', () => {
+    const rule: LintMdRule = {
+      meta: { name: 'legacy-fields-test' },
+      create: context => {
+        expect(context.markdown).toBe('中文');
+        expect(context.ast.type).toBe('root');
+        expect(context.options).toEqual({});
+        expect(typeof context.report).toBe('function');
+        return {};
+      }
+    };
+    runLint('中文', [{ rule }]);
+  });
+});

--- a/__tests__/unit/utils/rule-manager.spec.ts
+++ b/__tests__/unit/utils/rule-manager.spec.ts
@@ -1,12 +1,19 @@
 import { createRuleManager } from '../../../src/utils/rule-manager';
 
+const fakeSourceCode = {
+  text: '',
+  ast: {} as any,
+  getRaw: () => '',
+  getTextRange: () => [0, 0] as [number, number]
+} as any;
+
 describe('test rule-manager report content fallback', () => {
   test('report with offset slices only the reported range', () => {
     const markdown = 'line1\nline2\nline3';
     const manager = createRuleManager(markdown);
     const context = manager.createRuleContext(
       { rule: { meta: { name: 'demo' }, create: () => ({}) } as any, options: {} },
-      { ast: {} as any, markdown }
+      { ast: {} as any, markdown, sourceCode: fakeSourceCode }
     );
 
     context.report({
@@ -28,7 +35,7 @@ describe('test rule-manager report content fallback', () => {
     const manager = createRuleManager(markdown);
     const context = manager.createRuleContext(
       { rule: { meta: { name: 'demo' }, create: () => ({}) } as any, options: {} },
-      { ast: {} as any, markdown }
+      { ast: {} as any, markdown, sourceCode: fakeSourceCode }
     );
 
     context.report({

--- a/etc/core.api.md
+++ b/etc/core.api.md
@@ -136,6 +136,8 @@ export interface LintMdRuleContext {
     options: Record<string, any>;
     // (undocumented)
     report: (option: Omit<ReportOption, 'content' | 'name'>) => void;
+    // (undocumented)
+    sourceCode: LintSourceCode;
 }
 
 // @public (undocumented)
@@ -161,6 +163,18 @@ export interface LintReportItem {
     name: string;
     // (undocumented)
     severity: RULE_SEVERITY;
+}
+
+// @public (undocumented)
+export interface LintSourceCode {
+    // (undocumented)
+    readonly ast: PositionedMarkdownRoot;
+    // (undocumented)
+    getRaw(node: PositionedMarkdownNode): string;
+    // (undocumented)
+    getTextRange(node: PositionedTextNode, valueStart: number, valueEnd: number): TextRange;
+    // (undocumented)
+    readonly text: string;
 }
 
 // @public (undocumented)

--- a/src/core/run-lint.ts
+++ b/src/core/run-lint.ts
@@ -5,6 +5,7 @@ import { createTraverser } from '../utils/traverser';
 import { createRuleManager } from '../utils/rule-manager';
 import { createRuleErrorCollector } from '../utils/rule-execution-errors';
 import { registerTextNodeSourceMap } from '../utils/text-scanner';
+import { createLintSourceCode } from '../utils/source-code';
 
 /**
  * 基于各种 rules 对 Markdown 文本进行校验
@@ -35,6 +36,8 @@ export const runLint = (
   const { ast, sourceMap } = parseMdWithSourceMap(markdown);
   registerTextNodeSourceMap(ast, sourceMap);
 
+  const sourceCode = createLintSourceCode({ text: markdown, ast, sourceMap });
+
   // 全局规则管理器（传入 collector，使 fix 阶段捕获生效）
   const ruleManager = createRuleManager(markdown, collector);
 
@@ -54,7 +57,7 @@ export const runLint = (
   for (const { rule, options: ruleOptions } of allRuleConfigs) {
     const ruleContext = ruleManager.createRuleContext(
       { rule, options: ruleOptions },
-      { ast, markdown }
+      { ast, markdown, sourceCode }
     );
 
     // create 阶段也可能抛错，需在调用 create 处捕获并归入规则执行错误。

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,12 +71,32 @@ export interface ReportOption {
   fix?: (fixer: ReturnType<typeof createFixer>) => FixConfig
 }
 
+/** Source code and mapping service for the current lint document */
+export interface LintSourceCode {
+  /** Complete original Markdown input */
+  readonly text: string
+  /** Parsed AST associated with this source document */
+  readonly ast: PositionedMarkdownRoot
+  /** Return the complete raw Markdown represented by a node */
+  getRaw(node: PositionedMarkdownNode): string
+  /**
+   * Convert a range in normalized text-node value to an absolute
+   * range in the original Markdown as `[start, end)`.
+   */
+  getTextRange(
+    node: PositionedTextNode,
+    valueStart: number,
+    valueEnd: number
+  ): TextRange
+}
+
 /** rules 上下文 */
 export interface LintMdRuleContext {
   report: (option: Omit<ReportOption, 'content' | 'name'>) => void
   options: Record<string, any>
   ast: PositionedMarkdownRoot
   markdown: string
+  sourceCode: LintSourceCode
 }
 
 /** rule 选择器签名：emitter 已按 node.type 分发，selector 形参可以用 positioned 具体节点类型 */

--- a/src/utils/rule-manager.ts
+++ b/src/utils/rule-manager.ts
@@ -70,10 +70,10 @@ export const createRuleManager = (
   // 初始化一个 rule context
   const createRuleContext = (
     ruleConfig: LintMdRuleWithOptions,
-    extra: Pick<LintMdRuleContext, 'ast' | 'markdown'>
+    extra: Pick<LintMdRuleContext, 'ast' | 'markdown' | 'sourceCode'>
   ): LintMdRuleContext => {
     const { rule, options } = ruleConfig;
-    const { ast, markdown } = extra;
+    const { ast, markdown, sourceCode } = extra;
 
     // 将 (line, column) 换算成文档中的真实偏移；供 offset 缺失时的兜底，避免切片退化成整篇文档。
     const resolveOffset = (line: number, column: number): number => {
@@ -115,7 +115,8 @@ export const createRuleManager = (
       report,
       options: options || {},
       ast,
-      markdown
+      markdown,
+      sourceCode
     };
   };
 

--- a/src/utils/source-code.ts
+++ b/src/utils/source-code.ts
@@ -1,0 +1,37 @@
+import type {
+  MarkdownSourceMap,
+  MarkdownTextNode as ParserMarkdownTextNode
+} from '@lint-md/parser';
+import type { LintSourceCode, PositionedMarkdownNode, PositionedMarkdownRoot, PositionedTextNode } from '../types';
+
+interface SourceCodeOptions {
+  text: string
+  ast: PositionedMarkdownRoot
+  sourceMap: MarkdownSourceMap
+}
+
+export const createLintSourceCode = ({
+  text,
+  ast,
+  sourceMap
+}: SourceCodeOptions): LintSourceCode => ({
+  text,
+  ast,
+
+  getRaw(node: PositionedMarkdownNode): string {
+    return sourceMap.getRaw(node as any);
+  },
+
+  getTextRange(
+    node: PositionedTextNode,
+    valueStart: number,
+    valueEnd: number
+  ): [number, number] {
+    const range = sourceMap.getSourceRange(
+      node as unknown as ParserMarkdownTextNode,
+      valueStart,
+      valueEnd
+    );
+    return [range.start.offset, range.end.offset];
+  }
+});


### PR DESCRIPTION
Part of #187.

## Summary

Add `LintSourceCode` interface and inject it as `context.sourceCode` so
third-party rules can map normalized text ranges to raw Markdown
offsets through the parser source map.

## Changes

| File | Change |
|------|--------|
| `src/types.ts` | Add `LintSourceCode` interface; add `sourceCode` to `LintMdRuleContext` |
| `src/utils/source-code.ts` | `createLintSourceCode()` factory (internal, not exported) |
| `src/core/run-lint.ts` | Create SourceCode per document, pass to `createRuleContext` |
| `src/utils/rule-manager.ts` | Accept `sourceCode` in `createRuleContext` extra params |
| `__tests__/unit/source-code.spec.ts` | Tests: context exposure, entity fix, shared instance, `getRaw`, `getTextRange`, legacy fields |
| `etc/core.api.md` | Updated API report |

## Not included

- `context.report({ range })` range-based reporting
- `getPosition()` / `getLocation()`
- Strict `TextRange` tuple type
- Built-in rule migration
- TextScanner WeakMap removal
- Source mapping error classification

## Design decisions

- `createLintSourceCode()` is not exported — it wraps parser-internal
  `MarkdownSourceMap` and should stay internal to core
- Only `LintSourceCode` interface enters the public API
- `sourceCode` is the single instance per document (shared across rules)
- Legacy `ast` and `markdown` fields remain on context