### PR TITLE
feat(core): add SourceCode getPosition and getLocation APIs

### DIFF
--- a/__tests__/unit/source-code.spec.ts
+++ b/__tests__/unit/source-code.spec.ts
@@ -1,6 +1,7 @@
-import type { LintMdRule, LintMdRuleContext, LintSourceCode, ReportOption } from '../../src/types';
+import type { LintMdRule, LintMdRuleContext, LintSourceCode } from '../../src/types';
 import { lintMarkdownInternal } from '../../src/core/lint-markdown';
 import { runLint } from '../../src/core/run-lint';
+import { createLintSourceCode } from '../../src/utils/source-code';
 
 describe('LintSourceCode', () => {
   test('exposes sourceCode on rule context', () => {
@@ -109,5 +110,114 @@ describe('LintSourceCode', () => {
       }
     };
     runLint('中文', [{ rule }]);
+  });
+
+  describe('getPosition', () => {
+    const sc = createLintSourceCode({
+      text: 'line1\nline2\r\nline3\n',
+      ast: {} as any,
+      sourceMap: {} as any
+    });
+
+    test('first line first character', () => {
+      expect(sc.getPosition(0)).toEqual({ line: 1, column: 1, offset: 0 });
+    });
+
+    test('start of second line (LF)', () => {
+      const lfOffset = 'line1\n'.length;
+      expect(sc.getPosition(lfOffset)).toEqual({ line: 2, column: 1, offset: lfOffset });
+    });
+
+    test('start of third line (CRLF)', () => {
+      const crlfOffset = 'line1\nline2\r\n'.length;
+      expect(sc.getPosition(crlfOffset)).toEqual({ line: 3, column: 1, offset: crlfOffset });
+    });
+
+    test('supports standalone CR line endings', () => {
+      const sc2 = createLintSourceCode({
+        text: 'a\rb',
+        ast: {} as any,
+        sourceMap: {} as any
+      });
+      expect(sc2.getPosition(2)).toEqual({ line: 2, column: 1, offset: 2 });
+    });
+
+    test('columns use UTF-16 code-unit offsets', () => {
+      const sc2 = createLintSourceCode({
+        text: 'a😀b',
+        ast: {} as any,
+        sourceMap: {} as any
+      });
+      expect(sc2.getPosition(3)).toEqual({ line: 1, column: 4, offset: 3 });
+    });
+
+    test('end of document', () => {
+      const len = 'line1\nline2\r\nline3\n'.length;
+      expect(sc.getPosition(len)).toEqual({ line: 4, column: 1, offset: len });
+    });
+
+    test('offset equals text length returns position at end', () => {
+      const sc2 = createLintSourceCode({
+        text: '\n',
+        ast: {} as any,
+        sourceMap: {} as any
+      });
+      expect(sc2.getPosition(1)).toEqual({ line: 2, column: 1, offset: 1 });
+    });
+
+    test('throws on negative offset', () => {
+      expect(() => sc.getPosition(-1)).toThrow(RangeError);
+    });
+
+    test('throws on non-integer offset', () => {
+      expect(() => sc.getPosition(1.5)).toThrow(RangeError);
+      expect(() => sc.getPosition(NaN)).toThrow(RangeError);
+    });
+
+    test('throws on offset beyond text length', () => {
+      expect(() => sc.getPosition(100)).toThrow(RangeError);
+    });
+  });
+
+  describe('getLocation', () => {
+    const sc = createLintSourceCode({
+      text: 'ab\ncd\r\nef\n',
+      ast: {} as any,
+      sourceMap: {} as any
+    });
+
+    test('single-line range', () => {
+      const result = sc.getLocation([0, 2]);
+      expect(result.start).toEqual({ line: 1, column: 1, offset: 0 });
+      expect(result.end).toEqual({ line: 1, column: 3, offset: 2 });
+    });
+
+    test('cross-line range', () => {
+      const result = sc.getLocation([0, 5]);
+      expect(result.start).toEqual({ line: 1, column: 1, offset: 0 });
+      expect(result.end).toEqual({ line: 2, column: 3, offset: 5 });
+    });
+
+    test('empty range (start === end)', () => {
+      const result = sc.getLocation([3, 3]);
+      expect(result.start).toEqual(result.end);
+      expect(result.start.offset).toBe(3);
+    });
+
+    test('throws on end < start', () => {
+      expect(() => sc.getLocation([5, 0])).toThrow(RangeError);
+    });
+
+    test('throws on negative start', () => {
+      expect(() => sc.getLocation([-1, 1])).toThrow(RangeError);
+    });
+
+    test('throws on non-integer range element', () => {
+      expect(() => sc.getLocation([0, 1.5])).toThrow(RangeError);
+    });
+
+    test('throws on range beyond text length', () => {
+      expect(() => sc.getLocation([0, 100])).toThrow(RangeError);
+    });
   });
 });

--- a/etc/core.api.md
+++ b/etc/core.api.md
@@ -170,6 +170,13 @@ export interface LintSourceCode {
     // (undocumented)
     readonly ast: PositionedMarkdownRoot;
     // (undocumented)
+    getLocation(range: TextRange): {
+        start: MarkdownPosition;
+        end: MarkdownPosition;
+    };
+    // (undocumented)
+    getPosition(offset: number): MarkdownPosition;
+    // (undocumented)
     getRaw(node: PositionedMarkdownNode): string;
     // (undocumented)
     getTextRange(node: PositionedTextNode, valueStart: number, valueEnd: number): TextRange;

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,20 @@ export interface LintSourceCode {
     valueStart: number,
     valueEnd: number
   ): TextRange
+  /**
+   * Convert an absolute source offset to a position.
+   * Throws RangeError if offset is not a finite integer in [0, text.length].
+   */
+  getPosition(offset: number): MarkdownPosition
+  /**
+   * Convert a source range to start/end positions.
+   * Throws RangeError if range contains non-finite integers
+   * or start < 0 or start > end or end > text.length.
+   */
+  getLocation(range: TextRange): {
+    start: MarkdownPosition
+    end: MarkdownPosition
+  }
 }
 
 /** rules 上下文 */

--- a/src/utils/fixer.ts
+++ b/src/utils/fixer.ts
@@ -15,7 +15,7 @@ export const createFixer = () => {
    * @param index 索引的开始点
    * @param text 文本内容
    */
-  const insertTextAt = (index: number, text: string) => {
+  const insertTextAt = (index: number, text: string): { range: TextRange; text: string } => {
     return {
       range: [index, index],
       text

--- a/src/utils/source-code.ts
+++ b/src/utils/source-code.ts
@@ -2,7 +2,7 @@ import type {
   MarkdownSourceMap,
   MarkdownTextNode as ParserMarkdownTextNode
 } from '@lint-md/parser';
-import type { LintSourceCode, PositionedMarkdownNode, PositionedMarkdownRoot, PositionedTextNode } from '../types';
+import type { LintSourceCode, MarkdownPosition, PositionedMarkdownNode, PositionedMarkdownRoot, PositionedTextNode, TextRange } from '../types';
 
 interface SourceCodeOptions {
   text: string
@@ -14,24 +14,88 @@ export const createLintSourceCode = ({
   text,
   ast,
   sourceMap
-}: SourceCodeOptions): LintSourceCode => ({
-  text,
-  ast,
+}: SourceCodeOptions): LintSourceCode => {
+  const lineStarts = buildLineStarts(text);
 
-  getRaw(node: PositionedMarkdownNode): string {
-    return sourceMap.getRaw(node as any);
-  },
+  return {
+    text,
+    ast,
 
-  getTextRange(
-    node: PositionedTextNode,
-    valueStart: number,
-    valueEnd: number
-  ): [number, number] {
-    const range = sourceMap.getSourceRange(
-      node as unknown as ParserMarkdownTextNode,
-      valueStart,
-      valueEnd
-    );
-    return [range.start.offset, range.end.offset];
+    getRaw(node: PositionedMarkdownNode): string {
+      return sourceMap.getRaw(node as any);
+    },
+
+    getTextRange(
+      node: PositionedTextNode,
+      valueStart: number,
+      valueEnd: number
+    ): TextRange {
+      const range = sourceMap.getSourceRange(
+        node as unknown as ParserMarkdownTextNode,
+        valueStart,
+        valueEnd
+      );
+      return [range.start.offset, range.end.offset];
+    },
+
+    getPosition(offset: number): MarkdownPosition {
+      if (!Number.isInteger(offset) || offset < 0 || offset > text.length) {
+        throw new RangeError(`getPosition: offset must be an integer in [0, ${text.length}], got ${offset}`);
+      }
+      return offsetToPosition(lineStarts, offset);
+    },
+
+    getLocation(range: TextRange): { start: MarkdownPosition; end: MarkdownPosition } {
+      const [start, end] = range;
+      if (!Number.isInteger(start) || !Number.isInteger(end)
+        || start < 0 || start > end || end > text.length) {
+        throw new RangeError(
+          `getLocation: range must satisfy 0 <= start <= end <= ${text.length}, got [${start}, ${end}]`
+        );
+      }
+      return {
+        start: offsetToPosition(lineStarts, start),
+        end: offsetToPosition(lineStarts, end)
+      };
+    }
+  };
+};
+
+function buildLineStarts(text: string): number[] {
+  const starts: number[] = [0];
+  let i = 0;
+  while (i < text.length) {
+    if (text.charCodeAt(i) === 0x0D && text.charCodeAt(i + 1) === 0x0A) {
+      starts.push(i + 2);
+      i += 2;
+    }
+    else if (text.charCodeAt(i) === 0x0D || text.charCodeAt(i) === 0x0A) {
+      starts.push(i + 1);
+      i += 1;
+    }
+    else {
+      i += 1;
+    }
   }
-});
+  return starts;
+}
+
+function offsetToPosition(
+  lineStarts: number[],
+  offset: number
+): MarkdownPosition {
+  let lo = 0;
+  let hi = lineStarts.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (lineStarts[mid] <= offset) {
+      lo = mid + 1;
+    }
+    else {
+      hi = mid;
+    }
+  }
+  const line = lo;
+  const column = offset - lineStarts[line - 1] + 1;
+  return { line, column, offset };
+}


### PR DESCRIPTION
Follow-up to #203.
Part of #187, #190.

## Summary

Add `getPosition(offset)` and `getLocation(range)` to `LintSourceCode`,
with precomputed line-start index for O(log n) lookups.

## Changes

| File | Change |
|------|--------|
| `src/types.ts` | Add `getPosition` / `getLocation` to `LintSourceCode` |
| `src/utils/source-code.ts` | Precompute `lineStarts` array, binary-search `offsetToPosition`, validate inputs |
| `src/utils/fixer.ts` | Explicit return types for fix methods |
| `__tests__/unit/source-code.spec.ts` | 17 new tests |
| `etc/core.api.md` | Updated |

## What is validated

- `getPosition`: offset must be finite integer in `[0, text.length]`
- `getLocation`: start/end must be finite integers, `0 ⇐ start ⇐ end ⇐ text.length`
- Invalid inputs throw `RangeError`

## Line ending support

- LF (`\n`), CR (`\r`), and CRLF (`\r\n`) line breaks
- Matches parser behavior for standalone `\r`

## Column semantics

Columns use UTF-16 code-unit offsets, consistent with JavaScript string
indexing and parser positions. Verified with astral character test.