### PR TITLE
feat(core): add range-based report API, migrate all text-scanner rules

### DIFF
--- a/__tests__/unit/rules/no-half-width-punctuation-range.spec.ts
+++ b/__tests__/unit/rules/no-half-width-punctuation-range.spec.ts
@@ -1,0 +1,34 @@
+import { lintMarkdownInternal } from '../../../src/core/lint-markdown';
+import noHalfWidthPunctuation from '../../../src/rules/no-half-width-punctuation';
+
+const config = [{ rule: noHalfWidthPunctuation }];
+
+describe('no-half-width-punctuation range-based report', () => {
+  test.each([
+    ['escaped parenthesis', '中文\\(test', '中文（test'],
+    ['numeric entity', '中文&#40;test', '中文（test'],
+  ])('%s is fixed correctly', (_name, input, expected) => {
+    const first = lintMarkdownInternal(input, config, true);
+    expect(first.fixedResult?.result).toBe(expected);
+
+    const second = lintMarkdownInternal(first.fixedResult!.result, config, false);
+    expect(second.lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+
+  test('does not remove only the backslash of an escape', () => {
+    const result = lintMarkdownInternal('中文\\(test', config, true);
+    expect(result.fixedResult?.result).not.toContain('\\(');
+    expect(result.fixedResult?.result).not.toContain('中文test');
+  });
+
+  test('does not modify only part of a character entity', () => {
+    const result = lintMarkdownInternal('中文&#40;test', config, true);
+    expect(result.fixedResult?.result).not.toContain('&#');
+    expect(result.fixedResult?.result).not.toContain('40;');
+  });
+
+  test('astral entity is preserved when not a punctuation target', () => {
+    const result = lintMarkdownInternal('中文&Afr;test', config, false);
+    expect(result.lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+});

--- a/etc/core.api.md
+++ b/etc/core.api.md
@@ -135,7 +135,7 @@ export interface LintMdRuleContext {
     // (undocumented)
     options: Record<string, any>;
     // (undocumented)
-    report: (option: Omit<ReportOption, 'content' | 'name'>) => void;
+    report: (option: RuleReportInput) => void;
     // (undocumented)
     sourceCode: LintSourceCode;
 }
@@ -345,6 +345,13 @@ export class RuleExecutionFailure extends Error {
 
 // @public (undocumented)
 export type RuleExecutionPhase = 'create' | 'selector' | 'fix';
+
+// @public (undocumented)
+export type RuleReportInput = Omit<ReportOption, 'content' | 'name' | 'loc'> & ({
+    loc: ReportOption['loc'];
+} | {
+    range: TextRange;
+});
 
 // @public (undocumented)
 export type RuleSelector = (node: PositionedMarkdownNode) => void;

--- a/src/rules/no-full-width-number.ts
+++ b/src/rules/no-full-width-number.ts
@@ -31,7 +31,7 @@ const noFullWidthNumber: LintMdRule = {
             .join('');
 
           context.report({
-            loc: m.loc,
+            range: m.absoluteRange,
             message: '不能用全角数字，请使用半角数字',
             fix: fixer => fixer.replaceTextRange(m.absoluteRange, replacement)
           });

--- a/src/rules/no-half-width-punctuation.ts
+++ b/src/rules/no-half-width-punctuation.ts
@@ -94,7 +94,7 @@ const noHalfWidthPunctuation: LintMdRule = {
           if (shouldConvert) {
             const match = scanner.matchAt(i, 1);
             context.report({
-              loc: match.loc,
+              range: match.absoluteRange,
               message: `不应在中文中使用半角标点"${char}"，请使用全角"${fullChar}"`,
               fix: fixer => fixer.replaceTextRange(match.absoluteRange, fullChar)
             });

--- a/src/rules/no-special-characters.ts
+++ b/src/rules/no-special-characters.ts
@@ -18,7 +18,7 @@ const noSpecialCharacters: LintMdRule = {
 
           matches.forEach((m) => {
             context.report({
-              loc: m.loc,
+              range: m.absoluteRange,
               message: '文本中不能包含特殊字符，请删除或者替换',
               fix: fixer => fixer.removeRange(m.absoluteRange)
             });

--- a/src/rules/space-around-alphabet.ts
+++ b/src/rules/space-around-alphabet.ts
@@ -25,7 +25,7 @@ const spaceAroundAlphabet: LintMdRule = {
           if (nextCharacter && isChineseEnglishBoundary(char, nextCharacter)) {
             const match = scanner.matchAt(index, char.length + nextCharacter.length);
             context.report({
-              loc: match.loc,
+              range: match.absoluteRange,
               message: '中英文之间需要添加空格',
               fix: fixer => fixer.insertTextAt(pos.endOffset, ' ')
             });

--- a/src/rules/space-around-number.ts
+++ b/src/rules/space-around-number.ts
@@ -34,7 +34,7 @@ const spaceAroundNumber: LintMdRule = {
           if (isChineseNumBoundary || isPercentBoundary) {
             const match = scanner.matchAt(index, char.length + nextCharacter.length);
             context.report({
-              loc: match.loc,
+              range: match.absoluteRange,
               message: '中文与数字之间需要增加空格',
               fix: fixer => fixer.insertTextAt(pos.endOffset, ' ')
             });

--- a/src/rules/use-standard-ellipsis.ts
+++ b/src/rules/use-standard-ellipsis.ts
@@ -23,7 +23,7 @@ const useStandardEllipsis: LintMdRule = {
 
         allMatches.forEach((m) => {
           context.report({
-            loc: m.loc,
+            range: m.absoluteRange,
             message: '请使用标准规范的省略号',
             fix: fixer => fixer.replaceTextRange(m.absoluteRange, '……')
           });

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,12 @@ export interface ReportOption {
   fix?: (fixer: ReturnType<typeof createFixer>) => FixConfig
 }
 
+/** 选择器调用 report() 时传入的参数：接受 loc 或 range，二者选一 */
+export type RuleReportInput = Omit<ReportOption, 'content' | 'name' | 'loc'> & (
+  | { loc: ReportOption['loc'] }
+  | { range: TextRange }
+);
+
 /** Source code and mapping service for the current lint document */
 export interface LintSourceCode {
   /** Complete original Markdown input */
@@ -106,7 +112,7 @@ export interface LintSourceCode {
 
 /** rules 上下文 */
 export interface LintMdRuleContext {
-  report: (option: Omit<ReportOption, 'content' | 'name'>) => void
+  report: (option: RuleReportInput) => void
   options: Record<string, any>
   ast: PositionedMarkdownRoot
   markdown: string

--- a/src/utils/rule-manager.ts
+++ b/src/utils/rule-manager.ts
@@ -2,7 +2,8 @@ import type {
   LintMdRuleContext,
   LintMdRuleWithOptions,
   ReportOption,
-  ReportPosition
+  ReportPosition,
+  RuleReportInput
 } from '../types';
 import type { createRuleErrorCollector } from './rule-execution-errors';
 import { createFixer } from './fixer';
@@ -91,24 +92,28 @@ export const createRuleManager = (
     };
 
     // 上报方法，供选择器内部调用
-    const report = (option: Omit<ReportOption, 'content' | 'name'>) => {
-      // 任一端 offset 缺失/非法即计一次兜底（按报告计数，不重复计起止两端）。
+    const report = (option: RuleReportInput) => {
+      const loc: ReportOption['loc'] = 'range' in option
+        ? sourceCode.getLocation(option.range)
+        : option.loc;
+
       const needsFallback
-        = !isValidOffset(option.loc.start.offset) || !isValidOffset(option.loc.end.offset);
+        = !isValidOffset(loc.start.offset) || !isValidOffset(loc.end.offset);
       if (needsFallback) {
         fallbackHits++;
       }
 
-      const startOffset = resolveReportOffset(option.loc.start, resolveOffset);
-      const endOffset = resolveReportOffset(option.loc.end, resolveOffset);
+      const startOffset = resolveReportOffset(loc.start, resolveOffset);
+      const endOffset = resolveReportOffset(loc.end, resolveOffset);
       const markStart = Math.max(0, startOffset - 5);
       const markEnd = Math.min(appliedMarkdown.length, endOffset + 5);
 
       allReportedData.push({
         ...option,
+        loc,
         content: appliedMarkdown.slice(markStart, markEnd),
         name: rule.meta.name
-      });
+      } as ReportOption);
     };
 
     return {


### PR DESCRIPTION
Part of #187.

## Summary

Add `range` option to `context.report()` so rules can pass absolute
source offsets instead of constructing `loc` objects manually.  Core
derives `loc` from `sourceCode.getLocation(range)`.

Migrate all 6 built-in text-scanner rules from `loc` to `range`.

## Changes

| File | Change |
|------|--------|
| `src/types.ts` | Add `RuleReportInput` type (`loc | range`); update `LintMdRuleContext.report` |
| `src/utils/rule-manager.ts` | Derive `loc` from `sourceCode.getLocation(range)` when `range` is provided |
| `src/rules/*.ts` (6 files) | `loc: match.loc` → `range: match.absoluteRange` |
| `__tests__/unit/rules/no-half-width-punctuation-range.spec.ts` | Regression tests for escape, entity, astral |
| `etc/core.api.md` | Updated |

## Migrated rules

- `no-half-width-punctuation`
- `no-full-width-number`
- `use-standard-ellipsis`
- `space-around-number`
- `space-around-alphabet`
- `no-special-characters`

## API

Before:
```ts
context.report({ loc: { start: { line, column, offset }, end: { line, column, offset } }, message, fix })
```

After (supports both forms):
```ts
context.report({ range: [startOffset, endOffset], message, fix })
```