### PR TITLE
fix(core): allow adjacent non-overlapping fixes

### DIFF
--- a/__tests__/unit/apply-fix.spec.ts
+++ b/__tests__/unit/apply-fix.spec.ts
@@ -106,6 +106,29 @@ describe('test apply fix', () => {
     });
   });
 
+  test('an insertion blocks a replacement at the same offset', () => {
+    const skippedFix: FixConfig = {
+      text: 'C',
+      range: [2, 3]
+    };
+    const fixes: FixConfig[] = [
+      {
+        text: 'B',
+        range: [1, 2]
+      },
+      {
+        text: '-',
+        range: [2, 2]
+      },
+      skippedFix
+    ];
+
+    expect(applyFix('abcd', fixes)).toStrictEqual({
+      result: 'aB-cd',
+      notAppliedFixes: [skippedFix]
+    });
+  });
+
   test('skips a truly overlapping replacement range', () => {
     const skippedFix: FixConfig = {
       text: 'Y',

--- a/__tests__/unit/apply-fix.spec.ts
+++ b/__tests__/unit/apply-fix.spec.ts
@@ -70,6 +70,80 @@ describe('test apply fix', () => {
     ]);
   });
 
+  test('applies adjacent replacement ranges in one round', () => {
+    const fixes: FixConfig[] = [
+      {
+        text: 'B',
+        range: [1, 2]
+      },
+      {
+        text: 'C',
+        range: [2, 3]
+      }
+    ];
+
+    expect(applyFix('abcd', fixes)).toStrictEqual({
+      result: 'aBCd',
+      notAppliedFixes: []
+    });
+  });
+
+  test('applies an insertion at the end of a replacement', () => {
+    const fixes: FixConfig[] = [
+      {
+        text: 'B',
+        range: [1, 2]
+      },
+      {
+        text: '-',
+        range: [2, 2]
+      }
+    ];
+
+    expect(applyFix('abcd', fixes)).toStrictEqual({
+      result: 'aB-cd',
+      notAppliedFixes: []
+    });
+  });
+
+  test('skips a truly overlapping replacement range', () => {
+    const skippedFix: FixConfig = {
+      text: 'Y',
+      range: [2, 4]
+    };
+    const fixes: FixConfig[] = [
+      {
+        text: 'X',
+        range: [1, 3]
+      },
+      skippedFix
+    ];
+
+    expect(applyFix('abcde', fixes)).toStrictEqual({
+      result: 'aXde',
+      notAppliedFixes: [skippedFix]
+    });
+  });
+
+  test('keeps the first insertion at the same offset', () => {
+    const skippedFix: FixConfig = {
+      text: 'Y',
+      range: [1, 1]
+    };
+    const fixes: FixConfig[] = [
+      {
+        text: 'X',
+        range: [1, 1]
+      },
+      skippedFix
+    ];
+
+    expect(applyFix('abc', fixes)).toStrictEqual({
+      result: 'aXbc',
+      notAppliedFixes: [skippedFix]
+    });
+  });
+
   test('test the fixes will be sorted by range', () => {
     const content = 'hello world! Do you like JavaScript?';
     const fixes: FixConfig[] = [

--- a/src/utils/apply-fix.ts
+++ b/src/utils/apply-fix.ts
@@ -14,6 +14,7 @@ export const applyFix = (content: string, fixes: FixConfig[]) => {
   // 初始化数据
   let result = '';
   let currentIndex = Number.NEGATIVE_INFINITY;
+  let lastAppliedWasInsertion = false;
 
   // 未被处理的 fix
   const notAppliedFixes: FixConfig[] = [];
@@ -26,8 +27,9 @@ export const applyFix = (content: string, fixes: FixConfig[]) => {
       return;
     }
 
-    // 如果新的 fix 的起始点在当前节点的前面（这是多个 fix 重合导致的，我们会跳过它，并在下一次 fix 中尝试去 fix 它）
-    if (currentIndex >= start) {
+    // A fix overlaps when it starts before the last applied range ends.
+    // An insertion owns its offset. This rule keeps same-offset fixes deterministic.
+    if (currentIndex > start || (currentIndex === start && lastAppliedWasInsertion)) {
       notAppliedFixes.push(fix);
       return;
     }
@@ -38,6 +40,7 @@ export const applyFix = (content: string, fixes: FixConfig[]) => {
     result += fix.text;
     // 将当前索引指向 fix range 的末尾
     currentIndex = end;
+    lastAppliedWasInsertion = start === end;
   };
 
   for (const fix of fixes) {


### PR DESCRIPTION
## Summary

- Apply adjacent replacement ranges in one fix round.
- Keep same-offset insertion conflicts deterministic.
- Add tests for adjacent, overlapping, and same-offset ranges.

## Root cause

The overlap check rejected a fix when its start matched the prior range end. This rule treated adjacent ranges as overlaps.

## Impact

Independent adjacent fixes now apply in one round. True overlaps still skip one fix.

## Checks

- npm test -- --runInBand
- npm run lint
- npm run typecheck
- git diff --check

Closes #207