### PR TITLE
feat(core): report unapplied fix reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ lintMarkdown(
 - `fixedResult`：开启修复模式时返回 `{ result, notAppliedFixes }`（`result` 为修复后的文本，`notAppliedFixes` 为因冲突等原因未能应用的修复项），否则为 `null`
 - `executionErrors`：规则执行失败的结构化列表。非空时，`diagnostics` 与 `lintResult` 可能只是部分结果；CLI 和编辑器 Adapter 应据此标记本次检查不完整。
 
+### Unapplied fix contract
+
+Each `notAppliedFixes` item contains these fields:
+
+- `range`: The fix range for the final fix round.
+- `text`: The replacement text.
+- `targetRule`: The source `rule.meta.name`.
+- `reason`: A stable conflict code.
+
+The `reason` value is `overlap` or `same-offset`.
+`overlap` means that the fix starts inside an applied range.
+`same-offset` means that an earlier insertion owns the same offset.
+The result contains only conflicts from the final fix round.
+The new `targetRule` and `reason` fields use JSON-compatible strings.
+
 下面是一个最小示例，可直接作为接入起点：
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -67,16 +67,19 @@ lintMarkdown(
 
 Each `notAppliedFixes` item contains these fields:
 
-- `range`: The fix range for the final fix round.
+- `range`: The range is relative to the input of the final fix round.
 - `text`: The replacement text.
 - `targetRule`: The source `rule.meta.name`.
 - `reason`: A stable conflict code.
 
+The range is not necessarily relative to the returned `result`.
 The `reason` value is `overlap` or `same-offset`.
 `overlap` means that the fix starts inside an applied range.
 `same-offset` means that an earlier insertion owns the same offset.
 The result contains only conflicts from the final fix round.
 The new `targetRule` and `reason` fields use JSON-compatible strings.
+The optional `data` field remains rule-defined.
+The API does not guarantee that `data` supports JSON serialization.
 
 下面是一个最小示例，可直接作为接入起点：
 

--- a/__tests__/unit/apply-fix.spec.ts
+++ b/__tests__/unit/apply-fix.spec.ts
@@ -58,14 +58,16 @@ describe('test apply fix', () => {
           1,
           3
         ],
-        text: '不太喜欢'
+        text: '不太喜欢',
+        reason: 'overlap'
       },
       {
         range: [
           1,
           3
         ],
-        text: '不怎么喜欢'
+        text: '不怎么喜欢',
+        reason: 'overlap'
       }
     ]);
   });
@@ -125,7 +127,10 @@ describe('test apply fix', () => {
 
     expect(applyFix('abcd', fixes)).toStrictEqual({
       result: 'aB-cd',
-      notAppliedFixes: [skippedFix]
+      notAppliedFixes: [{
+        ...skippedFix,
+        reason: 'same-offset'
+      }]
     });
   });
 
@@ -144,7 +149,10 @@ describe('test apply fix', () => {
 
     expect(applyFix('abcde', fixes)).toStrictEqual({
       result: 'aXde',
-      notAppliedFixes: [skippedFix]
+      notAppliedFixes: [{
+        ...skippedFix,
+        reason: 'overlap'
+      }]
     });
   });
 
@@ -163,7 +171,10 @@ describe('test apply fix', () => {
 
     expect(applyFix('abc', fixes)).toStrictEqual({
       result: 'aXbc',
-      notAppliedFixes: [skippedFix]
+      notAppliedFixes: [{
+        ...skippedFix,
+        reason: 'same-offset'
+      }]
     });
   });
 

--- a/__tests__/unit/core.spec.ts
+++ b/__tests__/unit/core.spec.ts
@@ -3,7 +3,7 @@ import noEmptyCode from '../../src/rules/no-empty-code';
 import { getExample } from '../utils/test-utils';
 import { runLint } from '../../src/core/run-lint';
 import { lintMarkdownInternal } from '../../src/core/lint-markdown';
-import type { LintMdRule } from '../../src/types';
+import type { LintMdRule, NotAppliedFix } from '../../src/types';
 
 describe('test core methods for lint-markdown', () => {
   afterEach(() => {
@@ -182,9 +182,13 @@ Some **importance**, and \`code\`.
 
     expect(res.fixedResult).not.toBeNull();
     expect(res.fixedResult!.result).toBe('X');
-    // ruleB's fix conflicts with ruleA's — should be in notAppliedFixes
-    expect(res.fixedResult!.notAppliedFixes.length).toBe(1);
-    expect(res.fixedResult!.notAppliedFixes[0].text).toBe('Y');
+    const unappliedFix: NotAppliedFix = res.fixedResult!.notAppliedFixes[0];
+    expect(JSON.parse(JSON.stringify(unappliedFix))).toStrictEqual({
+      range: [0, 3],
+      text: 'Y',
+      targetRule: 'replace-to-y',
+      reason: 'overlap'
+    });
   });
 
   test('notAppliedFixes empty when no conflicts', () => {

--- a/__tests__/unit/core.spec.ts
+++ b/__tests__/unit/core.spec.ts
@@ -183,12 +183,17 @@ Some **importance**, and \`code\`.
     expect(res.fixedResult).not.toBeNull();
     expect(res.fixedResult!.result).toBe('X');
     const unappliedFix: NotAppliedFix = res.fixedResult!.notAppliedFixes[0];
-    expect(JSON.parse(JSON.stringify(unappliedFix))).toStrictEqual({
+    expect(unappliedFix).toStrictEqual({
       range: [0, 3],
       text: 'Y',
       targetRule: 'replace-to-y',
       reason: 'overlap'
     });
+    const serializableMetadata = {
+      targetRule: unappliedFix.targetRule,
+      reason: unappliedFix.reason
+    };
+    expect(JSON.parse(JSON.stringify(serializableMetadata))).toStrictEqual(serializableMetadata);
   });
 
   test('notAppliedFixes empty when no conflicts', () => {

--- a/etc/core.api.md
+++ b/etc/core.api.md
@@ -38,7 +38,7 @@ export interface FixedResult {
     // (undocumented)
     metrics?: FixMetrics;
     // (undocumented)
-    notAppliedFixes: FixConfig[];
+    notAppliedFixes: NotAppliedFix[];
     // (undocumented)
     result: string;
     // (undocumented)
@@ -53,6 +53,14 @@ export interface FixMetrics {
     rounds: number;
     // (undocumented)
     wallTime: number;
+}
+
+// @public (undocumented)
+export enum FixNotAppliedReason {
+    // (undocumented)
+    OVERLAP = "overlap",
+    // (undocumented)
+    SAME_OFFSET = "same-offset"
 }
 
 // @public (undocumented)
@@ -235,6 +243,12 @@ export const noSpaceInLink: LintMdRule;
 export const noSpecialCharacters: LintMdRule;
 
 // @public (undocumented)
+export interface NotAppliedFix extends RuleFixConfig {
+    // (undocumented)
+    reason: FixNotAppliedReason;
+}
+
+// @public (undocumented)
 export type PositionedBlockquoteNode = Extract<PositionedMarkdownNode, {
     type: 'blockquote';
 }>;
@@ -345,6 +359,12 @@ export class RuleExecutionFailure extends Error {
 
 // @public (undocumented)
 export type RuleExecutionPhase = 'create' | 'selector' | 'fix';
+
+// @public (undocumented)
+export interface RuleFixConfig extends FixConfig {
+    // (undocumented)
+    targetRule: string;
+}
 
 // @public (undocumented)
 export type RuleReportInput = Omit<ReportOption, 'content' | 'name' | 'loc'> & ({

--- a/src/core/handle-fix-mode.ts
+++ b/src/core/handle-fix-mode.ts
@@ -1,4 +1,4 @@
-import type { FixConfig, FixMetrics, LintMdRuleWithOptions } from '../types';
+import type { FixMetrics, LintMdRuleWithOptions, NotAppliedFix } from '../types';
 import { FixConvergence } from '../types';
 import { MAX_LINT_AND_FIX_CALL_TIMES } from '../common/constant';
 import { applyFix } from '../utils/apply-fix';
@@ -16,7 +16,7 @@ export const handleFixMode = (
   const allExecutionErrors: ReturnType<typeof runLint>['executionErrors'] = [];
 
   let current = markdown;
-  let lastNotAppliedFixes: FixConfig[] = [];
+  let lastNotAppliedFixes: NotAppliedFix[] = [];
 
   // 记录已处理过的文本状态，用于检测振荡循环（如 A -> B -> A）。
   const seenTexts = new Set<string>();

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,22 @@ export interface FixConfig {
   data?: Record<string, unknown>
 }
 
+/** Stable reason code for an unapplied fix. */
+export enum FixNotAppliedReason {
+  OVERLAP = 'overlap',
+  SAME_OFFSET = 'same-offset'
+}
+
+/** A fix with its source rule ID. */
+export interface RuleFixConfig extends FixConfig {
+  targetRule: string
+}
+
+/** A fix that the engine skipped because it conflicts with another fix. */
+export interface NotAppliedFix extends RuleFixConfig {
+  reason: FixNotAppliedReason
+}
+
 /** 上报信息配置 */
 export interface ReportOption {
   name: string
@@ -267,7 +283,7 @@ export interface FixedResult {
    * 最终轮次中因冲突等原因未能应用的修复项。
    * range 基于 result 文本的坐标，可直接用于 result。
    */
-  notAppliedFixes: FixConfig[]
+  notAppliedFixes: NotAppliedFix[]
   /** 收敛状态，调用方可据此判断质量而非盲用文本（兼容扩展，历史构造方式仍可用） */
   convergence?: FixConvergence
   /** 实际执行的 runLint 轮数（兼容扩展，历史构造方式仍可用） */

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,11 @@ export interface RuleFixConfig extends FixConfig {
   targetRule: string
 }
 
-/** A fix that the engine skipped because it conflicts with another fix. */
+/**
+ * A fix that the engine skipped because it conflicts with another fix.
+ * `targetRule` and `reason` are JSON-compatible strings.
+ * The inherited `data` field remains rule-defined and might not support JSON serialization.
+ */
 export interface NotAppliedFix extends RuleFixConfig {
   reason: FixNotAppliedReason
 }
@@ -280,8 +284,9 @@ export interface FixedResult {
   /** 修复后的完整 Markdown 文本 */
   result: string
   /**
-   * 最终轮次中因冲突等原因未能应用的修复项。
-   * range 基于 result 文本的坐标，可直接用于 result。
+   * Fixes that conflict during the final fix round.
+   * Each range uses the input coordinates from that round.
+   * A range is not guaranteed to apply directly to result.
    */
   notAppliedFixes: NotAppliedFix[]
   /** 收敛状态，调用方可据此判断质量而非盲用文本（兼容扩展，历史构造方式仍可用） */

--- a/src/utils/apply-fix.ts
+++ b/src/utils/apply-fix.ts
@@ -1,11 +1,18 @@
 import type { FixConfig } from '../types';
+import { FixNotAppliedReason } from '../types';
+
+const addReason = <T extends FixConfig>(
+  fix: T,
+  reason: FixNotAppliedReason
+): T & { reason: FixNotAppliedReason } =>
+  ({ ...fix, reason }) as T & { reason: FixNotAppliedReason };
 
 /**
  * 基于多个 fix 来修复一个字符串，关于 fix 的数据结构请查看相关类型定义
  *
  * @date 2021-12-14 15:48:27
  */
-export const applyFix = (content: string, fixes: FixConfig[]) => {
+export const applyFix = <T extends FixConfig>(content: string, fixes: T[]) => {
   // 对所有的 fix 进行排序
   fixes.sort((a, b) => {
     return a.range[0] - b.range[0] || a.range[1] - b.range[1];
@@ -17,9 +24,9 @@ export const applyFix = (content: string, fixes: FixConfig[]) => {
   let lastAppliedWasInsertion = false;
 
   // 未被处理的 fix
-  const notAppliedFixes: FixConfig[] = [];
+  const notAppliedFixes: Array<T & { reason: FixNotAppliedReason }> = [];
 
-  const tryApplyOneFix = (fix: FixConfig) => {
+  const tryApplyOneFix = (fix: T) => {
     const [start, end] = fix.range;
 
     // 不合法 range
@@ -29,8 +36,13 @@ export const applyFix = (content: string, fixes: FixConfig[]) => {
 
     // A fix overlaps when it starts before the last applied range ends.
     // An insertion owns its offset. This rule keeps same-offset fixes deterministic.
-    if (currentIndex > start || (currentIndex === start && lastAppliedWasInsertion)) {
-      notAppliedFixes.push(fix);
+    if (currentIndex > start) {
+      notAppliedFixes.push(addReason(fix, FixNotAppliedReason.OVERLAP));
+      return;
+    }
+
+    if (currentIndex === start && lastAppliedWasInsertion) {
+      notAppliedFixes.push(addReason(fix, FixNotAppliedReason.SAME_OFFSET));
       return;
     }
 

--- a/src/utils/apply-fix.ts
+++ b/src/utils/apply-fix.ts
@@ -5,7 +5,7 @@ const addReason = <T extends FixConfig>(
   fix: T,
   reason: FixNotAppliedReason
 ): T & { reason: FixNotAppliedReason } =>
-  ({ ...fix, reason }) as T & { reason: FixNotAppliedReason };
+    ({ ...fix, reason }) as T & { reason: FixNotAppliedReason };
 
 /**
  * 基于多个 fix 来修复一个字符串，关于 fix 的数据结构请查看相关类型定义

--- a/src/utils/rule-manager.ts
+++ b/src/utils/rule-manager.ts
@@ -3,6 +3,7 @@ import type {
   LintMdRuleWithOptions,
   ReportOption,
   ReportPosition,
+  RuleFixConfig,
   RuleReportInput
 } from '../types';
 import type { createRuleErrorCollector } from './rule-execution-errors';
@@ -49,7 +50,7 @@ export const createRuleManager = (
   // 暴露 collector 中已收集的规则执行错误（含 fix 阶段），供单测与上层聚合读取。
   const getExecutionErrors = () => collector?.getErrors() ?? [];
 
-  const getAllFixes = () =>
+  const getAllFixes = (): RuleFixConfig[] =>
     allReportedData.flatMap((item) => {
       if (typeof item.fix === 'function') {
         try {


### PR DESCRIPTION
## Summary

- Add stable reason codes to unapplied fixes.
- Include the source rule ID in the public result.
- Document the result contract.
- Add conflict and serialization tests.

## Root cause

The engine returned skipped fixes without a conflict reason. The runtime rule ID was missing from public types.

## Impact

Consumers can identify overlap and same-offset conflicts. Consumers can also identify the source rule.

## Checks

- npm test -- --runInBand
- npm run lint
- npm run typecheck
- npm run api:check
- npm run package-contract
- git diff --check

Closes #209