### PR TITLE
fix(core): support CR report offset fallback

### DIFF
--- a/__tests__/unit/rule-manager-offset-fallback.spec.ts
+++ b/__tests__/unit/rule-manager-offset-fallback.spec.ts
@@ -109,6 +109,39 @@ describe('rule-manager offset contract: resolveOffset fallback slices correctly 
     expect(data[0].content.length).toBeLessThan(md.length);
     expect(data[0].content).toContain('加粗 中文');
   });
+
+  test.each([
+    ['LF', '\n'],
+    ['CRLF', '\r\n'],
+    ['CR', '\r']
+  ])('fallback resolves start and end offsets after %s line endings', (_label, lineEnding) => {
+    const md = ['first', 'second', 'third TARGET tail'].join(lineEnding);
+    const target = 'TARGET';
+    const start = md.indexOf(target);
+    const end = start + target.length;
+    const rule: LintMdRule = {
+      meta: { name: 'line-ending-fallback' },
+      create: context => ({
+        root: () => {
+          context.report({
+            loc: {
+              start: { line: 3, column: 7 },
+              end: { line: 3, column: 13 }
+            },
+            message: 'report without offsets'
+          });
+        }
+      })
+    };
+
+    const { data, fallbackHits } = runRule(md, rule);
+
+    expect(fallbackHits).toBe(1);
+    expect(data).toHaveLength(1);
+    expect(data[0].content).toBe(
+      md.slice(Math.max(0, start - 5), Math.min(md.length, end + 5))
+    );
+  });
 });
 
 describe('rule-manager offset contract: invalid offsets trigger fallback (#180 P2)', () => {

--- a/src/utils/rule-manager.ts
+++ b/src/utils/rule-manager.ts
@@ -82,12 +82,18 @@ export const createRuleManager = (
       let offset = 0;
       let currentLine = 1;
       while (currentLine < line && offset < appliedMarkdown.length) {
-        const next = appliedMarkdown.indexOf('\n', offset);
-        if (next === -1) {
-          break;
+        const char = appliedMarkdown[offset];
+        if (char === '\r') {
+          offset += appliedMarkdown[offset + 1] === '\n' ? 2 : 1;
+          currentLine += 1;
         }
-        offset = next + 1;
-        currentLine += 1;
+        else if (char === '\n') {
+          offset += 1;
+          currentLine += 1;
+        }
+        else {
+          offset += 1;
+        }
       }
       return Math.min(appliedMarkdown.length, offset + Math.max(0, column - 1));
     };


### PR DESCRIPTION
## Summary

- Support lone CR line endings in report offset fallback.
- Keep LF and CRLF offset behavior unchanged.
- Add fallback tests for LF, CRLF, and CR inputs.

## Root cause

The fallback only scanned for LF characters. It did not advance past lone CR line endings.

## Validation

- `npx jest --no-cache --runInBand --coverage=false`
- `npm run typecheck`
- `npm run lint`

Fixes #208
