### PR TITLE
chore: lint tests and maintenance scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ npm run typecheck
 npm run build
 ```
 
+`npm run lint` checks TypeScript and MJS files in `src/`, `__tests__/`, and `scripts/`.
+
 ### 维护公共 API
 
 项目使用 [API Extractor](https://api-extractor.com/) 跟踪 `@lint-md/core` 的公开类型接口。API 基线保存在 `etc/core.api.md`，该文件由工具生成，请勿手动编辑。

--- a/__tests__/unit/core.spec.ts
+++ b/__tests__/unit/core.spec.ts
@@ -140,7 +140,7 @@ Some **importance**, and \`code\`.
   test('notAppliedFixes accessible via lintMarkdown public API', () => {
     const ruleA: LintMdRule = {
       meta: { name: 'replace-to-x' },
-      create: (ctx) => ({
+      create: ctx => ({
         text: (node: any) => {
           if (node.value === 'abc') {
             ctx.report({
@@ -158,7 +158,7 @@ Some **importance**, and \`code\`.
 
     const ruleB: LintMdRule = {
       meta: { name: 'replace-to-y' },
-      create: (ctx) => ({
+      create: ctx => ({
         text: (node: any) => {
           if (node.value === 'abc') {
             ctx.report({
@@ -199,7 +199,7 @@ Some **importance**, and \`code\`.
   test('notAppliedFixes empty when no conflicts', () => {
     const ruleA: LintMdRule = {
       meta: { name: 'replace-foo' },
-      create: (ctx) => ({
+      create: ctx => ({
         text: (node: any) => {
           if (node.value === 'foo') {
             ctx.report({

--- a/__tests__/unit/fixable-counts.spec.ts
+++ b/__tests__/unit/fixable-counts.spec.ts
@@ -4,12 +4,12 @@ import type { LintMdRule, LintMdRulesConfig, PositionedTextNode } from '../../sr
 import { RULE_SEVERITY } from '../../src/types';
 
 const makeMockRule = (opts: {
-  name: string;
-  withFix: boolean;
-  matchesText?: string;
+  name: string
+  withFix: boolean
+  matchesText?: string
 }): LintMdRule => ({
   meta: { name: opts.name },
-  create: (context) => ({
+  create: context => ({
     text: (node: PositionedTextNode) => {
       if (opts.matchesText !== undefined && node.value !== opts.matchesText) {
         return;
@@ -19,7 +19,7 @@ const makeMockRule = (opts: {
         message: `mock report from ${opts.name}`,
         ...(opts.withFix
           ? {
-              fix: (fixer) => fixer.replaceTextRange(
+              fix: fixer => fixer.replaceTextRange(
                 [node.position.start.offset, node.position.end.offset],
                 'X'
               )
@@ -32,7 +32,7 @@ const makeMockRule = (opts: {
 
 const disableAllInternal = (): LintMdRulesConfig =>
   Object.fromEntries(
-    Object.values(internalRules).map((rule) => [rule.meta.name, RULE_SEVERITY.OFF])
+    Object.values(internalRules).map(rule => [rule.meta.name, RULE_SEVERITY.OFF])
   );
 
 describe('lintMarkdown() fixable counts (issue #152)', () => {

--- a/__tests__/unit/handle-fix-mode.spec.ts
+++ b/__tests__/unit/handle-fix-mode.spec.ts
@@ -1,16 +1,16 @@
 import { handleFixMode } from '../../src/core/handle-fix-mode';
 import { MAX_LINT_AND_FIX_CALL_TIMES } from '../../src/common/constant';
-import type { LintMdRule, LintMdRuleContext, FixConfig } from '../../src/types';
+import type { LintMdRule, LintMdRuleContext } from '../../src/types';
 import { FixConvergence } from '../../src/types';
 
 function makeRule(config: {
-  name: string;
-  selector: string;
-  reportFn: (ctx: LintMdRuleContext, node: any) => void;
+  name: string
+  selector: string
+  reportFn: (ctx: LintMdRuleContext, node: any) => void
 }): LintMdRule {
   return {
     meta: { name: config.name },
-    create: (ctx) => ({
+    create: ctx => ({
       [config.selector]: (node: any) => config.reportFn(ctx, node)
     })
   };
@@ -195,7 +195,7 @@ describe('handleFixMode', () => {
       name: 'double-a',
       selector: 'text',
       reportFn: (ctx, node) => {
-        if (node.value === 'a'.repeat(Math.pow(2, callCount))) {
+        if (node.value === 'a'.repeat(2 ** callCount)) {
           callCount++;
           ctx.report({
             loc: node.position,
@@ -212,7 +212,7 @@ describe('handleFixMode', () => {
     const result = handleFixMode('a', [{ rule }]);
     // Should hit MAX guard, not exit early
     expect(callCount).toBe(MAX_LINT_AND_FIX_CALL_TIMES);
-    expect(result.fixedResult.result).toBe('a'.repeat(Math.pow(2, MAX_LINT_AND_FIX_CALL_TIMES)));
+    expect(result.fixedResult.result).toBe('a'.repeat(2 ** MAX_LINT_AND_FIX_CALL_TIMES));
   });
 
   test('initialLintResult reflects first round', () => {
@@ -466,7 +466,7 @@ describe('handleFixMode', () => {
       });
     });
 
-    const result = handleFixMode(states[0], rules.map((rule) => ({ rule })));
+    const result = handleFixMode(states[0], rules.map(rule => ({ rule })));
     expect(result.fixedResult.rounds).toBe(MAX_LINT_AND_FIX_CALL_TIMES);
     expect(result.fixedResult.convergence).toBe(FixConvergence.CYCLE_DETECTED);
   });
@@ -477,7 +477,7 @@ describe('handleFixMode', () => {
       name: 'double-a',
       selector: 'text',
       reportFn: (ctx, node) => {
-        if (node.value === 'a'.repeat(Math.pow(2, callCount))) {
+        if (node.value === 'a'.repeat(2 ** callCount)) {
           callCount++;
           ctx.report({ loc: node.position, message: 'double', fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: node.value + node.value }) });
         }
@@ -513,5 +513,4 @@ describe('handleFixMode', () => {
     expect(result.fixedResult.metrics!.rounds).toBe(result.fixedResult.rounds);
     expect(result.fixedResult.metrics!.perRound).toHaveLength(result.fixedResult.rounds);
   });
-
 });

--- a/__tests__/unit/rule-alias.spec.ts
+++ b/__tests__/unit/rule-alias.spec.ts
@@ -4,12 +4,12 @@ import type { LintMdRule, LintMdRulesConfig, PositionedTextNode } from '../../sr
 import { RULE_SEVERITY } from '../../src/types';
 
 const makeMockRule = (opts: {
-  name: string;
-  withFix?: boolean;
-  matchesText?: string;
+  name: string
+  withFix?: boolean
+  matchesText?: string
 }): LintMdRule => ({
   meta: { name: opts.name },
-  create: (context) => ({
+  create: context => ({
     text: (node: PositionedTextNode) => {
       if (opts.matchesText !== undefined && node.value !== opts.matchesText) {
         return;
@@ -19,7 +19,7 @@ const makeMockRule = (opts: {
         message: `mock report from ${opts.name}`,
         ...(opts.withFix
           ? {
-              fix: (fixer) => fixer.replaceTextRange(
+              fix: fixer => fixer.replaceTextRange(
                 [node.position.start.offset, node.position.end.offset],
                 'X'
               )
@@ -32,7 +32,7 @@ const makeMockRule = (opts: {
 
 const disableAllInternal = (): LintMdRulesConfig =>
   Object.fromEntries(
-    Object.values(internalRules).map((rule) => [rule.meta.name, RULE_SEVERITY.OFF])
+    Object.values(internalRules).map(rule => [rule.meta.name, RULE_SEVERITY.OFF])
   );
 
 describe('lintMarkdown() rule alias & config contract (issue #177)', () => {

--- a/__tests__/unit/rule-execution-errors.spec.ts
+++ b/__tests__/unit/rule-execution-errors.spec.ts
@@ -1,4 +1,4 @@
-import { createRuleErrorCollector, RuleExecutionFailure, normalizeErrorMessage } from '../../src/utils/rule-execution-errors';
+import { RuleExecutionFailure, createRuleErrorCollector, normalizeErrorMessage } from '../../src/utils/rule-execution-errors';
 import { runLint } from '../../src/core/run-lint';
 import { handleFixMode } from '../../src/core/handle-fix-mode';
 import type { LintMdRule } from '../../src/types';
@@ -14,7 +14,7 @@ const makeFixRule = (
   fixImpl: () => { range: number[]; text: string }
 ): LintMdRule => ({
   meta: { name },
-  create: (context) => ({
+  create: context => ({
     text: (node: any) => {
       context.report({
         loc: node.position,
@@ -96,7 +96,7 @@ describe('rule-execution-errors', () => {
     const bad: LintMdRule = makeThrowingRule('bad-text', () => { throw new Error('bad'); });
     const good: LintMdRule = {
       meta: { name: 'good-text' },
-      create: (context) => ({
+      create: context => ({
         text: (node: any) => {
           context.report({ loc: node.position, message: 'ok' });
           goodReported = true;
@@ -160,7 +160,7 @@ describe('rule-execution-errors', () => {
     let bFixCalls = 0;
     const fixRule: LintMdRule = {
       meta: { name: 'B' },
-      create: (context) => ({
+      create: context => ({
         text: (node: any) => {
           context.report({
             loc: node.position,

--- a/__tests__/unit/rules/no-half-width-punctuation.spec.ts
+++ b/__tests__/unit/rules/no-half-width-punctuation.spec.ts
@@ -160,7 +160,7 @@ describe('test no-half-width-punctuation', () => {
     expect(fixedResult?.result).toStrictEqual('中文（test）中文');
   });
 
-  test.each(['&copy', '&amp'])('keep non-terminated entity-like text aligned: %s', entity => {
+  test.each(['&copy', '&amp'])('keep non-terminated entity-like text aligned: %s', (entity) => {
     const md = `中文${entity}(test)中文`;
     const { fixedResult, lintResult } = fixer(md);
     expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
@@ -170,7 +170,7 @@ describe('test no-half-width-punctuation', () => {
   test.each([
     '<https://example.com/?a&amp;b>',
     'www.example.com/?a&amp;b'
-  ])('does not reinterpret entities inside an autolink: %s', md => {
+  ])('does not reinterpret entities inside an autolink: %s', (md) => {
     const { executionErrors, lintResult } = fixer(md);
     expect(executionErrors).toHaveLength(0);
     expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
@@ -179,7 +179,7 @@ describe('test no-half-width-punctuation', () => {
   test.each([
     '&#00000049;',
     '&#x0000028;'
-  ])('keeps overlong numeric entity-like text aligned: %s', entity => {
+  ])('keeps overlong numeric entity-like text aligned: %s', (entity) => {
     const md = `中文${entity}(test)中文`;
     const { executionErrors, fixedResult, lintResult } = fixer(md);
     expect(executionErrors).toHaveLength(0);
@@ -194,7 +194,7 @@ describe('test no-half-width-punctuation', () => {
     '&#128;',
     '&#xFDD0;',
     '&#xFFFF;'
-  ])('aligns numeric entities normalized to replacement character: %s', entity => {
+  ])('aligns numeric entities normalized to replacement character: %s', (entity) => {
     const md = `中文${entity}(test)中文`;
     const { executionErrors, fixedResult, lintResult } = fixer(md);
     expect(executionErrors).toHaveLength(0);

--- a/__tests__/unit/source-code.spec.ts
+++ b/__tests__/unit/source-code.spec.ts
@@ -7,7 +7,7 @@ describe('LintSourceCode', () => {
   test('exposes sourceCode on rule context', () => {
     const rule: LintMdRule = {
       meta: { name: 'source-code-test' },
-      create: context => {
+      create: (context) => {
         expect(context.sourceCode).toBeDefined();
         expect(context.sourceCode.text).toBe('中文');
         expect(context.sourceCode.ast).toBe(context.ast);
@@ -22,7 +22,7 @@ describe('LintSourceCode', () => {
     const rule: LintMdRule = {
       meta: { name: 'source-code-range-test' },
       create: (context: LintMdRuleContext) => ({
-        text: node => {
+        text: (node) => {
           if (node.type === 'text') {
             const index = node.value.indexOf('(');
             if (index === -1) {
@@ -48,7 +48,7 @@ describe('LintSourceCode', () => {
 
     const makeRule = (name: string): LintMdRule => ({
       meta: { name },
-      create: context => {
+      create: (context) => {
         instances.push(context.sourceCode);
         return {};
       }
@@ -63,7 +63,7 @@ describe('LintSourceCode', () => {
     let capturedContext: LintMdRuleContext | undefined;
     const rule: LintMdRule = {
       meta: { name: 'getraw-test' },
-      create: context => {
+      create: (context) => {
         capturedContext = context;
         return {};
       }
@@ -81,7 +81,7 @@ describe('LintSourceCode', () => {
     const rule: LintMdRule = {
       meta: { name: 'entity-range-test' },
       create: (context: LintMdRuleContext) => ({
-        text: node => {
+        text: (node) => {
           if (node.type !== 'text') {
             return;
           }
@@ -101,7 +101,7 @@ describe('LintSourceCode', () => {
   test('context still exposes legacy ast and markdown fields', () => {
     const rule: LintMdRule = {
       meta: { name: 'legacy-fields-test' },
-      create: context => {
+      create: (context) => {
         expect(context.markdown).toBe('中文');
         expect(context.ast.type).toBe('root');
         expect(context.options).toEqual({});

--- a/__tests__/unit/source-map-integration.spec.ts
+++ b/__tests__/unit/source-map-integration.spec.ts
@@ -1,11 +1,11 @@
+import { parseMdWithSourceMap } from '@lint-md/parser';
 import { runLint } from '../../src/core/run-lint';
 import { lintMarkdownInternal } from '../../src/core/lint-markdown';
 import { RuleExecutionFailure } from '../../src/utils/rule-execution-errors';
-import { parseMdWithSourceMap } from '@lint-md/parser';
 import { TextScanner } from '../../src/utils/text-scanner';
 import { createLintSourceCode } from '../../src/utils/source-code';
 import noHalfWidthPunctuation from '../../src/rules/no-half-width-punctuation';
-import type { LintMdRule, LintSourceCode } from '../../src/types';
+import type { LintMdRule } from '../../src/types';
 
 const halfWidthConfig = [{ rule: noHalfWidthPunctuation }];
 
@@ -43,7 +43,7 @@ describe('parser source-map integration', () => {
     });
     expect(getTextRange).not.toHaveBeenCalled();
     expect(getLocation).not.toHaveBeenCalled();
-    positions.forEach(pos => void pos.endOffset);
+    expect(positions.map(pos => pos.endOffset)).toEqual([1, 2, 3]);
     expect(getTextRange).toHaveBeenCalledTimes(3);
     expect(getLocation).toHaveBeenCalledTimes(3);
     expect(getTextRange.mock.calls.map(([, start, end]) => [start, end]))
@@ -67,7 +67,7 @@ describe('parser source-map integration', () => {
     const inlineCodeRule: LintMdRule = {
       meta: { name: 'inline-code-source-map' },
       create: context => ({
-        inlineCode: node => {
+        inlineCode: (node) => {
           const match = new TextScanner(node as any, context.sourceCode).matchAt(0, 1);
           context.report({
             loc: match.loc,
@@ -148,7 +148,7 @@ describe('parser source-map integration', () => {
     const atomicRule: LintMdRule = {
       meta: { name: 'atomic-entity' },
       create: context => ({
-        text: node => {
+        text: (node) => {
           const scanner = new TextScanner(node as any, context.sourceCode);
           scanner.forEachChar((char, index) => {
             if (char === '𝔄') {
@@ -172,7 +172,7 @@ describe('parser source-map integration', () => {
     const mutatingRule: LintMdRule = {
       meta: { name: 'mutate-text-node' },
       create: context => ({
-        text: node => {
+        text: (node) => {
           (node as { value: string }).value = 'changed';
           new TextScanner(node as any, context.sourceCode).matchAt(0, 1);
           context.report({ loc: node.position, message: 'unreachable' });

--- a/__tests__/unit/utils/override-default-rules.spec.ts
+++ b/__tests__/unit/utils/override-default-rules.spec.ts
@@ -1,5 +1,5 @@
 import { overrideDefaultRules } from '../../../src/utils/override-default-rules';
-import { RULE_SEVERITY, type LintMdRule } from '../../../src/types';
+import { type LintMdRule, RULE_SEVERITY } from '../../../src/types';
 
 const createMockRule = (name: string): LintMdRule => ({
   meta: { name },
@@ -106,7 +106,7 @@ describe('overrideDefaultRules', () => {
     const rules = JSON.parse('{"__proto__": 2}') as any;
 
     expect(() => overrideDefaultRules(defaultRules, rules)).toThrow(/未知规则/);
-    expect(Object.prototype.hasOwnProperty.call(Object.prototype, 'severity')).toBe(false);
+    expect(Object.hasOwn(Object.prototype, 'severity')).toBe(false);
   });
 
   it('should store third-party rule whose meta.name is a prototype key as plain key without pollution (issue #177)', () => {
@@ -117,10 +117,9 @@ describe('overrideDefaultRules', () => {
       'proto-alias': [protoRule, RULE_SEVERITY.WARN, {}]
     });
 
-    expect(Object.prototype.hasOwnProperty.call(Object.prototype, 'severity')).toBe(false);
-    expect((result as any)['__proto__']).toBeDefined();
-    expect((result as any)['__proto__'].rule).toBe(protoRule);
+    expect(Object.hasOwn(Object.prototype, 'severity')).toBe(false);
+    const protoEntry = Object.getOwnPropertyDescriptor(result, '__proto__')?.value;
+    expect(protoEntry).toBeDefined();
+    expect(protoEntry.rule).toBe(protoRule);
   });
 });
-
-

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "test": "jest --no-cache",
-    "lint": "eslint src/",
+    "lint": "eslint --ext .ts,.mjs src/ __tests__/ scripts/",
     "typecheck": "tsc --noEmit",
     "lib:cjs": "tsc -p tsconfig.json --target ESNext --module commonjs --outDir lib",
     "lib:esm": "tsc -p tsconfig.json --target ESNext --module ESNext --outDir esm",

--- a/scripts/analyze-baseline.mjs
+++ b/scripts/analyze-baseline.mjs
@@ -18,39 +18,49 @@ import { readFileSync } from 'node:fs';
 // ---------------------------------------------------------------------------
 
 function median(values) {
-  if (values.length === 0) return null;
+  if (values.length === 0)
+    return null;
   const sorted = [...values].sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);
   return sorted.length % 2 !== 0 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }
 
 function safeMin(values) {
-  if (values.length === 0) return null;
+  if (values.length === 0)
+    return null;
   return Math.min(...values);
 }
 
 function safeMax(values) {
-  if (values.length === 0) return null;
+  if (values.length === 0)
+    return null;
   return Math.max(...values);
 }
 
 function formatBytes(n) {
-  if (n === null || n === undefined) return 'N/A';
-  if (n === 0) return '0 B';
+  if (n === null || n === undefined)
+    return 'N/A';
+  if (n === 0)
+    return '0 B';
   const abs = Math.abs(n);
-  if (abs >= 1024 * 1024 * 1024) return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GiB`;
-  if (abs >= 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(2)} MiB`;
-  if (abs >= 1024) return `${(n / 1024).toFixed(2)} KiB`;
+  if (abs >= 1024 * 1024 * 1024)
+    return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GiB`;
+  if (abs >= 1024 * 1024)
+    return `${(n / (1024 * 1024)).toFixed(2)} MiB`;
+  if (abs >= 1024)
+    return `${(n / 1024).toFixed(2)} KiB`;
   return `${n} B`;
 }
 
 function formatMs(n) {
-  if (n === null || n === undefined) return 'N/A';
+  if (n === null || n === undefined)
+    return 'N/A';
   return `${Math.round(n)} ms`;
 }
 
 function formatPct(n) {
-  if (n === null || n === undefined) return 'N/A';
+  if (n === null || n === undefined)
+    return 'N/A';
   return `${n.toFixed(1)}%`;
 }
 
@@ -75,7 +85,8 @@ function main() {
   const groups = new Map();
   for (const line of lines) {
     const key = `${line.shape}|${line.bytes}|${line.case}|${line.rule || ''}`;
-    if (!groups.has(key)) groups.set(key, []);
+    if (!groups.has(key))
+      groups.set(key, []);
     groups.get(key).push(line);
   }
 
@@ -108,8 +119,10 @@ function main() {
   // Sort: same shape together, then ascending bytes, then standard case order
   const caseOrder = ['noop', 'input-only', 'parser-only', 'parse-traverse', 'single-rule', 'all-rules', 'fix-mode'];
   rows.sort((a, b) => {
-    if (a.shape !== b.shape) return a.shape.localeCompare(b.shape);
-    if (a.bytes !== b.bytes) return a.bytes - b.bytes;
+    if (a.shape !== b.shape)
+      return a.shape.localeCompare(b.shape);
+    if (a.bytes !== b.bytes)
+      return a.bytes - b.bytes;
     return caseOrder.indexOf(a.caseName) - caseOrder.indexOf(b.caseName) || a.rule.localeCompare(b.rule);
   });
 
@@ -144,10 +157,12 @@ function main() {
   const combos = new Map();
   for (const r of rows) {
     const key = `${r.shape}|${r.bytes}`;
-    if (!combos.has(key)) combos.set(key, { shape: r.shape, bytes: r.bytes, cases: {} });
+    if (!combos.has(key))
+      combos.set(key, { shape: r.shape, bytes: r.bytes, cases: {} });
     const c = combos.get(key);
     if (r.caseName === 'single-rule') {
-      if (!c.singleRuleRows) c.singleRuleRows = [];
+      if (!c.singleRuleRows)
+        c.singleRuleRows = [];
       c.singleRuleRows.push(r);
     }
     c.cases[r.caseName] = r;
@@ -171,7 +186,8 @@ function main() {
 
     // %total is always relative to (allRules - inputOnly); guard against 0/NaN
     const calcPct = (delta) => {
-      if (Math.abs(totalDelta) < 1) return null;
+      if (Math.abs(totalDelta) < 1)
+        return null;
       return delta / totalDelta * 100;
     };
 
@@ -204,7 +220,8 @@ function main() {
       rows2.push({ label: 'fix-mode          ', delta: fixMode.rssMedian - allRulesBase, pct: calcPct(fixMode.rssMedian - allRulesBase), wall: fixMode.wallMedian - allRules.wallMedian, formula: 'fix-mode − all-rules' });
     }
 
-    if (rows2.length === 0) continue;
+    if (rows2.length === 0)
+      continue;
 
     // Print total
     console.log(`  total (all-rules − input-only): ${formatBytes(totalDelta)} ${formatMs(allRules ? allRules.wallMedian : 0)}`);
@@ -212,12 +229,12 @@ function main() {
 
     const col2w = [28, 12, 8, 12];
     const header2 = ['layer', 'rssΔ', '%total', 'wallΔ'].map((s, i) => pad(s, col2w[i])).join(' | ');
-    console.log('  ' + header2);
-    console.log('  ' + '-'.repeat(header2.length));
+    console.log(`  ${header2}`);
+    console.log(`  ${'-'.repeat(header2.length)}`);
 
     for (const r2 of rows2) {
       const vals = [r2.label, formatBytes(r2.delta), formatPct(r2.pct), formatMs(r2.wall)];
-      console.log('  ' + vals.map((s, i) => pad(s, col2w[i])).join(' | '));
+      console.log(`  ${vals.map((s, i) => pad(s, col2w[i])).join(' | ')}`);
     }
 
     // Decision guidance
@@ -225,7 +242,8 @@ function main() {
     if (inputOnly && parserOnly && allRules) {
       if (Math.abs(totalDelta) < 1024 * 1024) {
         console.log('  → Decision: total RSS delta too small/noisy → collect more runs or inspect profiles');
-      } else {
+      }
+      else {
         const parserPct = (parserBase - inputBase) / totalDelta * 100;
         const rulesPct = (allRulesBase - traverseBase) / totalDelta * 100;
         console.log(`  → parser contributes ${parserPct.toFixed(0)}% of total delta`);
@@ -233,9 +251,11 @@ function main() {
 
         if (parserPct >= 70) {
           console.log('  → Decision: parser dominates → Phase 3B (parser optimization)');
-        } else if (rulesPct >= 20) {
+        }
+        else if (rulesPct >= 20) {
           console.log('  → Decision: rules dominate → Phase 3A (text-rule optimization)');
-        } else {
+        }
+        else {
           console.log('  → Decision: evenly distributed → profile both before deciding');
         }
       }

--- a/scripts/benchmark-memory.mjs
+++ b/scripts/benchmark-memory.mjs
@@ -68,9 +68,7 @@ if (process.env.BENCHMARK_CHILD === '1') {
   }
 
   function runInputOnly() {
-    const s = input.slice(0);
-    void s;
-    return { reportCount: 0, fixCount: 0, runLintCalls: 0 };
+    return { reportCount: input.slice(0).length, fixCount: 0, runLintCalls: 0 };
   }
 
   function runParserOnly() {
@@ -93,7 +91,7 @@ if (process.env.BENCHMARK_CHILD === '1') {
       'space-around-number',
       'no-special-characters',
     ];
-    const configs = names.map((n) => ({ rule: TEXT_RULE_IMPORTS[n]() }));
+    const configs = names.map(n => ({ rule: TEXT_RULE_IMPORTS[n]() }));
     const result = runLint(input, configs);
     const reports = result.ruleManager.getReportData();
     const fixes = result.ruleManager.getAllFixes();
@@ -102,7 +100,8 @@ if (process.env.BENCHMARK_CHILD === '1') {
 
   function runSingleRule() {
     const ruleFactory = TEXT_RULE_IMPORTS[ruleName];
-    if (!ruleFactory) throw new Error(`Unknown rule: ${ruleName}`);
+    if (!ruleFactory)
+      throw new Error(`Unknown rule: ${ruleName}`);
     const result = runLint(input, [{ rule: ruleFactory() }]);
     const reports = result.ruleManager.getReportData();
     const fixes = result.ruleManager.getAllFixes();
@@ -135,7 +134,7 @@ if (process.env.BENCHMARK_CHILD === '1') {
   }
 
   const runners = {
-    noop: runNoop,
+    'noop': runNoop,
     'input-only': runInputOnly,
     'parser-only': runParserOnly,
     'parse-traverse': runParseTraverse,
@@ -146,13 +145,15 @@ if (process.env.BENCHMARK_CHILD === '1') {
   };
 
   const runner = runners[caseName];
-  if (!runner) throw new Error(`Unknown case: ${caseName}`);
+  if (!runner)
+    throw new Error(`Unknown case: ${caseName}`);
 
   // Warmup 完成后清零，只统计正式测量（见 #176 评审：避免诊断累计 warmup 而分母仅正式运行）。
   // Warmup
   for (let i = 0; i < warmupCount; i++) {
     runner();
-    if (typeof global.gc === 'function') global.gc();
+    if (typeof global.gc === 'function')
+      global.gc();
   }
 
   // Measure
@@ -195,7 +196,7 @@ if (process.env.BENCHMARK_CHILD === '1') {
     timestamp: new Date().toISOString(),
   };
 
-  process.stdout.write(JSON.stringify(result) + '\n');
+  process.stdout.write(`${JSON.stringify(result)}\n`);
   process.exit(0);
 }
 
@@ -230,13 +231,17 @@ function parseArgs() {
   const opts = { bytes: 65536, shape: 'long-paragraph', runs: 5, warmup: 2, all: false };
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
-    case '-h': case '--help': printHelp(); process.exit(0);
-    case '--bytes': opts.bytes = parseInt(args[++i], 10); break;
-    case '--shape': opts.shape = args[++i]; break;
-    case '--runs': opts.runs = parseInt(args[++i], 10); break;
-    case '--warmup': opts.warmup = parseInt(args[++i], 10); break;
-    case '--all': opts.all = true; break;
-    default: console.error(`Unknown flag: ${args[i]}\n`); printHelp(); process.exit(1);
+      case '-h':
+      case '--help':
+        printHelp();
+        process.exit(0);
+        return opts;
+      case '--bytes': opts.bytes = parseInt(args[++i], 10); break;
+      case '--shape': opts.shape = args[++i]; break;
+      case '--runs': opts.runs = parseInt(args[++i], 10); break;
+      case '--warmup': opts.warmup = parseInt(args[++i], 10); break;
+      case '--all': opts.all = true; break;
+      default: console.error(`Unknown flag: ${args[i]}\n`); printHelp(); process.exit(1);
     }
   }
   return opts;
@@ -269,7 +274,8 @@ function runChildCase(opts) {
     child.stdout.on('data', (chunk) => { stdout += chunk; });
     child.on('error', reject);
     child.on('close', (code) => {
-      if (code !== 0) reject(new Error(`Child exited with code ${code}`));
+      if (code !== 0)
+        reject(new Error(`Child exited with code ${code}`));
       else {
         try { resolve(JSON.parse(stdout.trim())); }
         catch (e) { reject(new Error(`Failed to parse child output: ${e.message}\n${stdout}`)); }
@@ -317,8 +323,8 @@ function repeatToSize(base, targetBytes) {
 }
 
 function generateLongParagraph(targetBytes) {
-  const base = '这是用于性能测试的长段落文本，包含中英文混合内容 test content and numbers 1234567890 以及标点符号。' +
-    CHINESE_CHARS.repeat(10) + ' ' + ENGLISH_WORDS.slice(0, 20).join(' ') + '。';
+  const base = `这是用于性能测试的长段落文本，包含中英文混合内容 test content and numbers 1234567890 以及标点符号。${
+    CHINESE_CHARS.repeat(10)} ${ENGLISH_WORDS.slice(0, 20).join(' ')}。`;
   return repeatToSize(base, targetBytes);
 }
 
@@ -328,8 +334,8 @@ function generateManyParagraphs(targetBytes) {
   let acc = 0;
   let i = 0;
   while (acc < targetBytes) {
-    const p = `## 第${i + 1}个段落标题\n\n这是第${i + 1}个段落的正文内容。` +
-      `包含一些中文文本和 English words mixed together。\n\n`;
+    const p = `## 第${i + 1}个段落标题\n\n这是第${i + 1}个段落的正文内容。`
+      + '包含一些中文文本和 English words mixed together。\n\n';
     const buf = Buffer.from(p, 'utf8');
     if (acc + buf.length > targetBytes) {
       parts.push(buf.slice(0, targetBytes - acc));
@@ -369,20 +375,20 @@ function generateMixedMarkdown(targetBytes) {
 
 function generateHighMatchDensity(targetBytes) {
   // Lots of Chinese + English adjacent text to trigger space-around-alphabet etc.
-  const base = '中文English中文123中文abc测试中文x' + CHINESE_CHARS.slice(0, 5);
+  const base = `中文English中文123中文abc测试中文x${CHINESE_CHARS.slice(0, 5)}`;
   return repeatToSize(base, targetBytes);
 }
 
 function generateLowMatchDensity(targetBytes) {
   // Plain English text — most Chinese rules won't fire.
-  const base = 'This is plain English text for low match density testing. ' +
-    ENGLISH_WORDS.join(' ') + '. ';
+  const base = `This is plain English text for low match density testing. ${
+    ENGLISH_WORDS.join(' ')}. `;
   return repeatToSize(base, targetBytes);
 }
 
 function generateOverlappingFixes(targetBytes) {
   // Content that triggers fixes whose ranges may overlap (e.g. many space insertions).
-  const base = '中文English中文123中文,测试中文;测试中文:测试中文(测试)中文！测试？测试。' + CHINESE_CHARS.slice(0, 5);
+  const base = `中文English中文123中文,测试中文;测试中文:测试中文(测试)中文！测试？测试。${CHINESE_CHARS.slice(0, 5)}`;
   return repeatToSize(base, targetBytes);
 }
 
@@ -408,7 +414,8 @@ function generateInput(shape, bytes) {
     'escape-dense': generateEscapeDense,
   };
   const gen = generators[shape];
-  if (!gen) throw new Error(`Unknown shape: ${shape}`);
+  if (!gen)
+    throw new Error(`Unknown shape: ${shape}`);
   return { input: gen(bytes), shape, bytes };
 }
 
@@ -433,16 +440,17 @@ async function main() {
                 shape, bytes, caseName, ruleName, warmup: opts.warmup,
               });
               result.run = run + 1;
-              process.stdout.write(JSON.stringify(result) + '\n');
+              process.stdout.write(`${JSON.stringify(result)}\n`);
             }
           }
-        } else {
+        }
+        else {
           for (let run = 0; run < opts.runs; run++) {
             const result = await runChildCase({
               shape, bytes, caseName, ruleName: '', warmup: opts.warmup,
             });
             result.run = run + 1;
-            process.stdout.write(JSON.stringify(result) + '\n');
+            process.stdout.write(`${JSON.stringify(result)}\n`);
           }
         }
       }

--- a/scripts/benchmark-memory.mjs
+++ b/scripts/benchmark-memory.mjs
@@ -68,7 +68,8 @@ if (process.env.BENCHMARK_CHILD === '1') {
   }
 
   function runInputOnly() {
-    return { reportCount: input.slice(0).length, fixCount: 0, runLintCalls: 0 };
+    input.slice(0);
+    return { reportCount: 0, fixCount: 0, runLintCalls: 0 };
   }
 
   function runParserOnly() {

--- a/scripts/benchmark-text-scanner.mjs
+++ b/scripts/benchmark-text-scanner.mjs
@@ -30,7 +30,8 @@ function generateMatches(text, count) {
   for (let i = 0; i < count; i++) {
     const idx = step * (i + 1);
     const len = Math.min(5, text.length - idx);
-    if (len > 0) matches.push({ index: idx, length: len });
+    if (len > 0)
+      matches.push({ index: idx, length: len });
   }
   return matches;
 }
@@ -43,7 +44,8 @@ function positionAtLinear(value, startLine, startColumn, startOffset, index) {
     if (value[i] === '\n') {
       line++;
       column = 1;
-    } else {
+    }
+    else {
       column++;
     }
   }
@@ -58,12 +60,14 @@ function matchAtLinear(value, startLine, startColumn, startOffset, index, length
     if (value[index + i] === '\n') {
       endLine++;
       endColumn = 1;
-    } else {
+    }
+    else {
       endColumn++;
     }
   }
   return {
-    index, length,
+    index,
+    length,
     loc: { start: { line: start.line, column: start.column, offset: start.offset }, end: { line: endLine, column: endColumn, offset: start.offset + length } },
     absoluteRange: [start.offset, start.offset + length]
   };
@@ -73,7 +77,8 @@ function matchAtLinear(value, startLine, startColumn, startOffset, index, length
 function buildLineBreakIndices(value) {
   const indices = [];
   for (let i = 0; i < value.length; i++) {
-    if (value[i] === '\n') indices.push(i);
+    if (value[i] === '\n')
+      indices.push(i);
   }
   return indices;
 }
@@ -84,7 +89,8 @@ function positionAtBinary(lineBreakIndices, startLine, startColumn, startOffset,
   let hi = lb.length;
   while (lo < hi) {
     const mid = (lo + hi) >> 1;
-    if (lb[mid] < index) lo = mid + 1;
+    if (lb[mid] < index)
+      lo = mid + 1;
     else hi = mid;
   }
   const line = startLine + lo;
@@ -98,7 +104,8 @@ function matchAtBinary(lineBreakIndices, startLine, startColumn, startOffset, in
   const start = positionAtBinary(lineBreakIndices, startLine, startColumn, startOffset, index);
   const end = positionAtBinary(lineBreakIndices, startLine, startColumn, startOffset, index + length);
   return {
-    index, length,
+    index,
+    length,
     loc: { start: { line: start.line, column: start.column, offset: start.offset }, end: { line: end.line, column: end.column, offset: start.offset + length } },
     absoluteRange: [start.offset, start.offset + length]
   };
@@ -131,9 +138,12 @@ function bench(label, fn, iterations, runs) {
 const args = process.argv.slice(2);
 const opts = { lines: 1000, matches: 500, runs: 5 };
 for (let i = 0; i < args.length; i += 2) {
-  if (args[i] === '--lines') opts.lines = parseInt(args[i + 1], 10);
-  if (args[i] === '--matches') opts.matches = parseInt(args[i + 1], 10);
-  if (args[i] === '--runs') opts.runs = parseInt(args[i + 1], 10);
+  if (args[i] === '--lines')
+    opts.lines = parseInt(args[i + 1], 10);
+  if (args[i] === '--matches')
+    opts.matches = parseInt(args[i + 1], 10);
+  if (args[i] === '--runs')
+    opts.runs = parseInt(args[i + 1], 10);
 }
 
 const text = generateText(opts.lines, 60);
@@ -177,7 +187,8 @@ bench('binary (lazy pre-compute)', () => {
   // New: first matchAt triggers O(n) constructor, then O(log k) per call
   let lb = null;
   for (const m of matches) {
-    if (!lb) lb = buildLineBreakIndices(text);
+    if (!lb)
+      lb = buildLineBreakIndices(text);
     matchAtBinary(lb, 1, 1, 0, m.index, m.length);
   }
 }, Math.round(iterations / 10), opts.runs);
@@ -186,16 +197,22 @@ bench('binary (lazy pre-compute)', () => {
 console.log('\n=== forEachChar simulation (no positionAt calls) ===');
 bench('linear (old constructor)', () => {
   // Old: O(1) constructor, then O(n) forEachChar
-  let line = 1, column = 1;
+  let line = 1;
+  let column = 1;
   for (let i = 0; i < text.length; i++) {
-    if (text[i] === '\n') { line++; column = 1; } else { column++; }
+    if (text[i] === '\n') { line++; column = 1; }
+    else { column++; }
   }
+  return line + column;
 }, iterations, opts.runs);
 bench('binary (new lazy constructor)', () => {
   // New: O(1) constructor (lazy), then O(n) forEachChar
   // Simulate: no positionAt called, so buildLineBreakIndices is never called
-  let line = 1, column = 1;
+  let line = 1;
+  let column = 1;
   for (let i = 0; i < text.length; i++) {
-    if (text[i] === '\n') { line++; column = 1; } else { column++; }
+    if (text[i] === '\n') { line++; column = 1; }
+    else { column++; }
   }
+  return line + column;
 }, iterations, opts.runs);

--- a/scripts/check-package-contract.mjs
+++ b/scripts/check-package-contract.mjs
@@ -21,7 +21,7 @@ const require = createRequire(import.meta.url);
 
 const cjs = require(path.join(root, 'lib', 'index.js'));
 if (typeof cjs.RuleExecutionFailure !== 'function') {
-  throw new Error('CJS entry does not export RuleExecutionFailure');
+  throw new TypeError('CJS entry does not export RuleExecutionFailure');
 }
 
 const esmEntry = await readFile(path.join(root, 'esm', 'index.js'), 'utf8');


### PR DESCRIPTION
# Summary

- Extend ESLint checks to tests and maintenance scripts.
- Fix errors from the expanded lint command.
- Document the lint scope for contributors.

# Validation

- `npm run lint`
- `npm test`
- `npm run typecheck`

Closes #212.
