### PR TITLE
chore: correct npm repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/lint-md.git"
+    "url": "git+https://github.com/lint-md/lint-md.git"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
# Summary

- Set the npm repository URL to the full GitHub repository path.

# Validation

- `npm run build`
- `npm run package-contract`
- `npm pack` metadata check

Closes #210.
