### PR TITLE
refactor(types): define TextRange as a fixed tuple

### DIFF
--- a/__tests__/unit/rule-execution-errors.spec.ts
+++ b/__tests__/unit/rule-execution-errors.spec.ts
@@ -1,7 +1,7 @@
 import { RuleExecutionFailure, createRuleErrorCollector, normalizeErrorMessage } from '../../src/utils/rule-execution-errors';
 import { runLint } from '../../src/core/run-lint';
 import { handleFixMode } from '../../src/core/handle-fix-mode';
-import type { LintMdRule } from '../../src/types';
+import type { FixConfig, LintMdRule } from '../../src/types';
 
 const makeThrowingRule = (name: string, fn: () => void): LintMdRule => ({
   meta: { name },
@@ -11,7 +11,7 @@ const makeThrowingRule = (name: string, fn: () => void): LintMdRule => ({
 // 一个 selector 正常 report 一个 fix 的规则（fix 回调抛错可控）。fix() 仅在 getAllFixes() 时执行。
 const makeFixRule = (
   name: string,
-  fixImpl: () => { range: number[]; text: string }
+  fixImpl: () => FixConfig
 ): LintMdRule => ({
   meta: { name },
   create: context => ({

--- a/__tests__/unit/types.spec.ts
+++ b/__tests__/unit/types.spec.ts
@@ -1,0 +1,14 @@
+import type { TextRange } from '../../src/types';
+
+describe('TextRange', () => {
+  test('requires exactly two offsets', () => {
+    expect([0, 1] satisfies TextRange).toEqual([0, 1]);
+
+    // TextRange requires exactly two offsets.
+    // @ts-expect-error A one-offset range is invalid.
+    expect([0] satisfies TextRange).toEqual([0]);
+
+    // @ts-expect-error A three-offset range is invalid.
+    expect([0, 1, 2] satisfies TextRange).toEqual([0, 1, 2]);
+  });
+});

--- a/etc/core.api.md
+++ b/etc/core.api.md
@@ -391,7 +391,7 @@ export const spaceAroundAlphabet: LintMdRule;
 export const spaceAroundNumber: LintMdRule;
 
 // @public (undocumented)
-export type TextRange = number[];
+export type TextRange = [number, number];
 
 // @public (undocumented)
 export function toALEOutput(diagnostics: LintDiagnostic[], filePath: string): string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export type PositionedTextNode = Extract<PositionedMarkdownNode, { type: 'text' 
 export type PositionedBlockquoteNode = Extract<PositionedMarkdownNode, { type: 'blockquote' }>;
 
 /** 文本范围信息 */
-export type TextRange = number[];
+export type TextRange = [number, number];
 
 /** 修复器配置 */
 export interface FixConfig {


### PR DESCRIPTION
# Summary

- Define `TextRange` as a fixed two-offset tuple.
- Add type checks for invalid range lengths.
- Update the public API report.

# Validation

- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run api:check`

Closes #211.
