### PR TITLE
chore: prepare 2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
-## [2.2.0](https://github.com/lint-md/lint-md/compare/v2.1.6...v2.2.0) - unreleased
+## [2.2.0](https://github.com/lint-md/lint-md/compare/v2.1.6...v2.2.0) - 2026-07-29
 
 ### Features
 
 - **source-code**: add `LintSourceCode` service on `context.sourceCode`, exposing `getRaw()`, `getTextRange()`, `getPosition()`, and `getLocation()` through parser source maps (#203, #204)
 - **report**: add `range` option to `context.report()` — rules pass absolute source offsets, core derives `loc` via `sourceCode.getLocation()` (#206)
 - **api-extractor**: add API Extractor baseline, committed report in `etc/core.api.md`, and CI check (#202)
+- **fix-mode**: expose reasons for fixes that the engine does not apply (#214)
 
 ### Refactoring
 
@@ -16,10 +17,16 @@
 
 - **space-around-alphabet**: use `codePointAt` for supplementary Han characters; preserve Markdown syntax when inserting spaces (#199)
 - **space-around-number**: use `codePointAt` for supplementary Han characters and percent-suffix boundaries (#201)
+- **rule-manager**: preserve CR offset fallback for rule reports (#215)
 
 ### Type Changes
 
-- **TextRange**: narrowed from `number[]` to `readonly [start: number, end: number]` (#203)
+- **TextRange**: narrowed from `number[]` to `[number, number]` (#211)
+
+### Chore
+
+- **package**: use the complete GitHub repository URL in npm metadata (#210)
+- **lint**: check source files, tests, and maintenance scripts (#212)
 
 ## [2.1.6](https://github.com/lint-md/lint-md/compare/v2.1.5...v2.1.6) - 2026-07-19
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lint-md/core",
-  "version": "2.1.6",
+  "version": "2.2.0",
   "description": "Core of lint-md which used to lint your markdown file for Chinese.",
   "main": "lib/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
# Summary

- Set the package version to `2.2.0`.
- Finalize the 2.2.0 release notes.

# Validation

- `npm run prepublishOnly`
- `npm run api:check`
- `npm publish --dry-run`

The package is not published by this pull request.
