### PR TITLE
chore: prepare 2.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [2.2.0](https://github.com/lint-md/lint-md/compare/v2.1.6...v2.2.0) - 2026-07-29
+## [2.2.1](https://github.com/lint-md/lint-md/compare/v2.1.6...v2.2.1) - 2026-07-29
 
 ### Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lint-md/core",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Core of lint-md which used to lint your markdown file for Chinese.",
   "main": "lib/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
# Summary

- Replace the unavailable `2.2.0` version with `2.2.1`.
- Update the release note title and comparison link.

# Validation

- `npm run prepublishOnly`
- `npm run api:check`
- `npm publish --dry-run`
- `npm pack --dry-run`

The package is not published by this pull request.
