### PR TITLE
chore: add test typecheck

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Typecheck tests
+        run: npm run typecheck:tests
+
       - name: Test
         run: npm test
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "jest --no-cache",
     "lint": "eslint --ext .ts,.mjs src/ __tests__/ scripts/",
     "typecheck": "tsc --noEmit",
+    "typecheck:tests": "tsc -p tsconfig.test.json --noEmit",
     "lib:cjs": "tsc -p tsconfig.json --target ESNext --module commonjs --outDir lib",
     "lib:esm": "tsc -p tsconfig.json --target ESNext --module ESNext --outDir esm",
     "build": "rm -rf lib esm && run-p lib:*",
@@ -21,7 +22,7 @@
     "smoke-test": "node scripts/benchmark-memory-smoke.mjs",
     "api:report": "npm run build && api-extractor run --local",
     "api:check": "api-extractor run",
-    "prepublishOnly": "npm run lint && npm run typecheck && npm run build && npm run package-contract && npm test",
+    "prepublishOnly": "npm run lint && npm run typecheck && npm run typecheck:tests && npm run build && npm run package-contract && npm test",
     "release": "npm publish"
   },
   "files": [

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "__tests__/**/*"
+  ]
+}


### PR DESCRIPTION
# Summary

- Add a dedicated TypeScript check for test files.
- Run the check in CI before Jest.
- Run the check before npm publication.

# Validation

- `npm run typecheck`
- `npm run typecheck:tests`
- `npm run lint`
- `npm test`
