### PR TITLE
ci: split benchmark tests from unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: 22
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: build
 
 on:
+  schedule:
+    - cron: '0 0 * * 1'
   push:
     branches: [master]
   pull_request:
@@ -10,6 +12,7 @@ permissions:
 
 jobs:
   build:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -34,8 +37,8 @@ jobs:
       - name: Typecheck tests
         run: npm run typecheck:tests
 
-      - name: Test
-        run: npm test
+      - name: Unit test
+        run: npm run test:unit
 
       - name: Build
         run: npm run build
@@ -47,3 +50,20 @@ jobs:
         run: |
           npm run package-contract
           npm pack --dry-run
+
+  benchmark:
+    name: Benchmark (Node 22)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Benchmark test
+        run: npm run test:benchmark

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: build
 
 on:
-  schedule:
-    - cron: '0 0 * * 1'
   push:
     branches: [master]
   pull_request:
@@ -12,7 +10,6 @@ permissions:
 
 jobs:
   build:
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -53,6 +50,7 @@ jobs:
 
   benchmark:
     name: Benchmark (Node 22)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   ],
   "scripts": {
     "test": "jest --no-cache",
+    "test:unit": "jest --no-cache --testPathIgnorePatterns=/benchmark/",
+    "test:benchmark": "jest --no-cache __tests__/benchmark",
     "lint": "eslint --ext .ts,.mjs src/ __tests__/ scripts/",
     "typecheck": "tsc --noEmit",
     "typecheck:tests": "tsc -p tsconfig.test.json --noEmit",


### PR DESCRIPTION
# Summary

- Split Jest commands into unit and benchmark test commands.
- Run unit tests on Node 20, 22, and 24.
- Run benchmarks only in a Node 22 job.
- Run the benchmark job every Monday at 00:00 UTC.

# Validation

- `npm run test:unit`
- `npm run test:benchmark`
- `npm run typecheck`
- `npm run typecheck:tests`
- `npm run lint`
