### PR TITLE
ci: reduce lint warning noise

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,11 @@
 module.exports = {
   extends: '@attachments/eslint-config',
+  overrides: [
+    {
+      files: ['scripts/**/*.mjs', '__tests__/utils/**/*.ts'],
+      rules: {
+        'no-console': 'off'
+      }
+    }
+  ]
 };

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,40 @@ permissions:
   contents: read
 
 jobs:
+  quality:
+    name: Quality (Node 22)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Typecheck tests
+        run: npm run typecheck:tests
+
+      - name: Build
+        run: npm run build
+
+      - name: API report check
+        run: npm run api:check
+
+      - name: Package contract check
+        run: |
+          npm run package-contract
+          npm pack --dry-run
+
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -25,28 +59,11 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Lint
-        run: npm run lint
-
-      - name: Typecheck
-        run: npm run typecheck
-
-      - name: Typecheck tests
-        run: npm run typecheck:tests
-
       - name: Unit test
         run: npm run test:unit
 
       - name: Build
         run: npm run build
-
-      - name: API report check
-        run: npm run api:check
-
-      - name: Package contract check
-        run: |
-          npm run package-contract
-          npm pack --dry-run
 
   benchmark:
     name: Benchmark (Node 22)


### PR DESCRIPTION
# Summary

- Allow console output in maintenance scripts and test utilities.
- Run lint and type checks once in a Node 22 quality job.
- Keep unit tests and builds on Node 20, 22, and 24.

# Validation

- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:tests`
- `npm run test:unit`
- `npm run build`
- `npm run api:check`
- `npm run package-contract`
- `npm pack --dry-run`
