### PR TITLE
ci: add CLI downstream compatibility check

### DIFF
--- a/.github/workflows/downstream-compatibility.yml
+++ b/.github/workflows/downstream-compatibility.yml
@@ -1,0 +1,69 @@
+name: downstream compatibility
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig*.json"
+      - "etc/core.api.md"
+      - "scripts/check-package-contract.mjs"
+      - ".github/workflows/downstream-compatibility.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cli-default-branch:
+    name: Core candidate × CLI master
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout core
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 22
+
+      - name: Build core package
+        run: |
+          npm install
+          npm run build
+          npm run package-contract
+          mkdir -p "$RUNNER_TEMP/core-package"
+          CORE_TARBALL=$(npm pack --pack-destination "$RUNNER_TEMP/core-package" | tail -n 1)
+          echo "CORE_TARBALL=$RUNNER_TEMP/core-package/$CORE_TARBALL" >> "$GITHUB_ENV"
+
+      - name: Checkout CLI
+        uses: actions/checkout@v6.0.2
+        with:
+          repository: lint-md/cli
+          path: downstream/cli
+
+      - name: Install candidate in CLI
+        working-directory: downstream/cli
+        run: |
+          npm install
+          npm install --no-save "$CORE_TARBALL"
+          node -e "
+            const entry = require.resolve('@lint-md/core');
+            console.log('Resolved core:', entry);
+          "
+
+      - name: Verify installed candidate
+        run: |
+          CORE_HASH=$(sha256sum lib/index.js | cut -d ' ' -f 1)
+          INSTALLED_HASH=$(sha256sum downstream/cli/node_modules/@lint-md/core/lib/index.js | cut -d ' ' -f 1)
+          test "$CORE_HASH" = "$INSTALLED_HASH"
+
+      - name: Test CLI compatibility
+        working-directory: downstream/cli
+        run: |
+          npm run lint
+          npm test
+          npm run test:package

--- a/.github/workflows/downstream-compatibility.yml
+++ b/.github/workflows/downstream-compatibility.yml
@@ -1,6 +1,15 @@
 name: downstream compatibility
 
 on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig*.json"
+      - "etc/core.api.md"
+      - "scripts/check-package-contract.mjs"
+      - ".github/workflows/downstream-compatibility.yml"
   push:
     branches:
       - master
@@ -45,6 +54,7 @@ jobs:
         uses: actions/checkout@v6.0.2
         with:
           repository: lint-md/cli
+          ref: master
           path: downstream/cli
 
       - name: Install candidate in CLI
@@ -63,9 +73,36 @@ jobs:
           INSTALLED_HASH=$(sha256sum downstream/cli/node_modules/@lint-md/core/lib/index.js | cut -d ' ' -f 1)
           test "$CORE_HASH" = "$INSTALLED_HASH"
 
-      - name: Test CLI compatibility
+      - name: Lint CLI
         working-directory: downstream/cli
         run: |
+          echo "COMPATIBILITY_COMMAND=npm run lint" >> "$GITHUB_ENV"
           npm run lint
+
+      - name: Test CLI
+        working-directory: downstream/cli
+        run: |
+          echo "COMPATIBILITY_COMMAND=npm test" >> "$GITHUB_ENV"
           npm test
+
+      - name: Test CLI package
+        working-directory: downstream/cli
+        run: |
+          echo "COMPATIBILITY_COMMAND=npm run test:package" >> "$GITHUB_ENV"
           npm run test:package
+
+      - name: Write compatibility summary
+        if: always()
+        working-directory: downstream/cli
+        run: |
+          {
+            echo "## Core × CLI compatibility"
+            echo
+            echo "- Core commit: \`${{ github.sha }}\`"
+            echo "- CLI commit: \`$(git rev-parse HEAD)\`"
+            echo "- Candidate package: \`$(basename \"$CORE_TARBALL\")\`"
+            echo "- Node.js: \`$(node --version)\`"
+            echo "- Consumer: \`lint-md/cli@master\`"
+            echo "- Last compatibility command: \`${COMPATIBILITY_COMMAND:-not reached}\`"
+            echo "- Job status: \`${{ job.status }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/downstream-compatibility.yml
+++ b/.github/workflows/downstream-compatibility.yml
@@ -1,7 +1,9 @@
 name: downstream compatibility
 
 on:
-  pull_request:
+  push:
+    branches:
+      - master
     paths:
       - "src/**"
       - "package.json"


### PR DESCRIPTION
## Summary

Add a Node.js 22 compatibility job for CLI master.

The job installs the core candidate tarball into CLI.

It verifies the installed core file hash.

Closes #194

## Checks

- `npm run build`
- `npm run package-contract`
- YAML parse check
- `git diff --check`