### PR TITLE
refactor(core): finish SourceCode mapping migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,30 @@ core 遵循「纯引擎 + 薄适配器」设计：
 - **集成做 I/O**：CLI、编辑器插件等适配器只负责输入输出和格式转换，不包含规则逻辑
 - **标准诊断**：`LintDiagnostic` 统一诊断格式，core 提供格式转换器（`toALEOutput`），适配器无需自行实现映射
 
+### SourceCode 范围
+
+每次 lint 执行创建一个 `SourceCode` 实例。
+规则通过 `context.sourceCode` 读取原文和 AST。
+规则也通过该实例转换文本范围。
+
+```ts
+const range = context.sourceCode.getTextRange(node, start, end);
+
+context.report({
+  range,
+  message: '发现不规范文本'
+});
+```
+
+所有范围使用 JavaScript UTF-16 索引。
+范围采用 `[start, end)` 语义。
+`TextRange` 是只读的二元组。
+
+无效范围会抛出 `InvalidRuleRangeError`。
+映射缺失会抛出 `SourceMapUnavailableError`。
+节点被修改后，映射会抛出 `SourceMapConsistencyError`。
+映射错误不会进入 `executionErrors`。
+
 ## 🚀 快速使用
 
 从 API 到结果处理，核心只需要一个方法即可完成 lint/fix。当前对外仅提供 **1 个核心 API**：`lintMarkdown`。

--- a/__tests__/unit/source-code.spec.ts
+++ b/__tests__/unit/source-code.spec.ts
@@ -1,7 +1,12 @@
+import {
+  SourceMapUnavailableError,
+  parseMdWithSourceMap
+} from '@lint-md/parser';
 import type { LintMdRule, LintMdRuleContext, LintSourceCode } from '../../src/types';
 import { lintMarkdownInternal } from '../../src/core/lint-markdown';
 import { runLint } from '../../src/core/run-lint';
 import { createLintSourceCode } from '../../src/utils/source-code';
+import { InvalidRuleRangeError } from '../../src/utils/source-code-errors';
 
 describe('LintSourceCode', () => {
   test('exposes sourceCode on rule context', () => {
@@ -98,6 +103,31 @@ describe('LintSourceCode', () => {
     runLint('中文&#40;', [{ rule }]);
   });
 
+  test('getTextRange rejects invalid normalized ranges', () => {
+    const markdown = 'abc';
+    const { ast, sourceMap } = parseMdWithSourceMap(markdown);
+    const sourceCode = createLintSourceCode({ text: markdown, ast, sourceMap });
+    const node = (ast.children[0] as any).children[0];
+
+    expect(() => sourceCode.getTextRange(node, -1, 1))
+      .toThrow(InvalidRuleRangeError);
+    expect(() => sourceCode.getTextRange(node, 2, 1))
+      .toThrow(InvalidRuleRangeError);
+    expect(() => sourceCode.getTextRange(node, 0, 4))
+      .toThrow(InvalidRuleRangeError);
+  });
+
+  test('getTextRange identifies non-contiguous source ranges', () => {
+    const markdown = '> a\n> b';
+    const { ast, sourceMap } = parseMdWithSourceMap(markdown);
+    const sourceCode = createLintSourceCode({ text: markdown, ast, sourceMap });
+    const blockquote = ast.children[0] as any;
+    const node = blockquote.children[0].children[0];
+
+    expect(() => sourceCode.getTextRange(node, 0, node.value.length))
+      .toThrow(SourceMapUnavailableError);
+  });
+
   test('context still exposes legacy ast and markdown fields', () => {
     const rule: LintMdRule = {
       meta: { name: 'legacy-fields-test' },
@@ -166,16 +196,16 @@ describe('LintSourceCode', () => {
     });
 
     test('throws on negative offset', () => {
-      expect(() => sc.getPosition(-1)).toThrow(RangeError);
+      expect(() => sc.getPosition(-1)).toThrow(InvalidRuleRangeError);
     });
 
     test('throws on non-integer offset', () => {
-      expect(() => sc.getPosition(1.5)).toThrow(RangeError);
-      expect(() => sc.getPosition(NaN)).toThrow(RangeError);
+      expect(() => sc.getPosition(1.5)).toThrow(InvalidRuleRangeError);
+      expect(() => sc.getPosition(NaN)).toThrow(InvalidRuleRangeError);
     });
 
     test('throws on offset beyond text length', () => {
-      expect(() => sc.getPosition(100)).toThrow(RangeError);
+      expect(() => sc.getPosition(100)).toThrow(InvalidRuleRangeError);
     });
   });
 
@@ -205,19 +235,19 @@ describe('LintSourceCode', () => {
     });
 
     test('throws on end < start', () => {
-      expect(() => sc.getLocation([5, 0])).toThrow(RangeError);
+      expect(() => sc.getLocation([5, 0])).toThrow(InvalidRuleRangeError);
     });
 
     test('throws on negative start', () => {
-      expect(() => sc.getLocation([-1, 1])).toThrow(RangeError);
+      expect(() => sc.getLocation([-1, 1])).toThrow(InvalidRuleRangeError);
     });
 
     test('throws on non-integer range element', () => {
-      expect(() => sc.getLocation([0, 1.5])).toThrow(RangeError);
+      expect(() => sc.getLocation([0, 1.5])).toThrow(InvalidRuleRangeError);
     });
 
     test('throws on range beyond text length', () => {
-      expect(() => sc.getLocation([0, 100])).toThrow(RangeError);
+      expect(() => sc.getLocation([0, 100])).toThrow(InvalidRuleRangeError);
     });
   });
 });

--- a/__tests__/unit/source-code.spec.ts
+++ b/__tests__/unit/source-code.spec.ts
@@ -1,4 +1,5 @@
 import {
+  SourceMapConsistencyError,
   SourceMapUnavailableError,
   parseMdWithSourceMap
 } from '@lint-md/parser';
@@ -115,6 +116,18 @@ describe('LintSourceCode', () => {
       .toThrow(InvalidRuleRangeError);
     expect(() => sourceCode.getTextRange(node, 0, 4))
       .toThrow(InvalidRuleRangeError);
+  });
+
+  test('getTextRange identifies shortened mapped nodes', () => {
+    const markdown = 'text';
+    const { ast, sourceMap } = parseMdWithSourceMap(markdown);
+    const sourceCode = createLintSourceCode({ text: markdown, ast, sourceMap });
+    const node = (ast.children[0] as any).children[0];
+
+    node.value = '';
+
+    expect(() => sourceCode.getTextRange(node, 0, 1))
+      .toThrow(SourceMapConsistencyError);
   });
 
   test('getTextRange identifies non-contiguous source ranges', () => {

--- a/__tests__/unit/source-map-integration.spec.ts
+++ b/__tests__/unit/source-map-integration.spec.ts
@@ -1,7 +1,9 @@
-import { parseMdWithSourceMap } from '@lint-md/parser';
+import {
+  SourceMapConsistencyError,
+  parseMdWithSourceMap
+} from '@lint-md/parser';
 import { runLint } from '../../src/core/run-lint';
 import { lintMarkdownInternal } from '../../src/core/lint-markdown';
-import { RuleExecutionFailure } from '../../src/utils/rule-execution-errors';
 import { TextScanner } from '../../src/utils/text-scanner';
 import { createLintSourceCode } from '../../src/utils/source-code';
 import noHalfWidthPunctuation from '../../src/rules/no-half-width-punctuation';
@@ -168,7 +170,7 @@ describe('parser source-map integration', () => {
     expect(result.fixedResult?.result).toBe('中文A中文');
   });
 
-  test('source-map consistency errors are collected and do not produce fixes', () => {
+  test('source-map consistency errors escape rule error collection', () => {
     const mutatingRule: LintMdRule = {
       meta: { name: 'mutate-text-node' },
       create: context => ({
@@ -180,13 +182,51 @@ describe('parser source-map integration', () => {
       })
     };
     const input = '中文(test)中文';
-    const result = runLint(input, [{ rule: mutatingRule }]);
-    expect(result.executionErrors).toEqual([
-      expect.objectContaining({ ruleName: 'mutate-text-node', phase: 'selector' })
-    ]);
-    expect(result.ruleManager.getAllFixes()).toEqual([]);
+
+    expect(() => runLint(input, [{ rule: mutatingRule }]))
+      .toThrow(SourceMapConsistencyError);
     expect(input).toBe('中文(test)中文');
     expect(() => runLint(input, [{ rule: mutatingRule }], { ruleErrorPolicy: 'strict' }))
-      .toThrow(RuleExecutionFailure);
+      .toThrow(SourceMapConsistencyError);
+  });
+
+  test('source-map errors escape the rule create phase', () => {
+    const mutatingRule: LintMdRule = {
+      meta: { name: 'mutate-during-create' },
+      create: (context) => {
+        const paragraph = context.ast.children[0] as any;
+        const node = paragraph.children[0];
+        node.value = 'changed';
+        context.sourceCode.getTextRange(node, 0, 1);
+        return {};
+      }
+    };
+
+    expect(() => runLint('text', [{ rule: mutatingRule }]))
+      .toThrow(SourceMapConsistencyError);
+  });
+
+  test('source-map errors escape the rule fix phase', () => {
+    const mutatingRule: LintMdRule = {
+      meta: { name: 'mutate-during-fix' },
+      create: context => ({
+        text: (node) => {
+          context.report({
+            loc: node.position,
+            message: 'trigger mapped fix',
+            fix: () => {
+              (node as { value: string }).value = 'changed';
+              const range = context.sourceCode.getTextRange(node as any, 0, 1);
+              return { range, text: 'x' };
+            }
+          });
+        }
+      })
+    };
+    const { ruleManager } = runLint('text', [{ rule: mutatingRule }]);
+
+    expect(() => ruleManager.getAllFixes())
+      .toThrow(SourceMapConsistencyError);
+    expect(ruleManager.getExecutionErrors()).toEqual([]);
   });
 });

--- a/__tests__/unit/source-map-integration.spec.ts
+++ b/__tests__/unit/source-map-integration.spec.ts
@@ -175,7 +175,7 @@ describe('parser source-map integration', () => {
       meta: { name: 'mutate-text-node' },
       create: context => ({
         text: (node) => {
-          (node as { value: string }).value = 'changed';
+          (node as { value: string }).value = '';
           new TextScanner(node as any, context.sourceCode).matchAt(0, 1);
           context.report({ loc: node.position, message: 'unreachable' });
         }
@@ -196,7 +196,7 @@ describe('parser source-map integration', () => {
       create: (context) => {
         const paragraph = context.ast.children[0] as any;
         const node = paragraph.children[0];
-        node.value = 'changed';
+        node.value = '';
         context.sourceCode.getTextRange(node, 0, 1);
         return {};
       }
@@ -215,7 +215,7 @@ describe('parser source-map integration', () => {
             loc: node.position,
             message: 'trigger mapped fix',
             fix: () => {
-              (node as { value: string }).value = 'changed';
+              (node as { value: string }).value = '';
               const range = context.sourceCode.getTextRange(node as any, 0, 1);
               return { range, text: 'x' };
             }

--- a/__tests__/unit/utils/text-scanner.spec.ts
+++ b/__tests__/unit/utils/text-scanner.spec.ts
@@ -1,43 +1,31 @@
+import { parseMdWithSourceMap } from '@lint-md/parser';
 import { TextScanner } from '../../../src/utils/text-scanner';
-import type { MarkdownTextNode } from '../../../src/utils/get-text-nodes';
+import { createLintSourceCode } from '../../../src/utils/source-code';
+import { InvalidRuleRangeError } from '../../../src/utils/source-code-errors';
+import type { PositionedTextNode } from '../../../src/types';
 
-const createTextNode = (
-  value: string,
-  startLine = 1,
-  startColumn = 1,
-  startOffset = 0
-): MarkdownTextNode => ({
-  type: 'text',
-  value,
-  position: {
-    start: { line: startLine, column: startColumn, offset: startOffset },
-    end: {
-      line: startLine,
-      column: startColumn + value.length,
-      offset: startOffset + value.length
-    }
-  }
-} as unknown as MarkdownTextNode);
+const createScanner = (markdown: string): TextScanner => {
+  const { ast, sourceMap } = parseMdWithSourceMap(markdown);
+  const parent = ast.children[0] as { children: PositionedTextNode[] };
+  const node = parent.children[0];
+  const sourceCode = createLintSourceCode({ text: markdown, ast, sourceMap });
+  return new TextScanner(node, sourceCode);
+};
 
 describe('TextScanner', () => {
   describe('constructor and getters', () => {
-    it('should expose value', () => {
-      const node = createTextNode('hello');
-      const scanner = new TextScanner(node);
-      expect(scanner.value).toBe('hello');
-    });
+    it('exposes the normalized value and source node', () => {
+      const scanner = createScanner('hello');
 
-    it('should expose node', () => {
-      const node = createTextNode('hello');
-      const scanner = new TextScanner(node);
-      expect(scanner.node).toBe(node);
+      expect(scanner.value).toBe('hello');
+      expect(scanner.node.value).toBe('hello');
     });
   });
 
   describe('matchAt', () => {
-    it('should match simple text', () => {
-      const scanner = new TextScanner(createTextNode('hello world'));
-      const match = scanner.matchAt(0, 5);
+    it('resolves a simple text range', () => {
+      const match = createScanner('hello world').matchAt(0, 5);
+
       expect(match).toEqual({
         index: 0,
         length: 5,
@@ -49,190 +37,142 @@ describe('TextScanner', () => {
       });
     });
 
-    it('should handle match at end of text', () => {
-      const scanner = new TextScanner(createTextNode('hello'));
-      const match = scanner.matchAt(5, 0);
-      expect(match.index).toBe(5);
-      expect(match.length).toBe(0);
+    it('resolves an empty range at the value end', () => {
+      const match = createScanner('hello').matchAt(5, 0);
+
+      expect(match.loc.start).toEqual({ line: 1, column: 6, offset: 5 });
+      expect(match.loc.end).toEqual({ line: 1, column: 6, offset: 5 });
       expect(match.absoluteRange).toEqual([5, 5]);
     });
 
-    it('should handle match spanning newlines', () => {
-      const scanner = new TextScanner(createTextNode('a\nb\nc'));
-      const match = scanner.matchAt(0, 3);
+    it('resolves a range across line endings', () => {
+      const match = createScanner('a\nb\nc').matchAt(0, 3);
+
       expect(match.loc.start).toEqual({ line: 1, column: 1, offset: 0 });
-      expect(match.loc.end.line).toBe(2);
-      expect(match.loc.end.column).toBe(2);
+      expect(match.loc.end).toEqual({ line: 2, column: 2, offset: 3 });
       expect(match.absoluteRange).toEqual([0, 3]);
     });
 
-    it('should handle non-1/1/0 start position with multi-line text', () => {
-      const scanner = new TextScanner(createTextNode('ab\ncd\nef', 3, 5, 100));
-      // ab\ncd\nef (8 chars)
-      const match = scanner.matchAt(0, 8);
-      expect(match.loc.start).toEqual({ line: 3, column: 5, offset: 100 });
-      // After 'f' at line 5 col 2 → end is line 5 col 3
-      expect(match.loc.end).toEqual({ line: 5, column: 3, offset: 108 });
-    });
+    it('uses the source node start position', () => {
+      const match = createScanner('# abc').matchAt(0, 3);
 
-    it('should hit middle of second/third line', () => {
-      const scanner = new TextScanner(createTextNode('line1\nline2\nline3'));
-      // 'line1\nline2\nline3'
-      //  01234 567890 1234567
-      const match = scanner.matchAt(8, 1); // 'i' in line2
-      expect(match.loc.start).toEqual({ line: 2, column: 3, offset: 8 });
-      expect(match.loc.end).toEqual({ line: 2, column: 4, offset: 9 });
-    });
-
-    it('should handle matchAt spanning 3+ lines', () => {
-      const scanner = new TextScanner(createTextNode('a\nb\nc\nd'));
-      const match = scanner.matchAt(0, 6); // 'a\nb\nc' (6 chars)
-      expect(match.loc.start).toEqual({ line: 1, column: 1, offset: 0 });
-      // After 'c' at line 3 col 1 → end is line 3 col 2? No — 6 chars means position at index 6 = 'd' at (4,1)
-      // Actually: indices 0-5 are 'a','\n','b','\n','c','\n'. index 6 is 'd' at (4,1)
-      expect(match.loc.end).toEqual({ line: 4, column: 1, offset: 6 });
-    });
-
-    it('should handle matchAt at value.length with length=0', () => {
-      const scanner = new TextScanner(createTextNode('hello'));
-      const match = scanner.matchAt(5, 0);
-      expect(match.loc.start).toEqual({ line: 1, column: 6, offset: 5 });
+      expect(match.loc.start).toEqual({ line: 1, column: 3, offset: 2 });
       expect(match.loc.end).toEqual({ line: 1, column: 6, offset: 5 });
     });
 
-    it('should handle empty text matchAt(0, 0)', () => {
-      const scanner = new TextScanner(createTextNode(''));
-      const match = scanner.matchAt(0, 0);
+    it('resolves CRLF positions from SourceCode', () => {
+      const match = createScanner('a\r\nb').matchAt(0, 4);
+
       expect(match.loc.start).toEqual({ line: 1, column: 1, offset: 0 });
-      expect(match.loc.end).toEqual({ line: 1, column: 1, offset: 0 });
+      expect(match.loc.end).toEqual({ line: 2, column: 2, offset: 4 });
     });
 
-    it('should handle CRLF text: \\r counted in column, \\n triggers newline', () => {
-      const scanner = new TextScanner(createTextNode('a\r\nb'));
-      // 'a' = index 0, '\r' = index 1, '\n' = index 2, 'b' = index 3
-      const match = scanner.matchAt(0, 4);
-      expect(match.loc.start).toEqual({ line: 1, column: 1, offset: 0 });
-      // '\r' at index 1 → column 2; '\n' at index 2 → line 2, column 1; 'b' at index 3 → column 2
-      expect(match.loc.end).toEqual({ line: 2, column: 2, offset: 4 });
+    it.each([
+      [-1, 1],
+      [2, -1],
+      [1, 10],
+      [0.5, 1]
+    ])('rejects an invalid range at index %s with length %s', (index, length) => {
+      expect(() => createScanner('abc').matchAt(index, length))
+        .toThrow(InvalidRuleRangeError);
     });
   });
 
   describe('findAllMatches', () => {
-    it('should find all matches with global flag', () => {
-      const scanner = new TextScanner(createTextNode('hello world hello'));
-      const matches = scanner.findAllMatches(/hello/g);
-      expect(matches).toHaveLength(2);
-      expect(matches[0].index).toBe(0);
-      expect(matches[1].index).toBe(12);
+    it('finds all matches with a global flag', () => {
+      const matches = createScanner('hello world hello').findAllMatches(/hello/g);
+
+      expect(matches.map(match => match.index)).toEqual([0, 12]);
     });
 
-    it('should auto-add global flag if missing', () => {
-      const scanner = new TextScanner(createTextNode('hello world hello'));
-      const matches = scanner.findAllMatches(/hello/);
+    it('adds the global flag when it is absent', () => {
+      const matches = createScanner('hello world hello').findAllMatches(/hello/);
+
       expect(matches).toHaveLength(2);
     });
 
-    it('should handle zero-length matches without infinite loop', () => {
-      const scanner = new TextScanner(createTextNode('abc'));
-      const matches = scanner.findAllMatches(/(\b)/g);
+    it('ignores zero-length matches', () => {
+      const matches = createScanner('abc').findAllMatches(/(\b)/g);
+
       expect(matches).toEqual([]);
     });
 
-    it('should return empty array when no matches', () => {
-      const scanner = new TextScanner(createTextNode('hello'));
-      const matches = scanner.findAllMatches(/xyz/g);
+    it('returns no matches for an absent value', () => {
+      const matches = createScanner('hello').findAllMatches(/xyz/g);
+
       expect(matches).toEqual([]);
     });
 
-    it('should have accurate loc for high-density matches', () => {
-      const scanner = new TextScanner(createTextNode('aaa'));
-      const matches = scanner.findAllMatches(/a/g);
-      expect(matches).toHaveLength(3);
-      expect(matches[0]).toMatchObject({ index: 0, length: 1, loc: { start: { line: 1, column: 1 }, end: { line: 1, column: 2 } } });
-      expect(matches[1]).toMatchObject({ index: 1, length: 1, loc: { start: { line: 1, column: 2 }, end: { line: 1, column: 3 } } });
-      expect(matches[2]).toMatchObject({ index: 2, length: 1, loc: { start: { line: 1, column: 3 }, end: { line: 1, column: 4 } } });
+    it('resolves dense matches through SourceCode', () => {
+      const matches = createScanner('aaa').findAllMatches(/a/g);
+
+      expect(matches.map(match => match.absoluteRange))
+        .toEqual([[0, 1], [1, 2], [2, 3]]);
     });
 
-    it('should have accurate loc across newlines', () => {
-      const scanner = new TextScanner(createTextNode('ab\ncd'));
-      // Use /[\s\S]/ to match each char including newline
-      const matches = scanner.findAllMatches(/[\s\S]/g);
-      expect(matches).toHaveLength(5);
-      expect(matches[2]).toMatchObject({ index: 2, loc: { start: { line: 1, column: 3 }, end: { line: 2, column: 1 } } }); // '\n'
-      expect(matches[3]).toMatchObject({ index: 3, loc: { start: { line: 2, column: 1 }, end: { line: 2, column: 2 } } }); // 'c'
-      expect(matches[4]).toMatchObject({ index: 4, loc: { start: { line: 2, column: 2 }, end: { line: 2, column: 3 } } }); // 'd'
+    it('resolves matches across newlines', () => {
+      const matches = createScanner('ab\ncd').findAllMatches(/[\s\S]/g);
+
+      expect(matches[2].loc).toEqual({
+        start: { line: 1, column: 3, offset: 2 },
+        end: { line: 2, column: 1, offset: 3 }
+      });
+      expect(matches[3].loc.start).toEqual({ line: 2, column: 1, offset: 3 });
     });
   });
 
   describe('findAllOccurrences', () => {
-    it('should find all occurrences', () => {
-      const scanner = new TextScanner(createTextNode('aXaXa'));
-      const matches = scanner.findAllOccurrences('X');
-      expect(matches).toHaveLength(2);
-      expect(matches[0].index).toBe(1);
-      expect(matches[1].index).toBe(3);
+    it('finds all occurrences', () => {
+      const matches = createScanner('aXaXa').findAllOccurrences('X');
+
+      expect(matches.map(match => match.index)).toEqual([1, 3]);
     });
 
-    it('should find overlapping occurrences', () => {
-      const scanner = new TextScanner(createTextNode('aaa'));
-      const matches = scanner.findAllOccurrences('aa');
-      expect(matches).toHaveLength(2);
-      expect(matches[0].index).toBe(0);
-      expect(matches[0].absoluteRange).toEqual([0, 2]);
-      expect(matches[1].index).toBe(1);
-      expect(matches[1].absoluteRange).toEqual([1, 3]);
+    it('finds overlapping occurrences', () => {
+      const matches = createScanner('aaa').findAllOccurrences('aa');
+
+      expect(matches.map(match => match.absoluteRange))
+        .toEqual([[0, 2], [1, 3]]);
     });
 
-    it('should return empty array for empty search string', () => {
-      const scanner = new TextScanner(createTextNode('hello'));
-      const matches = scanner.findAllOccurrences('');
-      expect(matches).toEqual([]);
+    it('returns no matches for an empty search string', () => {
+      expect(createScanner('hello').findAllOccurrences('')).toEqual([]);
     });
 
-    it('should return empty array when string not found', () => {
-      const scanner = new TextScanner(createTextNode('hello'));
-      const matches = scanner.findAllOccurrences('xyz');
-      expect(matches).toEqual([]);
-    });
+    it('resolves occurrences across newlines', () => {
+      const matches = createScanner('aa\naa').findAllOccurrences('aa');
 
-    it('should have accurate positions for overlapping occurrences across newlines', () => {
-      const scanner = new TextScanner(createTextNode('aa\naa'));
-      const matches = scanner.findAllOccurrences('aa');
-      expect(matches).toHaveLength(2);
-      expect(matches[0]).toMatchObject({ index: 0, absoluteRange: [0, 2], loc: { start: { line: 1, column: 1 }, end: { line: 1, column: 3 } } });
-      expect(matches[1]).toMatchObject({ index: 3, absoluteRange: [3, 5], loc: { start: { line: 2, column: 1 }, end: { line: 2, column: 3 } } });
+      expect(matches.map(match => match.absoluteRange))
+        .toEqual([[0, 2], [3, 5]]);
+      expect(matches[1].loc.start).toEqual({ line: 2, column: 1, offset: 3 });
     });
   });
 
   describe('forEachChar', () => {
-    it('should iterate over each character', () => {
-      const scanner = new TextScanner(createTextNode('abc'));
+    it('iterates through Unicode code points', () => {
       const chars: string[] = [];
-      scanner.forEachChar((char) => {
-        chars.push(char);
-      });
-      expect(chars).toEqual(['a', 'b', 'c']);
+
+      createScanner('a𝔄b').forEachChar(char => chars.push(char));
+
+      expect(chars).toEqual(['a', '𝔄', 'b']);
     });
 
-    it('should track line and column for newlines', () => {
-      const scanner = new TextScanner(createTextNode('a\nb'));
-      const positions: Array<{ line: number; column: number }> = [];
-      scanner.forEachChar((_char, _i, pos) => {
-        positions.push({ line: pos.line, column: pos.column });
-      });
-      expect(positions[0]).toEqual({ line: 1, column: 1 });
-      expect(positions[1]).toEqual({ line: 1, column: 2 });
-      expect(positions[2]).toEqual({ line: 2, column: 1 });
-    });
+    it('resolves positions only when a callback reads them', () => {
+      const positions: Array<{ line: number; column: number; offset: number }> = [];
 
-    it('should use start position from node', () => {
-      const node = createTextNode('abc', 5, 3, 10);
-      const scanner = new TextScanner(node);
-      const positions: number[] = [];
-      scanner.forEachChar((_char, _i, pos) => {
-        positions.push(pos.offset);
+      createScanner('a\nb').forEachChar((_char, _index, position) => {
+        positions.push({
+          line: position.line,
+          column: position.column,
+          offset: position.offset
+        });
       });
-      expect(positions).toEqual([10, 11, 12]);
+
+      expect(positions).toEqual([
+        { line: 1, column: 1, offset: 0 },
+        { line: 1, column: 2, offset: 1 },
+        { line: 2, column: 1, offset: 2 }
+      ]);
     });
   });
 });

--- a/etc/core.api.md
+++ b/etc/core.api.md
@@ -7,6 +7,9 @@
 import type { ParsedPoint } from '@lint-md/parser';
 import type { PositionedMarkdownNode as PositionedMarkdownNode_2 } from '@lint-md/parser';
 import type { PositionedMarkdownRoot as PositionedMarkdownRoot_2 } from '@lint-md/parser';
+import { SourceMapConsistencyError } from '@lint-md/parser';
+import { SourceMapError } from '@lint-md/parser';
+import { SourceMapUnavailableError } from '@lint-md/parser';
 
 // @public (undocumented)
 export const correctTitleTrailingPunctuation: LintMdRule;
@@ -61,6 +64,11 @@ export enum FixNotAppliedReason {
     OVERLAP = "overlap",
     // (undocumented)
     SAME_OFFSET = "same-offset"
+}
+
+// @public (undocumented)
+export class InvalidRuleRangeError extends RangeError {
+    constructor(message: string);
 }
 
 // @public (undocumented)
@@ -384,6 +392,12 @@ export interface RunLintOptions {
     ruleErrorPolicy?: RuleErrorPolicy;
 }
 
+export { SourceMapConsistencyError }
+
+export { SourceMapError }
+
+export { SourceMapUnavailableError }
+
 // @public (undocumented)
 export const spaceAroundAlphabet: LintMdRule;
 
@@ -391,7 +405,7 @@ export const spaceAroundAlphabet: LintMdRule;
 export const spaceAroundNumber: LintMdRule;
 
 // @public (undocumented)
-export type TextRange = [number, number];
+export type TextRange = readonly [number, number];
 
 // @public (undocumented)
 export function toALEOutput(diagnostics: LintDiagnostic[], filePath: string): string;

--- a/src/core/run-lint.ts
+++ b/src/core/run-lint.ts
@@ -5,6 +5,7 @@ import { createTraverser } from '../utils/traverser';
 import { createRuleManager } from '../utils/rule-manager';
 import { createRuleErrorCollector } from '../utils/rule-execution-errors';
 import { createLintSourceCode } from '../utils/source-code';
+import { isSourceMapError } from '../utils/source-code-errors';
 
 /**
  * 基于各种 rules 对 Markdown 文本进行校验
@@ -64,6 +65,10 @@ export const runLint = (
       ruleSelectors = rule.create(ruleContext);
     }
     catch (e) {
+      // Source-map errors are infrastructure failures.
+      if (isSourceMapError(e)) {
+        throw e;
+      }
       collector.collect(rule.meta.name, 'create', e);
       continue;
     }
@@ -76,6 +81,10 @@ export const runLint = (
           originalSelector(node);
         }
         catch (error) {
+          // Source-map errors are infrastructure failures.
+          if (isSourceMapError(error)) {
+            throw error;
+          }
           // 严格模式会在 collect 内抛出 RuleExecutionFailure，向上传递。
           collector.collect(ruleName, 'selector', error, node.type);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,9 @@ export * from './types';
 export { toALEOutput } from './diagnostics';
 // strict 模式下规则执行失败抛出的专用异常类，供调用方做 `instanceof` 判断。
 export { RuleExecutionFailure } from './utils/rule-execution-errors';
+export { InvalidRuleRangeError } from './utils/source-code-errors';
+export {
+  SourceMapConsistencyError,
+  SourceMapError,
+  SourceMapUnavailableError
+} from '@lint-md/parser';

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export type PositionedTextNode = Extract<PositionedMarkdownNode, { type: 'text' 
 export type PositionedBlockquoteNode = Extract<PositionedMarkdownNode, { type: 'blockquote' }>;
 
 /** 文本范围信息 */
-export type TextRange = [number, number];
+export type TextRange = readonly [number, number];
 
 /** 修复器配置 */
 export interface FixConfig {

--- a/src/utils/rule-manager.ts
+++ b/src/utils/rule-manager.ts
@@ -8,6 +8,7 @@ import type {
 } from '../types';
 import type { createRuleErrorCollector } from './rule-execution-errors';
 import { createFixer } from './fixer';
+import { isSourceMapError } from './source-code-errors';
 
 /** 合法 offset 必须是有限非负整数：排除 NaN / Infinity / 负数，避免第三方规则传入非法值绕过兜底。 */
 export const isValidOffset = (value: unknown): value is number =>
@@ -58,6 +59,10 @@ export const createRuleManager = (
           return [{ ...fix, targetRule: item.name }];
         }
         catch (e) {
+          // Source-map errors are infrastructure failures.
+          if (isSourceMapError(e)) {
+            throw e;
+          }
           if (collector) {
             // 严格模式会在 collect 内抛 RuleExecutionFailure，向上传递。
             collector.collect(item.name, 'fix', e);

--- a/src/utils/source-code-errors.ts
+++ b/src/utils/source-code-errors.ts
@@ -1,0 +1,32 @@
+import {
+  SourceMapError
+} from '@lint-md/parser';
+import type { SourceMapErrorCode } from '@lint-md/parser';
+
+const SOURCE_MAP_ERROR_CODES: ReadonlySet<SourceMapErrorCode> = new Set([
+  'ERR_SOURCE_MAP_CONSISTENCY',
+  'ERR_SOURCE_MAP_UNAVAILABLE'
+]);
+
+/** The rule supplied an invalid source range or offset. */
+export class InvalidRuleRangeError extends RangeError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidRuleRangeError';
+  }
+}
+
+/** Return true for parser source-map infrastructure errors. */
+export const isSourceMapError = (error: unknown): error is SourceMapError => {
+  if (error instanceof SourceMapError) {
+    return true;
+  }
+
+  if (typeof error !== 'object' || error === null || !('code' in error)) {
+    return false;
+  }
+
+  return SOURCE_MAP_ERROR_CODES.has(
+    (error as { code: SourceMapErrorCode }).code
+  );
+};

--- a/src/utils/source-code.ts
+++ b/src/utils/source-code.ts
@@ -33,8 +33,7 @@ export const createLintSourceCode = ({
       valueStart: number,
       valueEnd: number
     ): TextRange {
-      if (!Number.isInteger(valueStart) || !Number.isInteger(valueEnd)
-        || valueStart < 0 || valueStart > valueEnd || valueEnd > node.value.length) {
+      if (!Number.isInteger(valueStart) || !Number.isInteger(valueEnd)) {
         throw new InvalidRuleRangeError(
           `getTextRange: range must satisfy 0 <= start <= end <= ${node.value.length}, got [${valueStart}, ${valueEnd}]`
         );
@@ -53,6 +52,11 @@ export const createLintSourceCode = ({
           throw error;
         }
         if (error instanceof RangeError) {
+          if (valueStart < 0 || valueStart > valueEnd || valueEnd > node.value.length) {
+            throw new InvalidRuleRangeError(
+              `getTextRange: range must satisfy 0 <= start <= end <= ${node.value.length}, got [${valueStart}, ${valueEnd}]`
+            );
+          }
           throw new SourceMapUnavailableError(error.message);
         }
         throw error;

--- a/src/utils/source-code.ts
+++ b/src/utils/source-code.ts
@@ -3,7 +3,9 @@ import type {
   MarkdownSourceMap,
   MarkdownTextNode as ParserMarkdownTextNode
 } from '@lint-md/parser';
+import { SourceMapUnavailableError } from '@lint-md/parser';
 import type { LintSourceCode, MarkdownPosition, PositionedInlineCodeNode, PositionedMarkdownNode, PositionedMarkdownRoot, PositionedTextNode, TextRange } from '../types';
+import { InvalidRuleRangeError, isSourceMapError } from './source-code-errors';
 
 interface SourceCodeOptions {
   text: string
@@ -31,17 +33,37 @@ export const createLintSourceCode = ({
       valueStart: number,
       valueEnd: number
     ): TextRange {
-      const range = sourceMap.getSourceRange(
-        node as unknown as ParserMarkdownTextNode | MarkdownInlineCodeNode,
-        valueStart,
-        valueEnd
-      );
-      return [range.start.offset, range.end.offset];
+      if (!Number.isInteger(valueStart) || !Number.isInteger(valueEnd)
+        || valueStart < 0 || valueStart > valueEnd || valueEnd > node.value.length) {
+        throw new InvalidRuleRangeError(
+          `getTextRange: range must satisfy 0 <= start <= end <= ${node.value.length}, got [${valueStart}, ${valueEnd}]`
+        );
+      }
+
+      try {
+        const range = sourceMap.getSourceRange(
+          node as unknown as ParserMarkdownTextNode | MarkdownInlineCodeNode,
+          valueStart,
+          valueEnd
+        );
+        return [range.start.offset, range.end.offset];
+      }
+      catch (error) {
+        if (isSourceMapError(error)) {
+          throw error;
+        }
+        if (error instanceof RangeError) {
+          throw new SourceMapUnavailableError(error.message);
+        }
+        throw error;
+      }
     },
 
     getPosition(offset: number): MarkdownPosition {
       if (!Number.isInteger(offset) || offset < 0 || offset > text.length) {
-        throw new RangeError(`getPosition: offset must be an integer in [0, ${text.length}], got ${offset}`);
+        throw new InvalidRuleRangeError(
+          `getPosition: offset must be an integer in [0, ${text.length}], got ${offset}`
+        );
       }
       return offsetToPosition(lineStarts, offset);
     },
@@ -50,7 +72,7 @@ export const createLintSourceCode = ({
       const [start, end] = range;
       if (!Number.isInteger(start) || !Number.isInteger(end)
         || start < 0 || start > end || end > text.length) {
-        throw new RangeError(
+        throw new InvalidRuleRangeError(
           `getLocation: range must satisfy 0 <= start <= end <= ${text.length}, got [${start}, ${end}]`
         );
       }

--- a/src/utils/text-scanner.ts
+++ b/src/utils/text-scanner.ts
@@ -1,5 +1,11 @@
-import type { LintSourceCode, PositionedInlineCodeNode, PositionedTextNode } from '../types';
+import type {
+  LintSourceCode,
+  PositionedInlineCodeNode,
+  PositionedTextNode,
+  TextRange
+} from '../types';
 import type { MarkdownTextNode } from './get-text-nodes';
+import { InvalidRuleRangeError } from './source-code-errors';
 
 export interface TextMatch {
   index: number
@@ -8,7 +14,7 @@ export interface TextMatch {
     start: { line: number; column: number; offset: number }
     end: { line: number; column: number; offset: number }
   }
-  absoluteRange: [number, number]
+  absoluteRange: TextRange
 }
 
 export interface CharPosition {
@@ -19,17 +25,14 @@ export interface CharPosition {
 }
 
 /**
- * Scans a normalized text node and resolves every diagnostic/fix range through
- * the document SourceCode service.  Falls back to node-position arithmetic
- * when no source code is provided.
+ * Scans normalized text through the document SourceCode service.
  */
 export class TextScanner {
   private readonly _value: string;
   private readonly _node: MarkdownTextNode;
-  private readonly _sourceCode?: LintSourceCode;
-  private _lineBreakIndices?: number[];
+  private readonly _sourceCode: LintSourceCode;
 
-  constructor(node: MarkdownTextNode, sourceCode?: LintSourceCode) {
+  constructor(node: MarkdownTextNode, sourceCode: LintSourceCode) {
     this._node = node;
     this._value = node.value;
     this._sourceCode = sourceCode;
@@ -43,73 +46,19 @@ export class TextScanner {
     return this._node;
   }
 
-  private get lineBreakIndices(): number[] {
-    if (!this._lineBreakIndices) {
-      const indices: number[] = [];
-      for (let i = 0; i < this._value.length; i++) {
-        if (this._value[i] === '\n') {
-          indices.push(i);
-        }
-      }
-      this._lineBreakIndices = indices;
-    }
-    return this._lineBreakIndices;
-  }
-
-  private fallbackRange(start: number, end: number) {
-    const pointAt = (index: number) => {
-      const breaks = this.lineBreakIndices;
-      let lo = 0;
-      let hi = breaks.length;
-      while (lo < hi) {
-        const mid = (lo + hi) >> 1;
-        if (breaks[mid] < index) {
-          lo = mid + 1;
-        }
-        else {
-          hi = mid;
-        }
-      }
-      return {
-        line: this._node.position.start.line + lo,
-        column: lo === 0
-          ? this._node.position.start.column + index
-          : index - breaks[lo - 1],
-        offset: this._node.position.start.offset + index
-      };
-    };
-    return { start: pointAt(start), end: pointAt(end) };
-  }
-
-  private fallbackPointAtLinear(index: number) {
-    let line = this._node.position.start.line;
-    let column = this._node.position.start.column;
-    for (let i = 0; i < index; i++) {
-      if (this._value[i] === '\n') {
-        line++;
-        column = 1;
-      }
-      else {
-        column++;
-      }
-    }
-    return { line, column, offset: this._node.position.start.offset + index };
-  }
-
   private sourceRange(start: number, end: number) {
     if (!Number.isInteger(start) || !Number.isInteger(end)
       || start < 0 || end < start || end > this._value.length) {
-      throw new RangeError(`TextScanner range out of bounds: [${start}, ${end}]`);
-    }
-    if (this._sourceCode) {
-      const range = this._sourceCode.getTextRange(
-        this._node as MarkdownTextNode as PositionedTextNode | PositionedInlineCodeNode,
-        start,
-        end
+      throw new InvalidRuleRangeError(
+        `TextScanner range out of bounds: [${start}, ${end}]`
       );
-      return this._sourceCode.getLocation(range);
     }
-    return this.fallbackRange(start, end);
+    const range = this._sourceCode.getTextRange(
+      this._node as MarkdownTextNode as PositionedTextNode | PositionedInlineCodeNode,
+      start,
+      end
+    );
+    return this._sourceCode.getLocation(range);
   }
 
   matchAt(index: number, length: number): TextMatch {
@@ -162,12 +111,7 @@ export class TextScanner {
       const charLength = char.length;
       let range: ReturnType<TextScanner['sourceRange']> | undefined;
       const getRange = () => {
-        range ??= this._sourceCode
-          ? this.sourceRange(charIndex, charIndex + charLength)
-          : {
-              start: this.fallbackPointAtLinear(charIndex),
-              end: this.fallbackPointAtLinear(charIndex + charLength)
-            };
+        range ??= this.sourceRange(charIndex, charIndex + charLength);
         return range;
       };
       const pos = Object.defineProperties({}, {

--- a/src/utils/text-scanner.ts
+++ b/src/utils/text-scanner.ts
@@ -5,7 +5,6 @@ import type {
   TextRange
 } from '../types';
 import type { MarkdownTextNode } from './get-text-nodes';
-import { InvalidRuleRangeError } from './source-code-errors';
 
 export interface TextMatch {
   index: number
@@ -47,12 +46,6 @@ export class TextScanner {
   }
 
   private sourceRange(start: number, end: number) {
-    if (!Number.isInteger(start) || !Number.isInteger(end)
-      || start < 0 || end < start || end > this._value.length) {
-      throw new InvalidRuleRangeError(
-        `TextScanner range out of bounds: [${start}, ${end}]`
-      );
-    }
     const range = this._sourceCode.getTextRange(
       this._node as MarkdownTextNode as PositionedTextNode | PositionedInlineCodeNode,
       start,


### PR DESCRIPTION
## Summary

- Require `TextScanner` to use `LintSourceCode`.
- Remove the legacy position fallback.
- Make `TextRange` a readonly tuple.
- Add explicit invalid-range errors.
- Keep source-map failures outside `executionErrors`.
- Export the source-map error classes.
- Update tests, documentation, and the API report.

## Why

The parser now provides source mappings for normalized text.
The fallback can produce unsafe ranges for escapes and entities.
Core must treat mapping failures as infrastructure failures.

## Impact

Rules now resolve text ranges through `SourceCode` only.
Invalid ranges use `InvalidRuleRangeError`.
Unavailable or stale mappings use parser source-map errors.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:tests`
- `npm run test:unit` — 318 tests passed.
- `npm run test:benchmark`
- `npm run smoke-test`
- `npm run api:check`
- `npm run package-contract`

Closes #187
