### PR TITLE
feat: require trailing spaces for soft breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@
 - **build**: replace npm-run-all with npm-run-all2 (#147)
 - **build**: replace yarn with npm and add push trigger (#134)
 - **run-lint**: replace console.log with console.error to surface rule execution failures (#141)
-- **B2**: 消除 @ts-expect-error、as any、隐式 any，提升类型安全 （#139）
+- **B2**: 消除 @ts-expect-error、as any、隐式 any，提升类型安全 (#139)
 - detect percent suffix of number in space-around-number (#129)
 - no-space-in-inline-code backtick handling & correct-title-trailing (#127)
 - replace while(true) with clean exec() loop, fix premature break (#126)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@
 - **build**: replace npm-run-all with npm-run-all2 (#147)
 - **build**: replace yarn with npm and add push trigger (#134)
 - **run-lint**: replace console.log with console.error to surface rule execution failures (#141)
-- **B2**: 消除 @ts-expect-error、as any、隐式 any，提升类型安全 (#139)
+- **B2**: 消除 @ts-expect-error、as any、隐式 any，提升类型安全 （#139）
 - detect percent suffix of number in space-around-number (#129)
 - no-space-in-inline-code backtick handling & correct-title-trailing (#127)
 - replace while(true) with clean exec() loop, fix premature break (#126)

--- a/README.md
+++ b/README.md
@@ -175,17 +175,27 @@ lintMarkdown(markdown, rules, false, {
 | `no-half-width-punctuation` | 中文语境下应使用全角标点符号 | 否 | 是 |
 | `require-trailing-spaces` | 软换行前需要两个空格 | 否 | 是 |
 
-`require-trailing-spaces` 默认关闭。在 `lintMarkdown()` 的 `rules` 参数中启用该规则：
+`require-trailing-spaces` 默认关闭。CLI 用户可以在项目根目录的 `.lintmdrc` 中启用该规则：
+
+```json
+{
+  "rules": {
+    "require-trailing-spaces": 2
+  }
+}
+```
+
+CLI 默认读取 `./.lintmdrc`。也可以使用 `lint-md --config <文件路径>` 指定配置文件。
+
+直接使用 Core API 时，在 `lintMarkdown()` 的第二个参数中配置该规则：
 
 ```ts
-import { lintMarkdown, RULE_SEVERITY } from '@lint-md/core';
-
-const result = lintMarkdown(markdown, {
-  'require-trailing-spaces': RULE_SEVERITY.ERROR
+lintMarkdown(markdown, {
+  'require-trailing-spaces': 2
 });
 ```
 
-`RULE_SEVERITY.WARN`（`1`）生成警告。`RULE_SEVERITY.ERROR`（`2`）生成错误。
+规则级别 `1` 生成警告。规则级别 `2` 生成错误。
 
 欢迎大家提交需求，或者提交 PR 新增规则。
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ const markdown = '中文English 123';
 const result = lintMarkdown(markdown, {
   'space-around-alphabet': 2,
   'space-around-number': 2,
-  'no-long-code': [1, { length: 100, exclude: [] }]
+  'no-long-code': [1, { length: 100, exclude: [] }],
+  'require-trailing-spaces': 2
 }, true);
 
 console.log(result.lintResult);
@@ -151,7 +152,7 @@ lintMarkdown(markdown, rules, false, {
 
 ## 📏 书写规则列表
 
-目前内置 17 个规则，覆盖大部分的中文规则。
+目前内置 18 个规则，覆盖大部分的中文规则。
 
 | 规则名 | 说明 | 可配置 | 可修复 |
 | --- | --- | --- | --- |
@@ -172,6 +173,9 @@ lintMarkdown(markdown, rules, false, {
 | `no-space-in-inline-code` | 行内代码内容前后不能有空格 | 否 | 是 |
 | `no-long-code` | 代码块行长度不能超过限制 | 是 | 否 |
 | `no-half-width-punctuation` | 中文语境下应使用全角标点符号 | 否 | 是 |
+| `require-trailing-spaces` | 软换行前需要两个空格 | 否 | 是 |
+
+`require-trailing-spaces` 默认关闭。将规则级别设置为 `1` 或 `2` 可启用该规则。
 
 欢迎大家提交需求，或者提交 PR 新增规则。
 

--- a/README.md
+++ b/README.md
@@ -190,12 +190,22 @@ CLI 默认读取 `./.lintmdrc`。也可以使用 `lint-md --config <文件路径
 直接使用 Core API 时，在 `lintMarkdown()` 的第二个参数中配置该规则：
 
 ```ts
-lintMarkdown(markdown, {
-  'require-trailing-spaces': 2
-});
+import { lintMarkdown, RULE_SEVERITY } from '@lint-md/core';
+
+const markdown = '第一行\n第二行';
+const result = lintMarkdown(
+  markdown,
+  {
+    'require-trailing-spaces': RULE_SEVERITY.ERROR
+  },
+  true
+);
+
+console.log(result.fixedResult.result);
 ```
 
 规则级别 `1` 生成警告。规则级别 `2` 生成错误。
+第三个参数为 `true` 时，Core 自动修复文本。设置为 `false` 时，Core 只返回检查结果。
 
 欢迎大家提交需求，或者提交 PR 新增规则。
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,17 @@ lintMarkdown(markdown, rules, false, {
 | `no-half-width-punctuation` | 中文语境下应使用全角标点符号 | 否 | 是 |
 | `require-trailing-spaces` | 软换行前需要两个空格 | 否 | 是 |
 
-`require-trailing-spaces` 默认关闭。将规则级别设置为 `1` 或 `2` 可启用该规则。
+`require-trailing-spaces` 默认关闭。在 `lintMarkdown()` 的 `rules` 参数中启用该规则：
+
+```ts
+import { lintMarkdown, RULE_SEVERITY } from '@lint-md/core';
+
+const result = lintMarkdown(markdown, {
+  'require-trailing-spaces': RULE_SEVERITY.ERROR
+});
+```
+
+`RULE_SEVERITY.WARN`（`1`）生成警告。`RULE_SEVERITY.ERROR`（`2`）生成错误。
 
 欢迎大家提交需求，或者提交 PR 新增规则。
 

--- a/__tests__/unit/rules/require-trailing-spaces.spec.ts
+++ b/__tests__/unit/rules/require-trailing-spaces.spec.ts
@@ -1,0 +1,57 @@
+import { lintMarkdown } from '../../../src';
+import { RULE_SEVERITY } from '../../../src/types';
+import { requireTrailingSpaces } from '../../../src/rules';
+import { createFixer } from '../../utils/test-utils';
+
+const fixer = createFixer([{
+  rule: requireTrailingSpaces
+}]);
+
+describe('require-trailing-spaces', () => {
+  test.each([
+    ['缺少空格', '第一行\n第二行', '第一行  \n第二行', 1],
+    ['已有一个空格', '第一行 \n第二行', '第一行  \n第二行', 1],
+    ['多个软换行', '一\n二\n三', '一  \n二  \n三', 2],
+    ['CRLF 换行', '第一行\r\n第二行', '第一行  \r\n第二行', 1],
+    ['引用块', '> 第一行\n> 第二行', '> 第一行  \n> 第二行', 1],
+    ['连续链接', '[一](one)\n[二](two)', '[一](one)  \n[二](two)', 1]
+  ])('%s', (_name, markdown, expected, reportCount) => {
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe(expected);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(reportCount);
+  });
+
+  test.each([
+    ['已有两个空格', '第一行  \n第二行'],
+    ['使用反斜杠换行', '第一行\\\n第二行'],
+    ['没有软换行', '只有一行'],
+    ['代码块内换行', '```\n第一行\n第二行\n```']
+  ])('%s 时不报告', (_name, markdown) => {
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe(markdown);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+
+  test('默认关闭', () => {
+    const result = lintMarkdown('第一行\n第二行', {}, false);
+
+    expect(result.lintResult).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'require-trailing-spaces' })
+      ])
+    );
+  });
+
+  test('可以通过配置启用', () => {
+    const result = lintMarkdown(
+      '第一行\n第二行',
+      { 'require-trailing-spaces': RULE_SEVERITY.ERROR },
+      true
+    );
+
+    expect(result.fixedResult.result).toBe('第一行  \n第二行');
+    expect(result.fixableErrorCount).toBe(1);
+  });
+});

--- a/__tests__/unit/rules/require-trailing-spaces.spec.ts
+++ b/__tests__/unit/rules/require-trailing-spaces.spec.ts
@@ -26,6 +26,8 @@ describe('require-trailing-spaces', () => {
     ['已有两个空格', '第一行  \n第二行'],
     ['使用反斜杠换行', '第一行\\\n第二行'],
     ['没有软换行', '只有一行'],
+    ['行内代码中的换行', '`第一行\n第二行`'],
+    ['文档末尾换行', '只有一行\n'],
     ['代码块内换行', '```\n第一行\n第二行\n```']
   ])('%s 时不报告', (_name, markdown) => {
     const { fixedResult, lintResult } = fixer(markdown);

--- a/__tests__/unit/utils/override-default-rules.spec.ts
+++ b/__tests__/unit/utils/override-default-rules.spec.ts
@@ -34,6 +34,27 @@ describe('overrideDefaultRules', () => {
     expect(result['rule-a'].options).toEqual({});
   });
 
+  it('should use configured default severities', () => {
+    const result = overrideDefaultRules(
+      defaultRules,
+      {},
+      { 'rule-b': RULE_SEVERITY.OFF }
+    );
+
+    expect(result['rule-a'].severity).toBe(RULE_SEVERITY.ERROR);
+    expect(result['rule-b'].severity).toBe(RULE_SEVERITY.OFF);
+  });
+
+  it('should let user config override a configured default severity', () => {
+    const result = overrideDefaultRules(
+      defaultRules,
+      { 'rule-b': RULE_SEVERITY.WARN },
+      { 'rule-b': RULE_SEVERITY.OFF }
+    );
+
+    expect(result['rule-b'].severity).toBe(RULE_SEVERITY.WARN);
+  });
+
   it('should override severity and options with tuple config', () => {
     const result = overrideDefaultRules(defaultRules, {
       'rule-a': [RULE_SEVERITY.OFF, { foo: 'bar' }]

--- a/etc/core.api.md
+++ b/etc/core.api.md
@@ -332,6 +332,9 @@ export interface ReportPosition {
 }
 
 // @public (undocumented)
+export const requireTrailingSpaces: LintMdRule;
+
+// @public (undocumented)
 export enum RULE_SEVERITY {
     // (undocumented)
     ERROR = 2,

--- a/src/core/lint-markdown.ts
+++ b/src/core/lint-markdown.ts
@@ -10,6 +10,7 @@ import type {
   RegisteredRules
 } from '../types';
 import * as internalRuleConfig from '../rules';
+import { DEFAULT_RULE_SEVERITIES } from '../rules/default-rule-severities';
 import { overrideDefaultRules } from '../utils/override-default-rules';
 import { RULE_SEVERITY } from '../types';
 import { runLint } from './run-lint';
@@ -57,7 +58,11 @@ export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixM
 export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: boolean, options?: LintExecutionOptions): LintMdResult;
 export function lintMarkdown(markdown: string, rules: LintMdRulesConfig = {}, isFixMode = true, options: LintExecutionOptions = {}): LintMdResult {
   // 基于用户配置覆盖默认配置
-  const registeredRules = overrideDefaultRules(internalRuleConfig, rules);
+  const registeredRules = overrideDefaultRules(
+    internalRuleConfig,
+    rules,
+    DEFAULT_RULE_SEVERITIES
+  );
 
   const registeredRuleEntries = Object.entries(registeredRules);
 

--- a/src/rules/default-rule-severities.ts
+++ b/src/rules/default-rule-severities.ts
@@ -1,0 +1,7 @@
+import { RULE_SEVERITY } from '../types';
+
+export const DEFAULT_RULE_SEVERITIES: Readonly<
+  Partial<Record<string, RULE_SEVERITY>>
+> = {
+  'require-trailing-spaces': RULE_SEVERITY.OFF
+};

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -15,3 +15,4 @@ export { default as useStandardEllipsis } from './use-standard-ellipsis';
 export { default as correctTitleTrailingPunctuation } from './correct-title-trailing-punctuation';
 export { default as noEmptyBlockquote } from './no-empty-blockquote';
 export { default as noHalfWidthPunctuation } from './no-half-width-punctuation';
+export { default as requireTrailingSpaces } from './require-trailing-spaces';

--- a/src/rules/require-trailing-spaces.ts
+++ b/src/rules/require-trailing-spaces.ts
@@ -1,0 +1,43 @@
+import type { LintMdRule, PositionedTextNode } from '../types';
+import { TextScanner } from '../utils/text-scanner';
+
+const requireTrailingSpaces: LintMdRule = {
+  meta: {
+    name: 'require-trailing-spaces'
+  },
+  create(context) {
+    return {
+      text(node: PositionedTextNode) {
+        const scanner = new TextScanner(node, context.sourceCode);
+        const matches = scanner.findAllMatches(/\r\n|\r|\n/g);
+
+        for (const match of matches) {
+          const offset = match.absoluteRange[0];
+          let trailingSpaces = 0;
+
+          for (
+            let index = offset - 1;
+            index >= 0 && context.sourceCode.text[index] === ' ';
+            index--
+          ) {
+            trailingSpaces++;
+          }
+
+          const missingSpaces = Math.max(0, 2 - trailingSpaces);
+
+          if (missingSpaces === 0) {
+            continue;
+          }
+
+          context.report({
+            range: [offset, offset],
+            message: '软换行前需要两个空格',
+            fix: fixer => fixer.insertTextAt(offset, ' '.repeat(missingSpaces))
+          });
+        }
+      }
+    };
+  }
+};
+
+export default requireTrailingSpaces;

--- a/src/utils/override-default-rules.ts
+++ b/src/utils/override-default-rules.ts
@@ -6,7 +6,13 @@ import { RULE_SEVERITY } from '../types';
  *
  * @author YuZhanglong <loveyzl1123@gmail.com>
  */
-export const overrideDefaultRules = (defaultRules: Record<string, LintMdRule>, ruleConfig: LintMdRulesConfig) => {
+export const overrideDefaultRules = (
+  defaultRules: Record<string, LintMdRule>,
+  ruleConfig: LintMdRulesConfig,
+  defaultRuleSeverities: Readonly<
+    Partial<Record<string, RULE_SEVERITY>>
+  > = {}
+) => {
   // 默认所有的内部 rules 都会被初始化，等级为 Error，参数为空
   // 使用无原型对象，避免 __proto__/constructor/toString 等键从原型链误读，
   // 防止原型污染（见 issue #177 后续反馈）。
@@ -17,7 +23,8 @@ export const overrideDefaultRules = (defaultRules: Record<string, LintMdRule>, r
     registeredRules[ruleValue.meta.name] = {
       rule: ruleValue,
       options: {},
-      severity: RULE_SEVERITY.ERROR
+      severity:
+        defaultRuleSeverities[ruleValue.meta.name] ?? RULE_SEVERITY.ERROR
     };
   }
 

--- a/src/utils/override-default-rules.ts
+++ b/src/utils/override-default-rules.ts
@@ -13,7 +13,7 @@ export const overrideDefaultRules = (
     Partial<Record<string, RULE_SEVERITY>>
   > = {}
 ) => {
-  // 默认所有的内部 rules 都会被初始化，等级为 Error，参数为空
+  // 默认内部规则为 Error，个别规则可通过 defaultRuleSeverities 覆盖。
   // 使用无原型对象，避免 __proto__/constructor/toString 等键从原型链误读，
   // 防止原型污染（见 issue #177 后续反馈）。
   const registeredRules = Object.create(null) as RegisteredRules;


### PR DESCRIPTION
## Summary

- Add the optional `require-trailing-spaces` rule.
- Add missing spaces before soft line breaks.
- Keep the rule disabled by default.
- Preserve hard breaks and code blocks.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:tests`
- `npm run test:unit`
- `npm run api:check`
- `npm run package-contract`

Closes #53