### PR TITLE
feat: add space-around-link rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ const result = lintMarkdown(markdown, {
   'space-around-alphabet': 2,
   'space-around-number': 2,
   'no-long-code': [1, { length: 100, exclude: [] }],
-  'require-trailing-spaces': 2
+  'require-trailing-spaces': 2,
+  'space-around-link': 2
 }, true);
 
 console.log(result.lintResult);
@@ -152,7 +153,7 @@ lintMarkdown(markdown, rules, false, {
 
 ## 📏 书写规则列表
 
-目前内置 18 个规则，覆盖大部分的中文规则。
+目前内置 19 个规则，覆盖大部分的中文规则。
 
 | 规则名 | 说明 | 可配置 | 可修复 |
 | --- | --- | --- | --- |
@@ -174,13 +175,16 @@ lintMarkdown(markdown, rules, false, {
 | `no-long-code` | 代码块行长度不能超过限制 | 是 | 否 |
 | `no-half-width-punctuation` | 中文语境下应使用全角标点符号 | 否 | 是 |
 | `require-trailing-spaces` | 软换行前需要两个空格 | 否 | 是 |
+| `space-around-link` | 链接与正文之间需要空格 | 否 | 是 |
 
-`require-trailing-spaces` 默认关闭。CLI 用户可以在项目根目录的 `.lintmdrc` 中启用该规则：
+`require-trailing-spaces` 和 `space-around-link` 默认关闭。CLI 用户可以在项目根目录的
+`.lintmdrc` 中启用这些规则：
 
 ```json
 {
   "rules": {
-    "require-trailing-spaces": 2
+    "require-trailing-spaces": 2,
+    "space-around-link": 2
   }
 }
 ```
@@ -196,7 +200,8 @@ const markdown = '第一行\n第二行';
 const result = lintMarkdown(
   markdown,
   {
-    'require-trailing-spaces': RULE_SEVERITY.ERROR
+    'require-trailing-spaces': RULE_SEVERITY.ERROR,
+    'space-around-link': RULE_SEVERITY.ERROR
   },
   true
 );
@@ -206,6 +211,9 @@ console.log(result.fixedResult.result);
 
 规则级别 `1` 生成警告。规则级别 `2` 生成错误。
 第三个参数为 `true` 时，Core 自动修复文本。设置为 `false` 时，Core 只返回检查结果。
+
+`space-around-link` 处理普通链接、自动链接和引用链接。它不处理独立图片。
+全角标点、其他 Unicode 标点、已有空白和块边界不需要空格。连续链接之间只添加一个空格。
 
 欢迎大家提交需求，或者提交 PR 新增规则。
 

--- a/__tests__/unit/rules/space-around-link.spec.ts
+++ b/__tests__/unit/rules/space-around-link.spec.ts
@@ -32,6 +32,28 @@ describe('space-around-link', () => {
     expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
   });
 
+  test.each([
+    [
+      '左侧字符实体正文',
+      '&#20013;[文档](url)',
+      '&#20013; [文档](url)'
+    ],
+    [
+      '右侧字符实体正文',
+      '[文档](url)&#20013;',
+      '[文档](url) &#20013;'
+    ],
+    [
+      '补充平面 Unicode 标点',
+      '𐄀[文档](url)',
+      '𐄀[文档](url)'
+    ]
+  ])('%s', (_name, markdown, expected) => {
+    const { fixedResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe(expected);
+  });
+
   test('独立图片不属于链接空格规则', () => {
     const markdown = '正文![图片](image.png)内容';
     const { fixedResult, lintResult } = fixer(markdown);

--- a/__tests__/unit/rules/space-around-link.spec.ts
+++ b/__tests__/unit/rules/space-around-link.spec.ts
@@ -1,0 +1,152 @@
+import { lintMarkdown } from '../../../src';
+import { RULE_SEVERITY } from '../../../src/types';
+import spaceAroundLink from '../../../src/rules/space-around-link';
+import { createFixer } from '../../utils/test-utils';
+
+const fixer = createFixer([{
+  rule: spaceAroundLink
+}]);
+
+describe('space-around-link', () => {
+  test('在链接与正文之间添加空格', () => {
+    const markdown = '查看[文档](https://example.com)内容';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe('查看 [文档](https://example.com) 内容');
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(2);
+  });
+
+  test('全角标点与链接之间不添加空格', () => {
+    const markdown = '查看：[文档](https://example.com)。';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe(markdown);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+
+  test('ASCII 标点与链接之间不添加空格', () => {
+    const markdown = '查看,[文档](https://example.com).';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe(markdown);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+
+  test('独立图片不属于链接空格规则', () => {
+    const markdown = '正文![图片](image.png)内容';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe(markdown);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+
+  test('连续链接之间只添加一个空格', () => {
+    const markdown = '[文档一](one)[文档二](two)';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe('[文档一](one) [文档二](two)');
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(1);
+  });
+
+  test('链接图片按外层链接处理', () => {
+    const markdown = '查看[![图片](image.png)](https://example.com)内容';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result)
+      .toBe('查看 [![图片](image.png)](https://example.com) 内容');
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(2);
+  });
+
+  test('格式包装外添加链接空格', () => {
+    const markdown = '查看**[文档](https://example.com)**内容';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result)
+      .toBe('查看 **[文档](https://example.com)** 内容');
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(2);
+  });
+
+  test('相邻格式内容视为正文', () => {
+    const markdown = '**查看**[文档](https://example.com)内容';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result)
+      .toBe('**查看** [文档](https://example.com) 内容');
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(2);
+  });
+
+  test('可以通过 Core 配置启用', () => {
+    const result = lintMarkdown(
+      '查看[文档](https://example.com)内容',
+      { 'space-around-link': RULE_SEVERITY.ERROR },
+      true
+    );
+
+    expect(result.fixedResult.result)
+      .toBe('查看 [文档](https://example.com) 内容');
+    expect(result.fixableErrorCount).toBe(2);
+  });
+
+  test('默认关闭', () => {
+    const result = lintMarkdown(
+      '查看[文档](https://example.com)内容',
+      {},
+      false
+    );
+
+    expect(result.lintResult).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'space-around-link' })
+      ])
+    );
+  });
+
+  test('已有空白时不修改', () => {
+    const markdown = '查看 \t[文档](https://example.com)  内容';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe(markdown);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+
+  test('行首、行末和块边界不添加空格', () => {
+    const markdown = '[文档一](one)\n\n[文档二](two)';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe(markdown);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+
+  test('自动链接按链接处理', () => {
+    const markdown = '查看<https://example.com>内容';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe('查看 <https://example.com> 内容');
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(2);
+  });
+
+  test('引用链接按链接处理', () => {
+    const markdown = '查看[文档][docs]内容\n\n[docs]: https://example.com';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result)
+      .toBe('查看 [文档][docs] 内容\n\n[docs]: https://example.com');
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(2);
+  });
+
+  test('单词内的下划线不是格式包装', () => {
+    const markdown = 'foo_[文档](https://example.com)_bar';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe(markdown);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+
+  test('格式包装内的标点仍然豁免', () => {
+    const markdown = '**查看：**[文档](https://example.com)**。**';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe(markdown);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+});

--- a/etc/core.api.md
+++ b/etc/core.api.md
@@ -405,6 +405,9 @@ export { SourceMapUnavailableError }
 export const spaceAroundAlphabet: LintMdRule;
 
 // @public (undocumented)
+export const spaceAroundLink: LintMdRule;
+
+// @public (undocumented)
 export const spaceAroundNumber: LintMdRule;
 
 // @public (undocumented)

--- a/src/rules/default-rule-severities.ts
+++ b/src/rules/default-rule-severities.ts
@@ -3,5 +3,6 @@ import { RULE_SEVERITY } from '../types';
 export const DEFAULT_RULE_SEVERITIES: Readonly<
   Partial<Record<string, RULE_SEVERITY>>
 > = {
-  'require-trailing-spaces': RULE_SEVERITY.OFF
+  'require-trailing-spaces': RULE_SEVERITY.OFF,
+  'space-around-link': RULE_SEVERITY.OFF
 };

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -16,3 +16,4 @@ export { default as correctTitleTrailingPunctuation } from './correct-title-trai
 export { default as noEmptyBlockquote } from './no-empty-blockquote';
 export { default as noHalfWidthPunctuation } from './no-half-width-punctuation';
 export { default as requireTrailingSpaces } from './require-trailing-spaces';
+export { default as spaceAroundLink } from './space-around-link';

--- a/src/rules/space-around-link.ts
+++ b/src/rules/space-around-link.ts
@@ -1,0 +1,226 @@
+import type {
+  LintMdRule,
+  PositionedMarkdownNode
+} from '../types';
+import { createTraverser } from '../utils/traverser';
+
+type PositionedLinkLikeNode = Extract<
+  PositionedMarkdownNode,
+  { type: 'link' | 'linkReference' }
+>;
+
+const TRANSPARENT_NODE_TYPES = new Set(['strong', 'emphasis', 'delete']);
+const TRANSPARENT_MARKERS = ['**', '__', '~~', '*', '_'];
+const TRANSPARENT_MARKER_CHARACTER = /[*_~]/u;
+
+const needsSpace = (character: string): boolean => {
+  return !/[\s\p{P}]/u.test(character);
+};
+
+const isWordCharacter = (character: string | undefined): boolean => {
+  return character !== undefined && /[\p{L}\p{N}]/u.test(character);
+};
+
+const getChildren = (node: PositionedMarkdownNode): PositionedMarkdownNode[] => {
+  if ('children' in node && Array.isArray(node.children)) {
+    return node.children as PositionedMarkdownNode[];
+  }
+  return [];
+};
+
+const spaceAroundLink: LintMdRule = {
+  meta: {
+    name: 'space-around-link'
+  },
+  create(context) {
+    const linkStarts = new Set<number>();
+    const linkEnds = new Set<number>();
+    const links: PositionedLinkLikeNode[] = [];
+    const parents = new WeakMap<
+      PositionedMarkdownNode,
+      PositionedMarkdownNode | null
+    >();
+    const reportedOffsets = new Set<number>();
+
+    createTraverser({
+      onEnter(node, parent) {
+        parents.set(node, parent);
+        if (node.type === 'link' || node.type === 'linkReference') {
+          links.push(node);
+        }
+      }
+    }).traverse(context.ast, null);
+
+    const getBoundaryNode = (
+      node: PositionedMarkdownNode,
+      side: 'start' | 'end'
+    ): PositionedMarkdownNode => {
+      let boundary = node;
+      let parent = parents.get(boundary);
+
+      while (parent && TRANSPARENT_NODE_TYPES.has(parent.type)) {
+        const children = getChildren(parent);
+        const edgeChild = side === 'start'
+          ? children[0]
+          : children[children.length - 1];
+
+        if (edgeChild !== boundary) {
+          break;
+        }
+
+        boundary = parent;
+        parent = parents.get(boundary);
+      }
+
+      return boundary;
+    };
+
+    const getBoundaryRange = (link: PositionedLinkLikeNode) => {
+      let start = getBoundaryNode(link, 'start').position.start.offset;
+      let end = getBoundaryNode(link, 'end').position.end.offset;
+      let expanded = true;
+
+      while (expanded) {
+        expanded = false;
+
+        for (const marker of TRANSPARENT_MARKERS) {
+          const isIntrawordUnderscore = marker.includes('_')
+            && (
+              isWordCharacter(context.sourceCode.text[start - marker.length - 1])
+              || isWordCharacter(context.sourceCode.text[end + marker.length])
+            );
+
+          if (
+            !isIntrawordUnderscore
+            && context.sourceCode.text.slice(start - marker.length, start) === marker
+            && context.sourceCode.text.slice(end, end + marker.length) === marker
+          ) {
+            start -= marker.length;
+            end += marker.length;
+            expanded = true;
+            break;
+          }
+        }
+      }
+
+      return { start, end };
+    };
+
+    const getAdjacentNode = (
+      link: PositionedLinkLikeNode,
+      side: 'start' | 'end'
+    ): PositionedMarkdownNode | undefined => {
+      const boundary = getBoundaryNode(link, side);
+      const parent = parents.get(boundary);
+
+      if (!parent) {
+        return undefined;
+      }
+
+      const siblings = getChildren(parent);
+      const index = siblings.indexOf(boundary);
+      return side === 'start' ? siblings[index - 1] : siblings[index + 1];
+    };
+
+    const getVisibleTextCharacter = (
+      node: PositionedMarkdownNode,
+      side: 'start' | 'end'
+    ): string | undefined => {
+      if (node.type !== 'text') {
+        return node.type === 'image' || node.type === 'break'
+          ? undefined
+          : 'a';
+      }
+
+      let value = node.value;
+      let stripped = true;
+
+      while (stripped) {
+        stripped = false;
+
+        for (const marker of TRANSPARENT_MARKERS) {
+          if (
+            value.length > marker.length * 2
+            && value.startsWith(marker)
+            && value.endsWith(marker)
+          ) {
+            value = value.slice(marker.length, -marker.length);
+            stripped = true;
+            break;
+          }
+        }
+      }
+
+      const characters = Array.from(value);
+      return side === 'start' ? characters.at(-1) : characters[0];
+    };
+
+    const getBoundaryCharacter = (
+      link: PositionedLinkLikeNode,
+      side: 'start' | 'end',
+      offset: number
+    ): string => {
+      const character = side === 'start'
+        ? context.sourceCode.text[offset - 1]
+        : context.sourceCode.text[offset];
+
+      if (!TRANSPARENT_MARKER_CHARACTER.test(character)) {
+        return character;
+      }
+
+      const adjacentNode = getAdjacentNode(link, side);
+      return adjacentNode
+        ? getVisibleTextCharacter(adjacentNode, side) ?? character
+        : character;
+    };
+
+    for (const link of links) {
+      const { start, end } = getBoundaryRange(link);
+      linkStarts.add(start);
+      linkEnds.add(end);
+    }
+
+    const report = (offset: number) => {
+      if (reportedOffsets.has(offset)) {
+        return;
+      }
+      reportedOffsets.add(offset);
+      context.report({
+        range: [offset, offset],
+        message: '链接与正文之间需要添加空格',
+        fix: fixer => fixer.insertTextAt(offset, ' ')
+      });
+    };
+
+    const checkLink = (node: PositionedLinkLikeNode) => {
+      const { start, end } = getBoundaryRange(node);
+
+      if (
+        start > 0
+        && (
+          linkEnds.has(start)
+          || needsSpace(getBoundaryCharacter(node, 'start', start))
+        )
+      ) {
+        report(start);
+      }
+
+      if (
+        end < context.sourceCode.text.length
+        && (
+          linkStarts.has(end)
+          || needsSpace(getBoundaryCharacter(node, 'end', end))
+        )
+      ) {
+        report(end);
+      }
+    };
+
+    return {
+      link: checkLink,
+      linkReference: checkLink
+    };
+  }
+};
+
+export default spaceAroundLink;

--- a/src/rules/space-around-link.ts
+++ b/src/rules/space-around-link.ts
@@ -126,10 +126,30 @@ const spaceAroundLink: LintMdRule = {
       node: PositionedMarkdownNode,
       side: 'start' | 'end'
     ): string | undefined => {
+      if (node.type === 'image' || node.type === 'break') {
+        return undefined;
+      }
+
       if (node.type !== 'text') {
-        return node.type === 'image' || node.type === 'break'
-          ? undefined
-          : 'a';
+        const children = getChildren(node);
+
+        if (children.length > 0) {
+          const orderedChildren = side === 'start'
+            ? [...children].reverse()
+            : children;
+
+          for (const child of orderedChildren) {
+            const character = getVisibleTextCharacter(child, side);
+
+            if (character !== undefined) {
+              return character;
+            }
+          }
+
+          return undefined;
+        }
+
+        return 'a';
       }
 
       let value = node.value;
@@ -155,23 +175,36 @@ const spaceAroundLink: LintMdRule = {
       return side === 'start' ? characters.at(-1) : characters[0];
     };
 
+    const getRawBoundaryCharacter = (
+      side: 'start' | 'end',
+      offset: number
+    ): string | undefined => {
+      const text = side === 'start'
+        ? context.sourceCode.text.slice(Math.max(0, offset - 2), offset)
+        : context.sourceCode.text.slice(offset, offset + 2);
+      const characters = Array.from(text);
+
+      return side === 'start' ? characters.at(-1) : characters[0];
+    };
+
     const getBoundaryCharacter = (
       link: PositionedLinkLikeNode,
       side: 'start' | 'end',
       offset: number
     ): string => {
-      const character = side === 'start'
-        ? context.sourceCode.text[offset - 1]
-        : context.sourceCode.text[offset];
+      const adjacentNode = getAdjacentNode(link, side);
+      const visibleCharacter = adjacentNode
+        ? getVisibleTextCharacter(adjacentNode, side)
+        : undefined;
 
-      if (!TRANSPARENT_MARKER_CHARACTER.test(character)) {
-        return character;
+      if (
+        visibleCharacter !== undefined
+        && !TRANSPARENT_MARKER_CHARACTER.test(visibleCharacter)
+      ) {
+        return visibleCharacter;
       }
 
-      const adjacentNode = getAdjacentNode(link, side);
-      return adjacentNode
-        ? getVisibleTextCharacter(adjacentNode, side) ?? character
-        : character;
+      return getRawBoundaryCharacter(side, offset) ?? visibleCharacter ?? '';
     };
 
     for (const link of links) {


### PR DESCRIPTION
## Summary

- Add the `space-around-link` rule.
- Keep the rule disabled by default.
- Add one space between links and adjacent text.
- Exempt Unicode punctuation, whitespace, and block boundaries.
- Ignore standalone images.
- Handle linked images, formatted links, and consecutive links.
- Document CLI and Core API configuration.

## Validation

- `npm run test:unit`
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:tests`
- `npm run api:check`
- `npm run package-contract`

Closes #65
