### PR TITLE
feat: add no-multiple-blank-lines rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ const result = lintMarkdown(markdown, {
   'space-around-number': 2,
   'no-long-code': [1, { length: 100, exclude: [] }],
   'require-trailing-spaces': 2,
-  'space-around-link': 2
+  'space-around-link': 2,
+  'no-multiple-blank-lines': 2
 }, true);
 
 console.log(result.lintResult);
@@ -153,7 +154,7 @@ lintMarkdown(markdown, rules, false, {
 
 ## 📏 书写规则列表
 
-目前内置 19 个规则，覆盖大部分的中文规则。
+目前内置 20 个规则，覆盖大部分的中文规则。
 
 | 规则名 | 说明 | 可配置 | 可修复 |
 | --- | --- | --- | --- |
@@ -176,15 +177,25 @@ lintMarkdown(markdown, rules, false, {
 | `no-half-width-punctuation` | 中文语境下应使用全角标点符号 | 否 | 是 |
 | `require-trailing-spaces` | 软换行前需要两个空格 | 否 | 是 |
 | `space-around-link` | 链接与正文之间需要空格 | 否 | 是 |
+| `no-multiple-blank-lines` | 连续空白行最多保留一行 | 否 | 是 |
 
-`require-trailing-spaces` 和 `space-around-link` 默认关闭。CLI 用户可以在项目根目录的
-`.lintmdrc` 中启用这些规则：
+`require-trailing-spaces`、`space-around-link` 和 `no-multiple-blank-lines` 默认关闭。
+CLI 用户可以在项目根目录的 `.lintmdrc` 中启用这些规则：
+
+| 规则级别 | 含义 |
+| --- | --- |
+| `0` | 关闭规则 |
+| `1` | 生成警告 |
+| `2` | 生成错误 |
+
+下面的示例将三条规则设置为错误级别：
 
 ```json
 {
   "rules": {
     "require-trailing-spaces": 2,
-    "space-around-link": 2
+    "space-around-link": 2,
+    "no-multiple-blank-lines": 2
   }
 }
 ```
@@ -201,7 +212,8 @@ const result = lintMarkdown(
   markdown,
   {
     'require-trailing-spaces': RULE_SEVERITY.ERROR,
-    'space-around-link': RULE_SEVERITY.ERROR
+    'space-around-link': RULE_SEVERITY.ERROR,
+    'no-multiple-blank-lines': RULE_SEVERITY.ERROR
   },
   true
 );
@@ -209,11 +221,15 @@ const result = lintMarkdown(
 console.log(result.fixedResult.result);
 ```
 
-规则级别 `1` 生成警告。规则级别 `2` 生成错误。
+`RULE_SEVERITY.ERROR` 等同于规则级别 `2`。
 第三个参数为 `true` 时，Core 自动修复文本。设置为 `false` 时，Core 只返回检查结果。
 
 `space-around-link` 处理普通链接、自动链接和引用链接。它不处理独立图片。
 全角标点、其他 Unicode 标点、已有空白和块边界不需要空格。连续链接之间只添加一个空格。
+
+`no-multiple-blank-lines` 将连续空白行修复为一个空白行。
+它删除文档开头的空白行。它保留文档末尾的一个换行。
+空格和 Tab 组成的行也算空白行。代码块内部内容不受影响。
 
 欢迎大家提交需求，或者提交 PR 新增规则。
 

--- a/__tests__/unit/rules/no-multiple-blank-lines.spec.ts
+++ b/__tests__/unit/rules/no-multiple-blank-lines.spec.ts
@@ -49,6 +49,38 @@ describe('no-multiple-blank-lines', () => {
     expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
   });
 
+  test('不修改 YAML block scalar 内的空白行', () => {
+    const markdown = [
+      '---',
+      'description: |-',
+      '  第一段',
+      '',
+      '',
+      '  第二段',
+      '---'
+    ].join('\n');
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe(markdown);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+
+  test('不修改 pre HTML 内的空白行', () => {
+    const markdown = '<pre>\n第一行\n\n\n第二行\n</pre>';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe(markdown);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+
+  test('不修改数学块内的空白行', () => {
+    const markdown = '$$\na\n\n\nb\n$$';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe(markdown);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+
   test('删除文档开头的空白行', () => {
     const markdown = '\n \t\n# 标题';
     const { fixedResult, lintResult } = fixer(markdown);
@@ -59,6 +91,14 @@ describe('no-multiple-blank-lines', () => {
 
   test('只包含空白行的文档修复为空文档', () => {
     const markdown = '\n \t\n';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe('');
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(1);
+  });
+
+  test('无换行的纯空格文档修复为空文档', () => {
+    const markdown = ' \t';
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe('');

--- a/__tests__/unit/rules/no-multiple-blank-lines.spec.ts
+++ b/__tests__/unit/rules/no-multiple-blank-lines.spec.ts
@@ -1,0 +1,115 @@
+import { lintMarkdown } from '../../../src';
+import noMultipleBlankLines from '../../../src/rules/no-multiple-blank-lines';
+import { RULE_SEVERITY } from '../../../src/types';
+import { createFixer } from '../../utils/test-utils';
+
+const fixer = createFixer([{
+  rule: noMultipleBlankLines
+}]);
+
+describe('no-multiple-blank-lines', () => {
+  test('块之间只保留一个空白行', () => {
+    const markdown = '第一段\n\n\n第二段';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe('第一段\n\n第二段');
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(1);
+  });
+
+  test('处理不同类型块之间的多余空白行', () => {
+    const markdown = '# 标题\n\n\n---\n\n\n- 项目\n\n\n> 引用';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result)
+      .toBe('# 标题\n\n---\n\n- 项目\n\n> 引用');
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(3);
+  });
+
+  test('空格和 Tab 组成的 CRLF 空白行也参与限制', () => {
+    const markdown = '第一段\r\n \t\r\n\t\r\n第二段';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe('第一段\r\n\r\n第二段');
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(1);
+  });
+
+  test('不修改围栏代码块内部的空白行', () => {
+    const markdown = '```text\n第一行\n\n\n第二行\n```';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe(markdown);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+
+  test('不修改缩进代码块内部的空白行', () => {
+    const markdown = '    第一行\n\n\n    第二行';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe(markdown);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+
+  test('删除文档开头的空白行', () => {
+    const markdown = '\n \t\n# 标题';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe('# 标题');
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(1);
+  });
+
+  test('只包含空白行的文档修复为空文档', () => {
+    const markdown = '\n \t\n';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe('');
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(1);
+  });
+
+  test('文档末尾最多保留一个换行', () => {
+    const markdown = '正文\n \t\n\n';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe('正文\n');
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(1);
+  });
+
+  test('删除末尾空白行中的空格和 Tab', () => {
+    const markdown = '正文\n \t';
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe('正文\n');
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(1);
+  });
+
+  test('可以通过 Core 配置启用', () => {
+    const result = lintMarkdown(
+      '第一段\n\n\n第二段',
+      { 'no-multiple-blank-lines': RULE_SEVERITY.ERROR },
+      true
+    );
+
+    expect(result.fixedResult.result).toBe('第一段\n\n第二段');
+    expect(result.fixableErrorCount).toBe(1);
+  });
+
+  test('默认关闭', () => {
+    const result = lintMarkdown('第一段\n\n\n第二段', {}, false);
+
+    expect(result.lintResult).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'no-multiple-blank-lines' })
+      ])
+    );
+  });
+
+  test.each([
+    ['块之间只有一个空白行', '第一段\n\n第二段'],
+    ['文档末尾只有一个换行', '正文\n'],
+    ['文档末尾没有换行', '正文']
+  ])('%s 时不修改', (_name, markdown) => {
+    const { fixedResult, lintResult } = fixer(markdown);
+
+    expect(fixedResult?.result).toBe(markdown);
+    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+  });
+});

--- a/__tests__/unit/rules/no-multiple-blank-lines.spec.ts
+++ b/__tests__/unit/rules/no-multiple-blank-lines.spec.ts
@@ -65,6 +65,30 @@ describe('no-multiple-blank-lines', () => {
     expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
   });
 
+  test('删除 YAML 前导空行但保留 block scalar 空白行', () => {
+    const markdown = [
+      '',
+      '---',
+      'description: |-',
+      '  第一段',
+      '',
+      '',
+      '  第二段',
+      '---'
+    ].join('\n');
+    const expected = [
+      '---',
+      'description: |-',
+      '  第一段',
+      '',
+      '',
+      '  第二段',
+      '---'
+    ].join('\n');
+
+    expect(fixer(markdown).fixedResult?.result).toBe(expected);
+  });
+
   test('不修改 pre HTML 内的空白行', () => {
     const markdown = '<pre>\n第一行\n\n\n第二行\n</pre>';
     const { fixedResult, lintResult } = fixer(markdown);

--- a/etc/core.api.md
+++ b/etc/core.api.md
@@ -239,6 +239,9 @@ export const noHalfWidthPunctuation: LintMdRule;
 export const noLongCode: LintMdRule;
 
 // @public (undocumented)
+export const noMultipleBlankLines: LintMdRule;
+
+// @public (undocumented)
 export const noMultipleSpaceBlockquote: LintMdRule;
 
 // @public (undocumented)

--- a/src/rules/default-rule-severities.ts
+++ b/src/rules/default-rule-severities.ts
@@ -4,5 +4,6 @@ export const DEFAULT_RULE_SEVERITIES: Readonly<
   Partial<Record<string, RULE_SEVERITY>>
 > = {
   'require-trailing-spaces': RULE_SEVERITY.OFF,
-  'space-around-link': RULE_SEVERITY.OFF
+  'space-around-link': RULE_SEVERITY.OFF,
+  'no-multiple-blank-lines': RULE_SEVERITY.OFF
 };

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -17,3 +17,4 @@ export { default as noEmptyBlockquote } from './no-empty-blockquote';
 export { default as noHalfWidthPunctuation } from './no-half-width-punctuation';
 export { default as requireTrailingSpaces } from './require-trailing-spaces';
 export { default as spaceAroundLink } from './space-around-link';
+export { default as noMultipleBlankLines } from './no-multiple-blank-lines';

--- a/src/rules/no-multiple-blank-lines.ts
+++ b/src/rules/no-multiple-blank-lines.ts
@@ -63,6 +63,10 @@ const noMultipleBlankLines: LintMdRule = {
             message: '文档开头不能有空白行',
             fix: fixer => fixer.removeRange([0, end])
           });
+
+          if (/^---[ \t]*(?:\r\n|\r|\n)/u.test(source.slice(end))) {
+            return;
+          }
         }
 
         const trailingBlankLines = leadingBlankLines?.[0].length === source.length

--- a/src/rules/no-multiple-blank-lines.ts
+++ b/src/rules/no-multiple-blank-lines.ts
@@ -1,17 +1,26 @@
 import type { LintMdRule } from '../types';
 import { createTraverser } from '../utils/traverser';
 
+const PROTECTED_NODE_TYPES = new Set([
+  'code',
+  'inlineCode',
+  'yaml',
+  'html',
+  'math',
+  'inlineMath'
+]);
+
 const noMultipleBlankLines: LintMdRule = {
   meta: {
     name: 'no-multiple-blank-lines'
   },
   create(context) {
-    const codeRanges: Array<[number, number]> = [];
+    const protectedRanges: Array<[number, number]> = [];
 
     createTraverser({
       onEnter(node) {
-        if (node.type === 'code') {
-          codeRanges.push([
+        if (PROTECTED_NODE_TYPES.has(node.type)) {
+          protectedRanges.push([
             node.position.start.offset,
             node.position.end.offset
           ]);
@@ -19,13 +28,34 @@ const noMultipleBlankLines: LintMdRule = {
       }
     }).traverse(context.ast, null);
 
+    const overlapsProtectedRange = (start: number, end: number): boolean => {
+      return protectedRanges.some(([protectedStart, protectedEnd]) => {
+        return start < protectedEnd && end > protectedStart;
+      });
+    };
+
     return {
       root() {
         const source = context.sourceCode.text;
+
+        if (/^[ \t]*$/u.test(source)) {
+          if (source.length > 0) {
+            context.report({
+              range: [0, source.length],
+              message: '空白文档应为空文档',
+              fix: fixer => fixer.removeRange([0, source.length])
+            });
+          }
+          return;
+        }
+
         const leadingBlankLines
           = /^(?:[ \t]*(?:\r\n|\r|\n))+/.exec(source);
 
-        if (leadingBlankLines) {
+        if (
+          leadingBlankLines
+          && !overlapsProtectedRange(0, leadingBlankLines[0].length)
+        ) {
           const end = leadingBlankLines[0].length;
 
           context.report({
@@ -42,6 +72,10 @@ const noMultipleBlankLines: LintMdRule = {
         if (
           trailingBlankLines
           && trailingBlankLines[0] !== trailingBlankLines[1]
+          && !overlapsProtectedRange(
+            trailingBlankLines.index,
+            source.length
+          )
         ) {
           const start = trailingBlankLines.index;
           const end = source.length;
@@ -63,12 +97,8 @@ const noMultipleBlankLines: LintMdRule = {
           const end = start + match[0].length;
           const replacement = `${match[1]}${match[1]}`;
 
-          const isInCodeBlock = codeRanges.some(([codeStart, codeEnd]) => {
-            return start < codeEnd && end > codeStart;
-          });
-
           if (
-            !isInCodeBlock
+            !overlapsProtectedRange(start, end)
             && end <= (trailingBlankLines?.index ?? source.length)
           ) {
             context.report({

--- a/src/rules/no-multiple-blank-lines.ts
+++ b/src/rules/no-multiple-blank-lines.ts
@@ -1,0 +1,88 @@
+import type { LintMdRule } from '../types';
+import { createTraverser } from '../utils/traverser';
+
+const noMultipleBlankLines: LintMdRule = {
+  meta: {
+    name: 'no-multiple-blank-lines'
+  },
+  create(context) {
+    const codeRanges: Array<[number, number]> = [];
+
+    createTraverser({
+      onEnter(node) {
+        if (node.type === 'code') {
+          codeRanges.push([
+            node.position.start.offset,
+            node.position.end.offset
+          ]);
+        }
+      }
+    }).traverse(context.ast, null);
+
+    return {
+      root() {
+        const source = context.sourceCode.text;
+        const leadingBlankLines
+          = /^(?:[ \t]*(?:\r\n|\r|\n))+/.exec(source);
+
+        if (leadingBlankLines) {
+          const end = leadingBlankLines[0].length;
+
+          context.report({
+            range: [0, end],
+            message: '文档开头不能有空白行',
+            fix: fixer => fixer.removeRange([0, end])
+          });
+        }
+
+        const trailingBlankLines = leadingBlankLines?.[0].length === source.length
+          ? null
+          : /(\r\n|\r|\n)(?:[ \t]*(?:\r\n|\r|\n))*[ \t]*$/.exec(source);
+
+        if (
+          trailingBlankLines
+          && trailingBlankLines[0] !== trailingBlankLines[1]
+        ) {
+          const start = trailingBlankLines.index;
+          const end = source.length;
+          const replacement = trailingBlankLines[1];
+
+          context.report({
+            range: [start, end],
+            message: '文档末尾最多保留一个换行',
+            fix: fixer => fixer.replaceTextRange([start, end], replacement)
+          });
+        }
+
+        const pattern = /(\r\n|\r|\n)(?:[ \t]*(?:\r\n|\r|\n)){2,}/gu;
+        pattern.lastIndex = leadingBlankLines?.[0].length ?? 0;
+        let match = pattern.exec(source);
+
+        while (match) {
+          const start = match.index;
+          const end = start + match[0].length;
+          const replacement = `${match[1]}${match[1]}`;
+
+          const isInCodeBlock = codeRanges.some(([codeStart, codeEnd]) => {
+            return start < codeEnd && end > codeStart;
+          });
+
+          if (
+            !isInCodeBlock
+            && end <= (trailingBlankLines?.index ?? source.length)
+          ) {
+            context.report({
+              range: [start, end],
+              message: '连续空白行最多保留一行',
+              fix: fixer => fixer.replaceTextRange([start, end], replacement)
+            });
+          }
+
+          match = pattern.exec(source);
+        }
+      }
+    };
+  }
+};
+
+export default noMultipleBlankLines;


### PR DESCRIPTION
## Summary

- Add the `no-multiple-blank-lines` rule.
- Keep the rule disabled by default.
- Limit block gaps to one blank line.
- Treat spaces and tabs as blank line content.
- Preserve blank lines inside fenced and indented code blocks.
- Remove blank lines at the document start.
- Keep at most one line ending at the document end.
- Document CLI severity values and Core API configuration.

## Validation

- `npm run test:unit`
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:tests`
- `npm run api:check`
- `npm run package-contract`

Closes #56
