### PR TITLE
feat: add explicit fixMarkdown API

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ lintMarkdown(
 - `fixedResult`：开启修复模式时返回 `{ result, notAppliedFixes }`（`result` 为修复后的文本，`notAppliedFixes` 为因冲突等原因未能应用的修复项），否则为 `null`
 - `executionErrors`：规则执行失败的结构化列表。非空时，`diagnostics` 与 `lintResult` 可能只是部分结果；CLI 和编辑器 Adapter 应据此标记本次检查不完整。
 
+In fix mode, `lintResult`, `diagnostics`, and both fixable counts describe the original Markdown.
+`fixedResult.result` contains the final Markdown.
+`fixedResult.notAppliedFixes` uses coordinates from the final relevant fix round.
+`executionErrors` aggregates failures from all fix rounds.
+`fixedResult.convergence`, `rounds`, and `metrics` describe the complete fix process.
+Do not apply original diagnostic positions to `fixedResult.result`.
+
 ### Unapplied fix contract
 
 Each `notAppliedFixes` item contains these fields:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,26 @@ context.report({
 
 ## 🚀 快速使用
 
-从 API 到结果处理，核心只需要一个方法即可完成 lint/fix。当前对外仅提供 **1 个核心 API**：`lintMarkdown`。
+Core 提供明确的修复 API：`fixMarkdown`。
+
+```ts
+fixMarkdown(
+  markdown: string,
+  options?: {
+    rules?: LintMdRulesConfig,
+    ruleErrorPolicy?: 'collect' | 'strict'
+  }
+)
+```
+
+`rules` 配置本次修复使用的规则。
+`ruleErrorPolicy` 配置规则执行失败策略。
+
+`fixMarkdown()` 返回 `LintMdFixResult`。
+其中 `lintResult` 描述原始输入。
+`fixedResult.result` 包含最终修复文本。
+
+现有 `lintMarkdown` API 保持兼容：
 
 ```ts
 lintMarkdown(
@@ -108,18 +127,20 @@ The API does not guarantee that `data` supports JSON serialization.
 下面是一个最小示例，可直接作为接入起点：
 
 ```ts
-import { lintMarkdown } from '@lint-md/core';
+import { fixMarkdown } from '@lint-md/core';
 
 const markdown = '中文English 123';
 
-const result = lintMarkdown(markdown, {
-  'space-around-alphabet': 2,
-  'space-around-number': 2,
-  'no-long-code': [1, { length: 100, exclude: [] }],
-  'require-trailing-spaces': 2,
-  'space-around-link': 2,
-  'no-multiple-blank-lines': 2
-}, true);
+const result = fixMarkdown(markdown, {
+  rules: {
+    'space-around-alphabet': 2,
+    'space-around-number': 2,
+    'no-long-code': [1, { length: 100, exclude: [] }],
+    'require-trailing-spaces': 2,
+    'space-around-link': 2,
+    'no-multiple-blank-lines': 2
+  }
+});
 
 console.log(result.lintResult);
 console.log(result.fixedResult.result);
@@ -202,27 +223,26 @@ CLI 用户可以在项目根目录的 `.lintmdrc` 中启用这些规则：
 
 CLI 默认读取 `./.lintmdrc`。也可以使用 `lint-md --config <文件路径>` 指定配置文件。
 
-直接使用 Core API 时，在 `lintMarkdown()` 的第二个参数中配置该规则：
+直接使用 Core API 时，在 `fixMarkdown()` 的 `rules` 中配置规则：
 
 ```ts
-import { lintMarkdown, RULE_SEVERITY } from '@lint-md/core';
+import { fixMarkdown, RULE_SEVERITY } from '@lint-md/core';
 
 const markdown = '第一行\n第二行';
-const result = lintMarkdown(
-  markdown,
-  {
+const result = fixMarkdown(markdown, {
+  rules: {
     'require-trailing-spaces': RULE_SEVERITY.ERROR,
     'space-around-link': RULE_SEVERITY.ERROR,
     'no-multiple-blank-lines': RULE_SEVERITY.ERROR
-  },
-  true
-);
+  }
+});
 
 console.log(result.fixedResult.result);
 ```
 
 `RULE_SEVERITY.ERROR` 等同于规则级别 `2`。
-第三个参数为 `true` 时，Core 自动修复文本。设置为 `false` 时，Core 只返回检查结果。
+`fixMarkdown()` 始终执行自动修复。
+只检查时，继续使用 `lintMarkdown(markdown, rules, false)`。
 
 `space-around-link` 处理普通链接、自动链接和引用链接。它不处理独立图片。
 全角标点、其他 Unicode 标点、已有空白和块边界不需要空格。连续链接之间只添加一个空格。

--- a/__tests__/unit/fix-markdown.spec.ts
+++ b/__tests__/unit/fix-markdown.spec.ts
@@ -17,6 +17,9 @@ describe('fixMarkdown', () => {
     expect(result.fixedResult.result).toBe('第一段\n\n第二段');
     expect(result.lintResult).toHaveLength(1);
     expect(result.lintResult[0].name).toBe('no-multiple-blank-lines');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].ruleId).toBe('no-multiple-blank-lines');
+    expect(result.fixableErrorCount).toBe(1);
   });
 
   test('forwards the strict rule error policy', () => {

--- a/__tests__/unit/fix-markdown.spec.ts
+++ b/__tests__/unit/fix-markdown.spec.ts
@@ -1,0 +1,64 @@
+import {
+  RULE_SEVERITY,
+  RuleExecutionFailure,
+  fixMarkdown,
+  lintMarkdown
+} from '../../src';
+import type { LintMdFixResult, LintMdRule } from '../../src';
+
+describe('fixMarkdown', () => {
+  test('applies configured fixes and returns diagnostics for the original input', () => {
+    const result: LintMdFixResult = fixMarkdown('第一段\n\n\n第二段', {
+      rules: {
+        'no-multiple-blank-lines': RULE_SEVERITY.ERROR
+      }
+    });
+
+    expect(result.fixedResult.result).toBe('第一段\n\n第二段');
+    expect(result.lintResult).toHaveLength(1);
+    expect(result.lintResult[0].name).toBe('no-multiple-blank-lines');
+  });
+
+  test('forwards the strict rule error policy', () => {
+    const throwingRule: LintMdRule = {
+      meta: { name: 'throwing-rule' },
+      create: () => ({
+        text: () => {
+          throw new Error('strict failure');
+        }
+      })
+    };
+
+    expect(() => fixMarkdown('text', {
+      rules: {
+        'throwing-rule': [
+          throwingRule,
+          RULE_SEVERITY.ERROR,
+          {}
+        ]
+      },
+      ruleErrorPolicy: 'strict'
+    })).toThrow(RuleExecutionFailure);
+  });
+
+  test('matches the legacy fix behavior', () => {
+    const markdown = '第一段\n\n\n第二段';
+    const rules = {
+      'no-multiple-blank-lines': RULE_SEVERITY.ERROR
+    };
+    const current = fixMarkdown(markdown, { rules });
+    const legacy = lintMarkdown(markdown, rules, true);
+    const { metrics: currentMetrics, ...currentFixedResult }
+      = current.fixedResult;
+    const { metrics: legacyMetrics, ...legacyFixedResult }
+      = legacy.fixedResult;
+
+    expect(current.lintResult).toStrictEqual(legacy.lintResult);
+    expect(current.diagnostics).toStrictEqual(legacy.diagnostics);
+    expect(currentFixedResult).toStrictEqual(legacyFixedResult);
+    expect(current.fixableErrorCount).toBe(legacy.fixableErrorCount);
+    expect(current.fixableWarningCount).toBe(legacy.fixableWarningCount);
+    expect(current.executionErrors).toStrictEqual(legacy.executionErrors);
+    expect(currentMetrics?.rounds).toBe(legacyMetrics?.rounds);
+  });
+});

--- a/__tests__/unit/package-contract.spec.ts
+++ b/__tests__/unit/package-contract.spec.ts
@@ -1,4 +1,4 @@
-import { RuleExecutionFailure } from '../../src';
+import { RuleExecutionFailure, fixMarkdown } from '../../src';
 
 /**
  * 包入口契约：RuleExecutionFailure 必须能从公开入口导入，
@@ -8,6 +8,10 @@ import { RuleExecutionFailure } from '../../src';
  * CI 工作区独立运行；构建产物仍由 CI 的后续 `npm run build` 验证。
  */
 describe('package contract', () => {
+  test('public entry exports fixMarkdown', () => {
+    expect(typeof fixMarkdown).toBe('function');
+  });
+
   test('public entry exports RuleExecutionFailure and strict consumers can catch it', () => {
     expect(typeof RuleExecutionFailure).toBe('function');
     const e = new RuleExecutionFailure({

--- a/etc/core.api.md
+++ b/etc/core.api.md
@@ -49,6 +49,15 @@ export interface FixedResult {
 }
 
 // @public (undocumented)
+export function fixMarkdown(markdown: string, options?: FixMarkdownOptions): LintMdFixResult;
+
+// @public (undocumented)
+export interface FixMarkdownOptions extends LintExecutionOptions {
+    // (undocumented)
+    rules?: LintMdRulesConfig;
+}
+
+// @public (undocumented)
 export interface FixMetrics {
     // (undocumented)
     perRound: number[];

--- a/scripts/check-package-contract.mjs
+++ b/scripts/check-package-contract.mjs
@@ -20,11 +20,17 @@ const root = path.resolve(scriptDir, '..');
 const require = createRequire(import.meta.url);
 
 const cjs = require(path.join(root, 'lib', 'index.js'));
+if (typeof cjs.fixMarkdown !== 'function') {
+  throw new TypeError('CJS entry does not export fixMarkdown');
+}
 if (typeof cjs.RuleExecutionFailure !== 'function') {
   throw new TypeError('CJS entry does not export RuleExecutionFailure');
 }
 
 const esmEntry = await readFile(path.join(root, 'esm', 'index.js'), 'utf8');
+if (!/export\s*\{[^}]*\bfixMarkdown\b[^}]*\}/.test(esmEntry)) {
+  throw new Error('ESM entry does not explicitly export fixMarkdown');
+}
 if (!/export\s*\{\s*RuleExecutionFailure\s*\}/.test(esmEntry)) {
   throw new Error('ESM entry does not explicitly export RuleExecutionFailure');
 }

--- a/src/core/lint-markdown.ts
+++ b/src/core/lint-markdown.ts
@@ -1,4 +1,5 @@
 import type {
+  FixMarkdownOptions,
   FixedResult,
   LintExecutionOptions,
   LintMdFixResult,
@@ -44,65 +45,45 @@ export const lintMarkdownInternal = (
   }
 };
 
-/**
- * 核心方法，对某个 Markdown 文本进行 lint 或者 fix
- *
- * @date 2021-12-14 17:16:12
- *    默认开启 fix 模式：
- * - isFixMode=true 或省略时，fixedResult 为 FixedResult
- * - isFixMode=false 时，fixedResult 为 null
- * - isFixMode 为 boolean 变量时，返回联合类型
- */
-export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: true, options?: LintExecutionOptions): LintMdFixResult;
-export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: false, options?: LintExecutionOptions): LintMdLintResult;
-export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: boolean, options?: LintExecutionOptions): LintMdResult;
-export function lintMarkdown(markdown: string, rules: LintMdRulesConfig = {}, isFixMode = true, options: LintExecutionOptions = {}): LintMdResult {
-  // 基于用户配置覆盖默认配置
+const resolveConfiguredRules = (rules: LintMdRulesConfig) => {
   const registeredRules = overrideDefaultRules(
     internalRuleConfig,
     rules,
     DEFAULT_RULE_SEVERITIES
   );
-
-  const registeredRuleEntries = Object.entries(registeredRules);
-
-  // 最终的 rules
-  // 注意：注册表可能为同一注册记录建立过别名（配置键 + meta.name 指向同一对象），
-  // 这里按注册记录引用去重，避免规则被重复执行导致报告与计数翻倍。
-  // 按记录（而非 rule）去重很重要：当同一个 rule 对象被两个配置键复用时，
-  // 它们是不同的注册记录（不同 severity/options），冲突检查已在注册阶段阻止，
-  // 此处不会遇到这种情况，但按记录去重更能与注册表契约保持一致。
   const seenRecords = new Set<RegisteredRules[string]>();
-  const internalRules = registeredRuleEntries
-    .filter((item) => {
-      const value = item[1];
-      // 过滤掉 severity 为 0 的规则，提高性能
+  const executableRules = Object.values(registeredRules)
+    .filter((value) => {
       if (value.severity === RULE_SEVERITY.OFF) {
         return false;
       }
-      // 同一注册记录只保留一次（配置键与 meta.name 别名指向同一对象）
       if (seenRecords.has(value)) {
         return false;
       }
       seenRecords.add(value);
       return true;
     })
-    .map((options) => {
-      const value = options[1];
-      return {
-        rule: value.rule,
-        options: value.options
-      };
-    });
+    .map(value => ({
+      rule: value.rule,
+      options: value.options
+    }));
 
-  const policy = options.ruleErrorPolicy ?? 'collect';
-  const { fixedResult, lintResult, executionErrors } = lintMarkdownInternal(markdown, internalRules, isFixMode, policy);
+  return {
+    registeredRules,
+    executableRules
+  };
+};
 
-  const reportData = lintResult?.ruleManager.getReportData();
+const buildLintResult = (
+  registeredRules: RegisteredRules,
+  executionResult: ReturnType<typeof lintMarkdownInternal>
+): LintMdResult => {
+  const { fixedResult, lintResult, executionErrors } = executionResult;
+  const reportData = lintResult.ruleManager.getReportData();
   let fixableErrorCount = 0;
   let fixableWarningCount = 0;
 
-  const reportDataWithSeverity: LintReportItem[] = reportData?.map((item) => {
+  const reportDataWithSeverity: LintReportItem[] = reportData.map((item) => {
     const severity = registeredRules[item.name].severity as RULE_SEVERITY;
 
     if (typeof item.fix === 'function') {
@@ -122,9 +103,9 @@ export function lintMarkdown(markdown: string, rules: LintMdRulesConfig = {}, is
       content,
       severity
     };
-  }) ?? [];
+  });
 
-  const diagnostics = (reportDataWithSeverity ?? []).map(item => ({
+  const diagnostics = reportDataWithSeverity.map(item => ({
     line: item.loc.start.line,
     column: item.loc.start.column,
     ruleId: item.name,
@@ -140,4 +121,56 @@ export function lintMarkdown(markdown: string, rules: LintMdRulesConfig = {}, is
     fixableWarningCount,
     executionErrors
   };
+};
+
+function executeMarkdown(markdown: string, rules: LintMdRulesConfig, isFixMode: true, options: LintExecutionOptions): LintMdFixResult;
+function executeMarkdown(markdown: string, rules: LintMdRulesConfig, isFixMode: false, options: LintExecutionOptions): LintMdLintResult;
+function executeMarkdown(markdown: string, rules: LintMdRulesConfig, isFixMode: boolean, options: LintExecutionOptions): LintMdResult;
+function executeMarkdown(
+  markdown: string,
+  rules: LintMdRulesConfig,
+  isFixMode: boolean,
+  options: LintExecutionOptions
+): LintMdResult {
+  const { registeredRules, executableRules } = resolveConfiguredRules(rules);
+  const policy = options.ruleErrorPolicy ?? 'collect';
+  const executionResult = lintMarkdownInternal(
+    markdown,
+    executableRules,
+    isFixMode,
+    policy
+  );
+
+  return buildLintResult(registeredRules, executionResult);
+}
+
+/**
+ * 核心方法，对某个 Markdown 文本进行 lint 或者 fix
+ *
+ * @date 2021-12-14 17:16:12
+ *    默认开启 fix 模式：
+ * - isFixMode=true 或省略时，fixedResult 为 FixedResult
+ * - isFixMode=false 时，fixedResult 为 null
+ * - isFixMode 为 boolean 变量时，返回联合类型
+ */
+export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: true, options?: LintExecutionOptions): LintMdFixResult;
+export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: false, options?: LintExecutionOptions): LintMdLintResult;
+export function lintMarkdown(markdown: string, rules?: LintMdRulesConfig, isFixMode?: boolean, options?: LintExecutionOptions): LintMdResult;
+export function lintMarkdown(markdown: string, rules: LintMdRulesConfig = {}, isFixMode = true, options: LintExecutionOptions = {}): LintMdResult {
+  return executeMarkdown(markdown, rules, isFixMode, options);
+}
+
+/**
+ * Apply configured fixes to Markdown.
+ *
+ * `lintResult` describes the original input. `fixedResult.result` contains
+ * the final fixed Markdown.
+ *
+ * @public
+ */
+export function fixMarkdown(
+  markdown: string,
+  options: FixMarkdownOptions = {}
+): LintMdFixResult {
+  return executeMarkdown(markdown, options.rules ?? {}, true, options);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { lintMarkdown } from './core/lint-markdown';
+export { fixMarkdown, lintMarkdown } from './core/lint-markdown';
 export * from './rules';
 export * from './types';
 export { toALEOutput } from './diagnostics';

--- a/src/types.ts
+++ b/src/types.ts
@@ -258,6 +258,16 @@ export interface LintExecutionOptions {
   ruleErrorPolicy?: RuleErrorPolicy
 }
 
+/**
+ * Options for `fixMarkdown`.
+ *
+ * @public
+ */
+export interface FixMarkdownOptions extends LintExecutionOptions {
+  /** Rule settings for this fix operation. */
+  rules?: LintMdRulesConfig
+}
+
 /** 单条规则执行错误，挂在 LintMdResultBase 上，对 lint-only 与 fix 多轮均适用 */
 export interface RuleExecutionError {
   /** 失败规则名（来自 rule.meta.name） */


### PR DESCRIPTION
## Summary

- Add the explicit `fixMarkdown(markdown, options)` API.
- Share rule resolution, execution, and result construction with the legacy API.
- Export `FixMarkdownOptions` from CJS, ESM, and TypeScript entries.
- Document the original-input diagnostic contract.

## Impact

Callers can request fixes without a positional mode boolean.
The legacy `lintMarkdown` behavior stays unchanged.

`lintResult` describes the original input.
`fixedResult.result` contains the final fixed Markdown.

## Validation

- 45 test suites passed.
- 377 tests passed.
- ESLint passed.
- Production and test type checks passed.
- API Extractor passed.
- CJS and ESM package contract checks passed.

Fixes #229
