### PR TITLE
chore: prepare 2.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [2.3.0](https://github.com/lint-md/lint-md/compare/v2.2.1...v2.3.0) - 2026-07-30
+
+### Features
+
+- **api**: add the explicit `fixMarkdown()` API (#235)
+- **no-multiple-blank-lines**: limit block gaps to one blank line (#228)
+- **space-around-link**: add spaces between links and adjacent text (#227)
+- **require-trailing-spaces**: add trailing spaces for soft line breaks (#226)
+
+### Refactoring
+
+- **source-code**: require source maps for text ranges and export range error classes (#225)
+
 ## [2.2.1](https://github.com/lint-md/lint-md/compare/v2.1.6...v2.2.1) - 2026-07-29
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lint-md/core",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Core of lint-md which used to lint your markdown file for Chinese.",
   "main": "lib/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
## Summary

- Set the package version to `2.3.0`.
- Add the `2.3.0` changelog entry.
- List changes from PRs #225, #226, #227, #228, and #235.

## Impact

The next npm release uses version `2.3.0`.

## Validation

- `npm run prepublishOnly`
- `npm pack --dry-run --json`

All 46 test suites passed. All 378 tests passed.
