### PR TITLE
refactor: deepen single-round lint execution

### DIFF
--- a/__tests__/unit/core.spec.ts
+++ b/__tests__/unit/core.spec.ts
@@ -23,14 +23,14 @@ Some **importance**, and \`code\`.
       }
     ]);
 
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
-    const res = lintResult.ruleManager.getReportData().pop();
+    expect(lintResult.reports.length).toStrictEqual(1);
+    const res = lintResult.reports.pop();
     expect(res?.message).toStrictEqual('代码块内容不能为空，请删除空的代码块，或者填充代码内容');
   });
 
   test('test runLint() with empty rules array', () => {
     const lintResult = runLint('# Hello', []);
-    expect(lintResult.ruleManager.getReportData().length).toBe(0);
+    expect(lintResult.reports.length).toBe(0);
   });
 
   test('test runLint() collects Error thrown by rule (collect policy, structured errors)', () => {
@@ -103,14 +103,14 @@ Some **importance**, and \`code\`.
       })
     };
     const goodRule = noEmptyCode as unknown as LintMdRule;
-    const { ruleManager, executionErrors } = runLint('# Hello\n\n```\n\n```', [
+    const { reports, executionErrors } = runLint('# Hello\n\n```\n\n```', [
       { rule: badRule },
       { rule: goodRule }
     ]);
     // 坏规则失败被记录，好规则仍正常产出报告（部分成功）
     expect(executionErrors).toHaveLength(1);
     expect(executionErrors[0].ruleName).toBe('bad-rule');
-    expect(ruleManager.getReportData().length).toBeGreaterThan(0);
+    expect(reports.length).toBeGreaterThan(0);
   });
 
   test('test lintAndFixInternal() to lint or fix markdown source', () => {

--- a/__tests__/unit/fix-markdown.spec.ts
+++ b/__tests__/unit/fix-markdown.spec.ts
@@ -44,6 +44,42 @@ describe('fixMarkdown', () => {
     })).toThrow(RuleExecutionFailure);
   });
 
+  test('returns fix callback errors in collect mode', () => {
+    const throwingFixRule: LintMdRule = {
+      meta: { name: 'throwing-fix-rule' },
+      create: context => ({
+        text: (node) => {
+          context.report({
+            loc: node.position,
+            message: 'needs fix',
+            fix: () => {
+              throw new Error('fix failure');
+            }
+          });
+        }
+      })
+    };
+
+    const result = fixMarkdown('text', {
+      rules: {
+        'throwing-fix-rule': [
+          throwingFixRule,
+          RULE_SEVERITY.ERROR,
+          {}
+        ]
+      }
+    });
+
+    expect(result.executionErrors).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        ruleName: 'throwing-fix-rule',
+        phase: 'fix',
+        round: 0
+      })
+    ]));
+    expect(result.fixedResult.result).toBe('text');
+  });
+
   test('matches the legacy fix behavior', () => {
     const markdown = '第一段\n\n\n第二段';
     const rules = {

--- a/__tests__/unit/handle-fix-mode.spec.ts
+++ b/__tests__/unit/handle-fix-mode.spec.ts
@@ -139,7 +139,7 @@ describe('handleFixMode', () => {
     expect(result.fixedResult.result).toBe('X');
     expect(result.fixedResult.result).not.toContain('Y');
     // Loop completed in 2 rounds: round 1 applied A, round 2 found no fixes
-    expect(result.lintResult.ruleManager.getReportData().length).toBe(2);
+    expect(result.lintResult.reports.length).toBe(2);
   });
 
   test('text unchanged (all fixes conflict) — exits loop', () => {
@@ -235,8 +235,8 @@ describe('handleFixMode', () => {
 
     const result = handleFixMode('foo', [{ rule }]);
     // initialLintResult is from first round — should have 1 report
-    expect(result.lintResult.ruleManager.getReportData().length).toBe(1);
-    expect(result.lintResult.ruleManager.getReportData()[0].message).toBe('replace foo');
+    expect(result.lintResult.reports.length).toBe(1);
+    expect(result.lintResult.reports[0].message).toBe('replace foo');
   });
 
   test('notAppliedFixes reflects only last round, not historical', () => {

--- a/__tests__/unit/rule-execution-errors.spec.ts
+++ b/__tests__/unit/rule-execution-errors.spec.ts
@@ -8,7 +8,7 @@ const makeThrowingRule = (name: string, fn: () => void): LintMdRule => ({
   create: () => ({ text: fn })
 });
 
-// 一个 selector 正常 report 一个 fix 的规则（fix 回调抛错可控）。fix() 仅在 getAllFixes() 时执行。
+// This rule reports one fix. The test controls the fix callback result.
 const makeFixRule = (
   name: string,
   fixImpl: () => FixConfig
@@ -103,36 +103,47 @@ describe('rule-execution-errors', () => {
         }
       })
     };
-    const { ruleManager, executionErrors } = runLint('hello world', [{ rule: bad }, { rule: good }]);
+    const { reports, executionErrors } = runLint('hello world', [{ rule: bad }, { rule: good }]);
     expect(goodReported).toBe(true);
-    expect(ruleManager.getReportData().some(d => d.name === 'good-text')).toBe(true);
+    expect(reports.some(d => d.name === 'good-text')).toBe(true);
     expect(executionErrors).toHaveLength(1);
     expect(executionErrors[0]).toMatchObject({ ruleName: 'bad-text', phase: 'selector' });
   });
 
-  test('collect: manager wired with collector — fix() throwing is collected with phase=fix', () => {
-    // fix() 只在 getAllFixes() 时执行；验证 runLint 已将 collector 传给 ruleManager（P1 修复点）。
+  test('collect: the round returns fix errors with phase=fix', () => {
     const rule = makeFixRule('fix-throw', () => { throw new Error('fix failed'); });
-    const { ruleManager } = runLint('single', [{ rule }]);
-    const fixes = ruleManager.getAllFixes();
+    const { fixes, executionErrors } = runLint('single', [{ rule }], { computeFixes: true });
     expect(fixes).toEqual([]); // 抛错不产生 fix
-    const errs = ruleManager.getExecutionErrors();
-    expect(errs).toHaveLength(1);
-    expect(errs[0]).toMatchObject({ ruleName: 'fix-throw', phase: 'fix', round: 0, message: 'fix failed' });
+    expect(executionErrors).toHaveLength(1);
+    expect(executionErrors[0]).toMatchObject({ ruleName: 'fix-throw', phase: 'fix', round: 0, message: 'fix failed' });
   });
 
-  test('strict: manager wired with collector — fix() throwing throws RuleExecutionFailure', () => {
+  test('strict: the round throws when a fix callback fails', () => {
     const rule = makeFixRule('fix-strict', () => { throw new Error('fix failed'); });
-    const { ruleManager } = runLint('single', [{ rule }], { ruleErrorPolicy: 'strict' });
     let thrown: unknown;
     try {
-      ruleManager.getAllFixes();
+      runLint('single', [{ rule }], {
+        ruleErrorPolicy: 'strict',
+        computeFixes: true
+      });
     }
     catch (e) {
       thrown = e;
     }
     expect(thrown).toBeInstanceOf(RuleExecutionFailure);
     expect((thrown as RuleExecutionFailure).error).toMatchObject({ ruleName: 'fix-strict', phase: 'fix' });
+  });
+
+  test('lint-only: the round does not run fix callbacks', () => {
+    const fixImpl = jest.fn(() => ({ range: [0, 1] as [number, number], text: 'x' }));
+    const rule = makeFixRule('fix-skipped', fixImpl);
+
+    const result = runLint('single', [{ rule }]);
+
+    expect(result.reports).toHaveLength(1);
+    expect(result.fixes).toEqual([]);
+    expect(result.executionErrors).toEqual([]);
+    expect(fixImpl).not.toHaveBeenCalled();
   });
 
   test('fix-mode: fix() error aggregated into executionErrors with phase=fix, not rethrown', () => {

--- a/__tests__/unit/rule-manager-offset-fallback.spec.ts
+++ b/__tests__/unit/rule-manager-offset-fallback.spec.ts
@@ -21,8 +21,8 @@ const makeTextReportRule = (
 const runRule = (md: string, rule: LintMdRule, options?: Record<string, any>) => {
   const lintResult = runLint(md, [{ rule, options }]);
   return {
-    data: lintResult.ruleManager.getReportData(),
-    fallbackHits: lintResult.ruleManager.getFallbackHits()
+    data: lintResult.reports,
+    fallbackHits: lintResult.fallbackHits
   };
 };
 

--- a/__tests__/unit/rules/correct-title-trailing-punctuation.spec.ts
+++ b/__tests__/unit/rules/correct-title-trailing-punctuation.spec.ts
@@ -28,41 +28,41 @@ describe('test correct-title-trailing-punctuation', () => {
 `;
 
     const { fixedResult, lintResult } = fixer(mdToFix.trim());
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual(fixedMd.trim());
   });
 
   test('fix applied (复杂内容物)', () => {
     const { fixedResult, lintResult } = fixer('# 这就是 ~~删除线~~ ![12312313](213213) **啦啦啦**<div>~~123123~~!<a>测试测试</a></div> [123123123~](12312313)');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
     expect(fixedResult?.result).toStrictEqual('# 这就是 ~~删除线~~ ![12312313](213213) **啦啦啦**<div>~~123123~~!<a>测试测试</a></div> [123123123](12312313)');
   });
 
   test('do not remove punctuation from trailing inline code', () => {
     const md = '#### 强调符号 `#` 和 `~`';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+    expect(lintResult.reports.length).toStrictEqual(0);
     expect(fixedResult?.result).toStrictEqual(md);
   });
 
   test('still report trailing punctuation before trailing inline code', () => {
     const md = '# 这是一个错误标题。`code`';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
     expect(fixedResult?.result).toStrictEqual('# 这是一个错误标题`code`');
   });
 
   test('still report trailing punctuation in link text before trailing inline code', () => {
     const md = '# foo [bar~](x) `code`';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
     expect(fixedResult?.result).toStrictEqual('# foo [bar](x) `code`');
   });
 
   test('still report trailing punctuation in strong text before trailing inline code', () => {
     const md = '# foo **bar~** `code`';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
     expect(fixedResult?.result).toStrictEqual('# foo **bar** `code`');
   });
 });

--- a/__tests__/unit/rules/no-empty-blockquote.spec.ts
+++ b/__tests__/unit/rules/no-empty-blockquote.spec.ts
@@ -24,6 +24,6 @@ describe('test no-empty-blockquote', () => {
 - wrong
 
 `);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
   });
 });

--- a/__tests__/unit/rules/no-empty-code-lang.spec.ts
+++ b/__tests__/unit/rules/no-empty-code-lang.spec.ts
@@ -14,7 +14,7 @@ describe('test no-empty-code-lang', () => {
     const { fixedResult, lintResult } = fixer(md);
 
     expect(fixedResult?.result).toBe(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+    expect(lintResult.reports.length).toStrictEqual(0);
   });
 
   test('fix applied', () => {
@@ -27,6 +27,6 @@ describe('test no-empty-code-lang', () => {
     expect(fixedResult?.result).toBe('```plain\n'
       + 'const b = 2;\n'
       + '```');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
   });
 });

--- a/__tests__/unit/rules/no-empty-code.spec.ts
+++ b/__tests__/unit/rules/no-empty-code.spec.ts
@@ -10,13 +10,13 @@ describe('test no-empty-code', () => {
     const md = ' - right\n```js\n const a = 1;\n```\n你好\n';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toBe(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+    expect(lintResult.reports.length).toStrictEqual(0);
   });
 
   test('fix applied', () => {
     const md = ' - right\n```js\n\n```\n你好\n';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toBe(' - right\n\n你好\n');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
   });
 });

--- a/__tests__/unit/rules/no-empty-inline-code.spec.ts
+++ b/__tests__/unit/rules/no-empty-inline-code.spec.ts
@@ -10,13 +10,13 @@ describe('test no-empty-inline-code', () => {
     const md = '`const a = 0;`';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toBe(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+    expect(lintResult.reports.length).toStrictEqual(0);
   });
 
   test('fix applied', () => {
     const md = '- right ` ` 你好';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toBe('- right  你好');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
   });
 });

--- a/__tests__/unit/rules/no-empty-list.spec.ts
+++ b/__tests__/unit/rules/no-empty-list.spec.ts
@@ -11,7 +11,7 @@ describe('test no-empty-list', () => {
       + '2.';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result.trim()).toStrictEqual('');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
   });
 
   test('fix applied for common list', () => {
@@ -19,6 +19,6 @@ describe('test no-empty-list', () => {
       + '-         ';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result.trim()).toStrictEqual('- 测试');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
   });
 });

--- a/__tests__/unit/rules/no-empty-url.spec.ts
+++ b/__tests__/unit/rules/no-empty-url.spec.ts
@@ -10,7 +10,7 @@ describe('test no-empty-url', () => {
     const md = '参考资料：[JavaScript 高级程序设计]()';
     const { lintResult, fixedResult } = fixer(md);
     expect(fixedResult?.result).toStrictEqual('参考资料：[JavaScript 高级程序设计](https://example.com)');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
   });
 
   test('fix applied (for image)', () => {
@@ -18,12 +18,12 @@ describe('test no-empty-url', () => {
     const { lintResult, fixedResult } = fixer(md);
 
     expect(fixedResult?.result).toStrictEqual('快看看：![JavaScript 高级程序设计](https://example.com)');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
   });
 
   test('fix applied (链接全部为空格)', () => {
     const md = '快看看：![JavaScript 高级程序设计](    )';
     const { lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
   });
 });

--- a/__tests__/unit/rules/no-full-width-number.spec.ts
+++ b/__tests__/unit/rules/no-full-width-number.spec.ts
@@ -11,13 +11,13 @@ describe('test no-full-width-number', () => {
 
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toStrictEqual('> 这件蛋糕只卖 1000 元。\n这个 10 哈哈');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
   });
 
   test('reports correct line for match on second line', () => {
     const md = '第一行\n第二行有１００';
     const { lintResult } = fixer(md);
-    const reports = lintResult.ruleManager.getReportData();
+    const reports = lintResult.reports;
     expect(reports.length).toStrictEqual(1);
     expect(reports[0].loc.start.line).toStrictEqual(2);
     expect(reports[0].loc.start.column).toStrictEqual(5);
@@ -26,7 +26,7 @@ describe('test no-full-width-number', () => {
   test('reports correct line for match on third line', () => {
     const md = '第一行\n第二行\n第三行有１００';
     const { lintResult } = fixer(md);
-    const reports = lintResult.ruleManager.getReportData();
+    const reports = lintResult.reports;
     expect(reports.length).toStrictEqual(1);
     expect(reports[0].loc.start.line).toStrictEqual(3);
   });

--- a/__tests__/unit/rules/no-half-width-punctuation-range.spec.ts
+++ b/__tests__/unit/rules/no-half-width-punctuation-range.spec.ts
@@ -12,7 +12,7 @@ describe('no-half-width-punctuation range-based report', () => {
     expect(first.fixedResult?.result).toBe(expected);
 
     const second = lintMarkdownInternal(first.fixedResult!.result, config, false);
-    expect(second.lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(second.lintResult.reports).toHaveLength(0);
   });
 
   test('does not remove only the backslash of an escape', () => {
@@ -29,6 +29,6 @@ describe('no-half-width-punctuation range-based report', () => {
 
   test('astral entity is preserved when not a punctuation target', () => {
     const result = lintMarkdownInternal('中文&Afr;test', config, false);
-    expect(result.lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(result.lintResult.reports).toHaveLength(0);
   });
 });

--- a/__tests__/unit/rules/no-half-width-punctuation.spec.ts
+++ b/__tests__/unit/rules/no-half-width-punctuation.spec.ts
@@ -9,68 +9,68 @@ describe('test no-half-width-punctuation', () => {
   test('fix half-width comma and period in Chinese', () => {
     const md = '这是一个很好的东西,我很喜欢.';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('这是一个很好的东西，我很喜欢。');
   });
 
   test('no false positive in English text', () => {
     const md = 'hello world, ok.';
     const { lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+    expect(lintResult.reports.length).toStrictEqual(0);
   });
 
   test('no false positive in numbers', () => {
     const md = 'version 1.0';
     const { lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+    expect(lintResult.reports.length).toStrictEqual(0);
   });
 
   test('fix mixed half-width punctuation', () => {
     const md = 'price是9.99元,很不错!但还需要优化.';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(3);
+    expect(lintResult.reports.length).toStrictEqual(3);
     expect(fixedResult?.result).toStrictEqual('price是9.99元，很不错！但还需要优化。');
   });
 
   test('fix half-width parentheses in Chinese', () => {
     const md = '这是一个测试(test)例子';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('这是一个测试（test）例子');
   });
 
   test('fix semicolon and colon in Chinese', () => {
     const md = '需要注意以下几点:第一;第二;第三.';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(4);
+    expect(lintResult.reports.length).toStrictEqual(4);
     expect(fixedResult?.result).toStrictEqual('需要注意以下几点：第一；第二；第三。');
   });
 
   test('fix multiple occurrences', () => {
     const md = '你好,世界!这是测试.';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(3);
+    expect(lintResult.reports.length).toStrictEqual(3);
     expect(fixedResult?.result).toStrictEqual('你好，世界！这是测试。');
   });
 
   test('fix half-width parentheses at end of sentence', () => {
     const md = '这是一个测试(test)';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('这是一个测试（test）');
   });
 
   test('fix half-width parentheses with spaces', () => {
     const md = '这是一个测试 (test) 例子';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('这是一个测试 （test） 例子');
   });
 
   test('report location is correct across newline', () => {
     const md = '第一行,\n第二行.';
     const { lintResult } = fixer(md);
-    const reports = lintResult.ruleManager.getReportData();
+    const reports = lintResult.reports;
     expect(reports).toHaveLength(2);
     expect(reports[0]?.loc?.start).toEqual(expect.objectContaining({ line: 1, column: 4 }));
     expect(reports[1]?.loc?.start).toEqual(expect.objectContaining({ line: 2, column: 4 }));
@@ -79,91 +79,91 @@ describe('test no-half-width-punctuation', () => {
   test('fix unmatched opening parenthesis adjacent to Chinese', () => {
     const md = '这是测试(test';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
     expect(fixedResult?.result).toStrictEqual('这是测试（test');
   });
 
   test('fix unmatched closing parenthesis adjacent to Chinese', () => {
     const md = 'test)例子';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
     expect(fixedResult?.result).toStrictEqual('test）例子');
   });
 
   test('fix parenthesis with tab between Chinese and parenthesis', () => {
     const md = '这是测试\t(test)';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('这是测试\t（test）');
   });
 
   test('fix parenthesis with full-width space between Chinese and parenthesis', () => {
     const md = '这是测试\u3000(test)';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('这是测试\u3000（test）');
   });
 
   test('no false positive for parenthesis after newline', () => {
     const md = '这是测试\n(test)';
     const { lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+    expect(lintResult.reports.length).toStrictEqual(0);
   });
 
   test('no false positive for English parenthesis near English', () => {
     const md = 'Use function(test) here.';
     const { lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+    expect(lintResult.reports.length).toStrictEqual(0);
   });
 
   test('fix mixed full-width/half-width parentheses with escaped backslash in text (issue #155)', () => {
     const md = '在 DOM 检查器中按下 ctrl + \\\\(（(Chrome/Window）) 可以随时暂停 JS 的执行。这样您就可以检查 DOM 的快照，而不必担心 JS 会改变 DOM 或事件（如鼠标悬停）会导致 DOM 从您脚下发生变化。';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('在 DOM 检查器中按下 ctrl + \\\\(（（Chrome/Window）） 可以随时暂停 JS 的执行。这样您就可以检查 DOM 的快照，而不必担心 JS 会改变 DOM 或事件（如鼠标悬停）会导致 DOM 从您脚下发生变化。');
     const { lintResult: after } = fixer(fixedResult!.result);
-    expect(after.ruleManager.getReportData().length).toStrictEqual(0);
+    expect(after.reports.length).toStrictEqual(0);
   });
 
   test('fix ASCII parentheses adjacent to HTML entity in text', () => {
     const md = '价格&amp;(test)很不错';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('价格&amp;（test）很不错');
   });
 
   test('fix ASCII parentheses after multiple different HTML entities', () => {
     const md = '甲&amp;乙&lt;(test)中文';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('甲&amp;乙&lt;（test）中文');
   });
 
   test('fix ASCII parentheses after an HTML entity that decodes to two UTF-16 code units', () => {
     const md = '甲&Afr;(test)中文';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('甲&Afr;（test）中文');
   });
 
   test('replace the complete escaped parenthesis source', () => {
     const md = '中文\\(test\\)中文';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('中文（test）中文');
   });
 
   test('replace the complete parenthesis entity source', () => {
     const md = '中文&#40;test&#41;中文';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('中文（test）中文');
   });
 
   test.each(['&copy', '&amp'])('keep non-terminated entity-like text aligned: %s', (entity) => {
     const md = `中文${entity}(test)中文`;
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual(`中文${entity}（test）中文`);
   });
 
@@ -173,7 +173,7 @@ describe('test no-half-width-punctuation', () => {
   ])('does not reinterpret entities inside an autolink: %s', (md) => {
     const { executionErrors, lintResult } = fixer(md);
     expect(executionErrors).toHaveLength(0);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(lintResult.reports).toHaveLength(0);
   });
 
   test.each([
@@ -183,7 +183,7 @@ describe('test no-half-width-punctuation', () => {
     const md = `中文${entity}(test)中文`;
     const { executionErrors, fixedResult, lintResult } = fixer(md);
     expect(executionErrors).toHaveLength(0);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(2);
+    expect(lintResult.reports).toHaveLength(2);
     expect(fixedResult?.result).toStrictEqual(`中文${entity}（test）中文`);
   });
 
@@ -198,7 +198,7 @@ describe('test no-half-width-punctuation', () => {
     const md = `中文${entity}(test)中文`;
     const { executionErrors, fixedResult, lintResult } = fixer(md);
     expect(executionErrors).toHaveLength(0);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(2);
+    expect(lintResult.reports).toHaveLength(2);
     expect(fixedResult?.result).toStrictEqual(`中文${entity}（test）中文`);
   });
 });

--- a/__tests__/unit/rules/no-long-code.spec.ts
+++ b/__tests__/unit/rules/no-long-code.spec.ts
@@ -21,7 +21,7 @@ describe('test no-long-code', () => {
     const { fixedResult, lintResult } = fixer(md);
 
     expect(fixedResult?.result).toBe(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+    expect(lintResult.reports.length).toStrictEqual(0);
   });
 
   test('test fix applied', () => {
@@ -33,7 +33,7 @@ describe('test no-long-code', () => {
     ].join('\n');
 
     const { lintResult } = fixer(md);
-    const options = lintResult.ruleManager.getReportData().pop();
+    const options = lintResult.reports.pop();
 
     // 精确校验 offset 落在对应代码行，而非仅断言为 number
     expect(options?.loc.start.offset).toBe(md.indexOf(longCode));
@@ -56,7 +56,7 @@ describe('test no-long-code', () => {
     ].join('\r\n');
 
     const { lintResult } = fixer(md);
-    const options = lintResult.ruleManager.getReportData().pop();
+    const options = lintResult.reports.pop();
 
     // CRLF 下 offset 仍应精确落在代码行（基于原始文档坐标）
     expect(options?.loc.start.offset).toBe(md.indexOf(longCode));
@@ -74,7 +74,7 @@ describe('test no-long-code', () => {
     ].join('\r\n');
 
     const { lintResult } = fixer(md);
-    const options = lintResult.ruleManager.getReportData().pop();
+    const options = lintResult.reports.pop();
 
     // 代码块不在文档开头时，CRLF 下偏移也不能漂移
     expect(options?.loc.start.offset).toBe(md.indexOf(longCode));
@@ -90,7 +90,7 @@ describe('test no-long-code', () => {
     ].join('\n');
     const { lintResult } = fixer(md);
 
-    const data = lintResult.ruleManager.getReportData();
+    const data = lintResult.reports;
     expect(data.length).toStrictEqual(0);
   });
 
@@ -108,7 +108,7 @@ describe('test no-long-code', () => {
 
     expect(fixedResult?.result).toStrictEqual(md);
     const longLine = 'console.log("code code code code code code code code");';
-    const [r1, r2] = lintResult.ruleManager.getReportData();
+    const [r1, r2] = lintResult.reports;
     expect(r1.loc).toEqual({
       end: expect.objectContaining({ column: 55, line: 3, offset: expect.any(Number) }),
       start: expect.objectContaining({ column: 1, line: 3, offset: expect.any(Number) })
@@ -140,7 +140,7 @@ describe('test no-long-code', () => {
     ].join('\n');
 
     const { lintResult } = fixer(md);
-    const data = lintResult.ruleManager.getReportData();
+    const data = lintResult.reports;
 
     expect(data.length).toBeGreaterThan(0);
     for (const item of data) {
@@ -160,7 +160,7 @@ describe('test no-long-code', () => {
     const md = `    ${longCode}`;
 
     const { lintResult } = fixer(md);
-    const [report] = lintResult.ruleManager.getReportData();
+    const [report] = lintResult.reports;
 
     // 缩进代码块无围栏：offset 应落在实际代码内容（跳过起始缩进）
     expect(report.loc.start.offset).toBe(md.indexOf(longCode));
@@ -172,7 +172,7 @@ describe('test no-long-code', () => {
     const md = ['```js', longCode].join('\n');
 
     const { lintResult } = fixer(md);
-    const [report] = lintResult.ruleManager.getReportData();
+    const [report] = lintResult.reports;
 
     // EOF 未闭合围栏：最后一行是真实代码内容，不应被当成结尾围栏而漏报
     expect(report.loc.start.offset).toBe(md.indexOf(longCode));
@@ -187,7 +187,7 @@ describe('test no-long-code', () => {
     ].join('\n');
 
     const { lintResult } = fixer(md);
-    const [report] = lintResult.ruleManager.getReportData();
+    const [report] = lintResult.reports;
 
     // 多行缩进代码块：offset 应落在实际代码内容（跳过起始缩进），非统一缩进也需准确
     expect(report.loc.start.offset).toBe(md.indexOf(longCode));
@@ -204,7 +204,7 @@ describe('test no-long-code', () => {
     ].join('\n');
 
     const { lintResult } = fixer(md);
-    const [report] = lintResult.ruleManager.getReportData();
+    const [report] = lintResult.reports;
 
     // 缩进不一致时，offset/length 仍应精确对应真实代码内容
     expect(report.loc.start.offset).toBe(md.indexOf(valueLine));

--- a/__tests__/unit/rules/no-multiple-blank-lines.spec.ts
+++ b/__tests__/unit/rules/no-multiple-blank-lines.spec.ts
@@ -13,7 +13,7 @@ describe('no-multiple-blank-lines', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe('第一段\n\n第二段');
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(1);
+    expect(lintResult.reports).toHaveLength(1);
   });
 
   test('处理不同类型块之间的多余空白行', () => {
@@ -22,7 +22,7 @@ describe('no-multiple-blank-lines', () => {
 
     expect(fixedResult?.result)
       .toBe('# 标题\n\n---\n\n- 项目\n\n> 引用');
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(3);
+    expect(lintResult.reports).toHaveLength(3);
   });
 
   test('空格和 Tab 组成的 CRLF 空白行也参与限制', () => {
@@ -30,7 +30,7 @@ describe('no-multiple-blank-lines', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe('第一段\r\n\r\n第二段');
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(1);
+    expect(lintResult.reports).toHaveLength(1);
   });
 
   test('不修改围栏代码块内部的空白行', () => {
@@ -38,7 +38,7 @@ describe('no-multiple-blank-lines', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe(markdown);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(lintResult.reports).toHaveLength(0);
   });
 
   test('不修改缩进代码块内部的空白行', () => {
@@ -46,7 +46,7 @@ describe('no-multiple-blank-lines', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe(markdown);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(lintResult.reports).toHaveLength(0);
   });
 
   test('不修改 YAML block scalar 内的空白行', () => {
@@ -62,7 +62,7 @@ describe('no-multiple-blank-lines', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe(markdown);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(lintResult.reports).toHaveLength(0);
   });
 
   test('删除 YAML 前导空行但保留 block scalar 空白行', () => {
@@ -94,7 +94,7 @@ describe('no-multiple-blank-lines', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe(markdown);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(lintResult.reports).toHaveLength(0);
   });
 
   test('不修改数学块内的空白行', () => {
@@ -102,7 +102,7 @@ describe('no-multiple-blank-lines', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe(markdown);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(lintResult.reports).toHaveLength(0);
   });
 
   test('删除文档开头的空白行', () => {
@@ -110,7 +110,7 @@ describe('no-multiple-blank-lines', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe('# 标题');
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(1);
+    expect(lintResult.reports).toHaveLength(1);
   });
 
   test('只包含空白行的文档修复为空文档', () => {
@@ -118,7 +118,7 @@ describe('no-multiple-blank-lines', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe('');
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(1);
+    expect(lintResult.reports).toHaveLength(1);
   });
 
   test('无换行的纯空格文档修复为空文档', () => {
@@ -126,7 +126,7 @@ describe('no-multiple-blank-lines', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe('');
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(1);
+    expect(lintResult.reports).toHaveLength(1);
   });
 
   test('文档末尾最多保留一个换行', () => {
@@ -134,7 +134,7 @@ describe('no-multiple-blank-lines', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe('正文\n');
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(1);
+    expect(lintResult.reports).toHaveLength(1);
   });
 
   test('删除末尾空白行中的空格和 Tab', () => {
@@ -142,7 +142,7 @@ describe('no-multiple-blank-lines', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe('正文\n');
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(1);
+    expect(lintResult.reports).toHaveLength(1);
   });
 
   test('可以通过 Core 配置启用', () => {
@@ -174,6 +174,6 @@ describe('no-multiple-blank-lines', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe(markdown);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(lintResult.reports).toHaveLength(0);
   });
 });

--- a/__tests__/unit/rules/no-multiple-space-blockquote.spec.ts
+++ b/__tests__/unit/rules/no-multiple-space-blockquote.spec.ts
@@ -10,20 +10,20 @@ describe('test no-multiple-space-blockquote', () => {
     const md = '>    1231231232313';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toStrictEqual('> 1231231232313');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
   });
 
   test('fix applied (复杂孩子，大量空格)', () => {
     const md = '>    [1312313](13)';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toStrictEqual('> [1312313](13)');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
   });
 
   test('fix applied (缺失空格)', () => {
     const md = '>[1312313](13)';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toStrictEqual('> [1312313](13)');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
   });
 });

--- a/__tests__/unit/rules/no-space-in-inline-code.spec.ts
+++ b/__tests__/unit/rules/no-space-in-inline-code.spec.ts
@@ -10,41 +10,41 @@ describe('test no-space-in-inline-code', () => {
     const md = '- right `      const a = 1     ` 你好';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toBe('- right `const a = 1` 你好');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
   });
 
   test('fix applied (by ``` ```)', () => {
     const md = '```  test  ```';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toStrictEqual('```test```');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
   });
 
   test('do not report markdown padding for inline code containing backticks', () => {
     const md = '``` `` ` `` ```';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toStrictEqual(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+    expect(lintResult.reports.length).toStrictEqual(0);
   });
 
   test('fix applied while preserving safe backtick padding', () => {
     const md = '```  `` ` ``  ```';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toStrictEqual('``` `` ` `` ```');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
   });
 
   test('no report for inline code containing tilde without spaces', () => {
     const md = '- explain `~` symbol';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toStrictEqual(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+    expect(lintResult.reports.length).toStrictEqual(0);
   });
 
   test('fix applied for inline code with tilde and spaces', () => {
     const md = '- explain `  ~  ` symbol';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toStrictEqual('- explain `~` symbol');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
   });
 });

--- a/__tests__/unit/rules/no-space-in-link.spec.ts
+++ b/__tests__/unit/rules/no-space-in-link.spec.ts
@@ -10,27 +10,27 @@ describe('test no-space-in-link', () => {
     const md = '[ JavaScript 高级程序设计, **前端** ](https://book.douban.com/subject/10546125)';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toBe('[JavaScript 高级程序设计, **前端**](https://book.douban.com/subject/10546125)');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
   });
 
   test('fix applied (仅左侧)', () => {
     const md = '[       JavaScript 高级程序设计](https://book.douban.com/subject/10546125)';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toBe('[JavaScript 高级程序设计](https://book.douban.com/subject/10546125)');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
   });
 
   test('fix applied (仅右侧)', () => {
     const md = '[JavaScript 高级程序设计    ](https://book.douban.com/subject/10546125)';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toBe('[JavaScript 高级程序设计](https://book.douban.com/subject/10546125)');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
   });
 
   test('fix issue #98', () => {
     const md = 'only recalculate with [`hotReload` enabled](../../config/theme/basic.md#hotreload)';
     const { fixedResult, lintResult } = fixer(md);
     expect(fixedResult?.result).toStrictEqual('only recalculate with [`hotReload` enabled](../../config/theme/basic.md#hotreload)');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+    expect(lintResult.reports.length).toStrictEqual(0);
   });
 });

--- a/__tests__/unit/rules/no-special-characters-multiline.spec.ts
+++ b/__tests__/unit/rules/no-special-characters-multiline.spec.ts
@@ -12,7 +12,7 @@ describe('test no-special-characters multi-line', () => {
   test('reports correct line for special char on second line', () => {
     const md = `第一行\n第二行有${HAIR_SPACE}空格`;
     const { lintResult } = fixer(md);
-    const reports = lintResult.ruleManager.getReportData();
+    const reports = lintResult.reports;
     expect(reports.length).toStrictEqual(1);
     expect(reports[0].loc.start.line).toStrictEqual(2);
   });
@@ -20,7 +20,7 @@ describe('test no-special-characters multi-line', () => {
   test('reports correct line for special char on third line', () => {
     const md = `第一行\n第二行\n第三行有${HAIR_SPACE}空格`;
     const { lintResult } = fixer(md);
-    const reports = lintResult.ruleManager.getReportData();
+    const reports = lintResult.reports;
     expect(reports.length).toStrictEqual(1);
     expect(reports[0].loc.start.line).toStrictEqual(3);
   });
@@ -28,7 +28,7 @@ describe('test no-special-characters multi-line', () => {
   test('reports correct column for special char on second line', () => {
     const md = `第一行\n第二行有${HAIR_SPACE}空格`;
     const { lintResult } = fixer(md);
-    const reports = lintResult.ruleManager.getReportData();
+    const reports = lintResult.reports;
     expect(reports[0].loc.start.column).toStrictEqual(5);
   });
 });

--- a/__tests__/unit/rules/no-special-characters.spec.ts
+++ b/__tests__/unit/rules/no-special-characters.spec.ts
@@ -9,7 +9,7 @@ describe('test no-special-characters', () => {
   test('fix applied', () => {
     const md = 'hello wo rld, before here has a \\b.';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('hello world, before here has a \\b.');
   });
 });

--- a/__tests__/unit/rules/require-trailing-spaces.spec.ts
+++ b/__tests__/unit/rules/require-trailing-spaces.spec.ts
@@ -19,7 +19,7 @@ describe('require-trailing-spaces', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe(expected);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(reportCount);
+    expect(lintResult.reports).toHaveLength(reportCount);
   });
 
   test.each([
@@ -33,7 +33,7 @@ describe('require-trailing-spaces', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe(markdown);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(lintResult.reports).toHaveLength(0);
   });
 
   test('默认关闭', () => {

--- a/__tests__/unit/rules/space-around-alphabet.spec.ts
+++ b/__tests__/unit/rules/space-around-alphabet.spec.ts
@@ -10,7 +10,7 @@ describe('test space-around-alphabet', () => {
   test('fix applied', () => {
     const content = '（有时称为 m\\-dots 或 m子域名）就是 - 托管在 website子域名中的的移动特定版本，通常是 `m` 子域名。';
     const { fixedResult, lintResult } = fixer(content);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('（有时称为 m\\-dots 或 m 子域名）就是 - 托管在 website 子域名中的的移动特定版本，通常是 `m` 子域名。');
   });
 
@@ -21,7 +21,7 @@ describe('test space-around-alphabet', () => {
     ['English𠀀', 1, 'English 𠀀'],
   ])('%s → %i report, fix to "%s"', (input, expectedReports, expectedFix) => {
     const { lintResult, fixedResult } = fixer(input);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(expectedReports);
+    expect(lintResult.reports.length).toStrictEqual(expectedReports);
     expect(fixedResult?.result).toStrictEqual(expectedFix);
   });
 
@@ -33,7 +33,7 @@ describe('test space-around-alphabet', () => {
     ['中文😀abc'],
   ])('"%s" does not report (already spaced or punctuation in between)', (input) => {
     const { lintResult } = fixer(input);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+    expect(lintResult.reports.length).toStrictEqual(0);
   });
 
   test.each([
@@ -64,12 +64,12 @@ describe('test space-around-alphabet', () => {
 
       const first = combinedFixer(input);
       expect(first.fixedResult?.result).toBe(expected);
-      expect(first.lintResult.ruleManager.getReportData().map(report => report.name))
+      expect(first.lintResult.reports.map(report => report.name))
         .toEqual(expect.arrayContaining([
           'space-around-alphabet',
           'space-around-number'
         ]));
-      expect(combinedFixer(first.fixedResult!.result).lintResult.ruleManager.getReportData())
+      expect(combinedFixer(first.fixedResult!.result).lintResult.reports)
         .toHaveLength(0);
     }
   );

--- a/__tests__/unit/rules/space-around-link.spec.ts
+++ b/__tests__/unit/rules/space-around-link.spec.ts
@@ -13,7 +13,7 @@ describe('space-around-link', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe('查看 [文档](https://example.com) 内容');
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(2);
+    expect(lintResult.reports).toHaveLength(2);
   });
 
   test('全角标点与链接之间不添加空格', () => {
@@ -21,7 +21,7 @@ describe('space-around-link', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe(markdown);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(lintResult.reports).toHaveLength(0);
   });
 
   test('ASCII 标点与链接之间不添加空格', () => {
@@ -29,7 +29,7 @@ describe('space-around-link', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe(markdown);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(lintResult.reports).toHaveLength(0);
   });
 
   test.each([
@@ -59,7 +59,7 @@ describe('space-around-link', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe(markdown);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(lintResult.reports).toHaveLength(0);
   });
 
   test('连续链接之间只添加一个空格', () => {
@@ -67,7 +67,7 @@ describe('space-around-link', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe('[文档一](one) [文档二](two)');
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(1);
+    expect(lintResult.reports).toHaveLength(1);
   });
 
   test('链接图片按外层链接处理', () => {
@@ -76,7 +76,7 @@ describe('space-around-link', () => {
 
     expect(fixedResult?.result)
       .toBe('查看 [![图片](image.png)](https://example.com) 内容');
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(2);
+    expect(lintResult.reports).toHaveLength(2);
   });
 
   test('格式包装外添加链接空格', () => {
@@ -85,7 +85,7 @@ describe('space-around-link', () => {
 
     expect(fixedResult?.result)
       .toBe('查看 **[文档](https://example.com)** 内容');
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(2);
+    expect(lintResult.reports).toHaveLength(2);
   });
 
   test('相邻格式内容视为正文', () => {
@@ -94,7 +94,7 @@ describe('space-around-link', () => {
 
     expect(fixedResult?.result)
       .toBe('**查看** [文档](https://example.com) 内容');
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(2);
+    expect(lintResult.reports).toHaveLength(2);
   });
 
   test('可以通过 Core 配置启用', () => {
@@ -128,7 +128,7 @@ describe('space-around-link', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe(markdown);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(lintResult.reports).toHaveLength(0);
   });
 
   test('行首、行末和块边界不添加空格', () => {
@@ -136,7 +136,7 @@ describe('space-around-link', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe(markdown);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(lintResult.reports).toHaveLength(0);
   });
 
   test('自动链接按链接处理', () => {
@@ -144,7 +144,7 @@ describe('space-around-link', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe('查看 <https://example.com> 内容');
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(2);
+    expect(lintResult.reports).toHaveLength(2);
   });
 
   test('引用链接按链接处理', () => {
@@ -153,7 +153,7 @@ describe('space-around-link', () => {
 
     expect(fixedResult?.result)
       .toBe('查看 [文档][docs] 内容\n\n[docs]: https://example.com');
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(2);
+    expect(lintResult.reports).toHaveLength(2);
   });
 
   test('单词内的下划线不是格式包装', () => {
@@ -161,7 +161,7 @@ describe('space-around-link', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe(markdown);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(lintResult.reports).toHaveLength(0);
   });
 
   test('格式包装内的标点仍然豁免', () => {
@@ -169,6 +169,6 @@ describe('space-around-link', () => {
     const { fixedResult, lintResult } = fixer(markdown);
 
     expect(fixedResult?.result).toBe(markdown);
-    expect(lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(lintResult.reports).toHaveLength(0);
   });
 });

--- a/__tests__/unit/rules/space-around-number.spec.ts
+++ b/__tests__/unit/rules/space-around-number.spec.ts
@@ -18,28 +18,28 @@ const fixedMarkdownToCheck = `
 describe('test space-around-number', () => {
   test('fix applied', () => {
     const { fixedResult, lintResult } = fixer(markdownToCheck);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(3);
+    expect(lintResult.reports.length).toStrictEqual(3);
     expect(fixedResult?.result).toStrictEqual(fixedMarkdownToCheck);
   });
 
   test('fix applied for percentage between chinese text', () => {
     const md = '100%测试 测试100%';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('100% 测试 测试 100%');
   });
 
   test('does not treat symbols as alphabet through this rule', () => {
     const md = 'C#教程 中文#标签';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(0);
+    expect(lintResult.reports.length).toStrictEqual(0);
     expect(fixedResult?.result).toStrictEqual(md);
   });
 
   test('insert spaces outside a numeric character entity', () => {
     const md = '中&#49;文';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('中 &#49; 文');
   });
 
@@ -48,13 +48,13 @@ describe('test space-around-number', () => {
     ['123𠀀', '123 𠀀'],
   ])('supports supplementary Han characters: "%s" → "%s"', (input, expectedFix) => {
     const { fixedResult, lintResult } = fixer(input);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
     expect(fixedResult?.result).toStrictEqual(expectedFix);
   });
 
   test('supports supplementary Han around percentages', () => {
     const { fixedResult, lintResult } = fixer('𠀀100%𠀀');
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual('𠀀 100% 𠀀');
   });
 });

--- a/__tests__/unit/rules/use-standard-ellipsis.spec.ts
+++ b/__tests__/unit/rules/use-standard-ellipsis.spec.ts
@@ -9,21 +9,21 @@ describe('test use-standard-ellipsis', () => {
   test('fix .... case', () => {
     const md = 'hello world....';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
     expect(fixedResult?.result).toStrictEqual('hello world……');
   });
 
   test('fix … case', () => {
     const md = 'hello world…';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
     expect(fixedResult?.result).toStrictEqual('hello world……');
   });
 
   test('report invalid ellipsis after valid ellipsis', () => {
     const md = '前言……他说…';
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(1);
+    expect(lintResult.reports.length).toStrictEqual(1);
     expect(fixedResult?.result).toStrictEqual('前言……他说……');
   });
 
@@ -33,7 +33,7 @@ describe('test use-standard-ellipsis', () => {
 2. hello world........
     `;
     const { fixedResult, lintResult } = fixer(md);
-    expect(lintResult.ruleManager.getReportData().length).toStrictEqual(2);
+    expect(lintResult.reports.length).toStrictEqual(2);
     expect(fixedResult?.result).toStrictEqual(`
 1. hello world……
 2. hello world……
@@ -43,7 +43,7 @@ describe('test use-standard-ellipsis', () => {
   test('reports correct line for match on second line', () => {
     const md = '第一行\n第二行....';
     const { lintResult } = fixer(md);
-    const reports = lintResult.ruleManager.getReportData();
+    const reports = lintResult.reports;
     expect(reports.length).toStrictEqual(1);
     expect(reports[0].loc.start.line).toStrictEqual(2);
     expect(reports[0].loc.start.column).toStrictEqual(4);
@@ -52,7 +52,7 @@ describe('test use-standard-ellipsis', () => {
   test('reports correct line for match on third line', () => {
     const md = '第一行\n第二行\n第三行………';
     const { lintResult } = fixer(md);
-    const reports = lintResult.ruleManager.getReportData();
+    const reports = lintResult.reports;
     expect(reports.length).toStrictEqual(1);
     expect(reports[0].loc.start.line).toStrictEqual(3);
   });

--- a/__tests__/unit/source-map-integration.spec.ts
+++ b/__tests__/unit/source-map-integration.spec.ts
@@ -81,7 +81,7 @@ describe('parser source-map integration', () => {
     };
 
     const result = lintMarkdownInternal('` a `', [{ rule: inlineCodeRule }], true);
-    const [report] = result.lintResult.ruleManager.getReportData();
+    const [report] = result.lintResult.reports;
 
     expect(report.loc).toMatchObject({
       start: { offset: 2 },
@@ -98,7 +98,7 @@ describe('parser source-map integration', () => {
     expect(first.fixedResult?.result).toBe(expected);
 
     const second = lintMarkdownInternal(first.fixedResult!.result, halfWidthConfig, false);
-    expect(second.lintResult.ruleManager.getReportData()).toHaveLength(0);
+    expect(second.lintResult.reports).toHaveLength(0);
   });
 
   test.each([
@@ -120,9 +120,7 @@ describe('parser source-map integration', () => {
 
   test('diagnostic offsets and fix ranges are resolved by the same source-map range', () => {
     const input = '中文&#40;test&#41;中文';
-    const { ruleManager } = runLint(input, halfWidthConfig);
-    const reports = ruleManager.getReportData();
-    const fixes = ruleManager.getAllFixes();
+    const { reports, fixes } = runLint(input, halfWidthConfig, { computeFixes: true });
 
     expect(reports).toHaveLength(2);
     expect(fixes).toHaveLength(2);
@@ -138,9 +136,9 @@ describe('parser source-map integration', () => {
     ['LF', '\n', 4]
   ])('%s uses parser line/column positions and raw fix offsets', (_name, newline, expectedOffset) => {
     const input = `a${newline}中文(test)中文`;
-    const { ruleManager } = runLint(input, halfWidthConfig);
-    const [report] = ruleManager.getReportData();
-    const [fix] = ruleManager.getAllFixes();
+    const { reports, fixes } = runLint(input, halfWidthConfig, { computeFixes: true });
+    const [report] = reports;
+    const [fix] = fixes;
 
     expect(report.loc.start).toMatchObject({ line: 2, column: 3, offset: expectedOffset });
     expect(fix.range).toEqual([report.loc.start.offset, report.loc.end.offset]);
@@ -166,7 +164,7 @@ describe('parser source-map integration', () => {
       })
     };
     const result = lintMarkdownInternal('中文&Afr;中文', [{ rule: atomicRule }], true);
-    expect(result.lintResult.ruleManager.getReportData()).toHaveLength(1);
+    expect(result.lintResult.reports).toHaveLength(1);
     expect(result.fixedResult?.result).toBe('中文A中文');
   });
 
@@ -223,10 +221,7 @@ describe('parser source-map integration', () => {
         }
       })
     };
-    const { ruleManager } = runLint('text', [{ rule: mutatingRule }]);
-
-    expect(() => ruleManager.getAllFixes())
+    expect(() => runLint('text', [{ rule: mutatingRule }], { computeFixes: true }))
       .toThrow(SourceMapConsistencyError);
-    expect(ruleManager.getExecutionErrors()).toEqual([]);
   });
 });

--- a/scripts/benchmark-memory.mjs
+++ b/scripts/benchmark-memory.mjs
@@ -79,7 +79,7 @@ if (process.env.BENCHMARK_CHILD === '1') {
 
   function runParseTraverse() {
     const result = runLint(input, []);
-    const reports = result.ruleManager.getReportData();
+    const reports = result.reports;
     return { reportCount: reports.length, fixCount: 0, runLintCalls: 1 };
   }
 
@@ -93,9 +93,9 @@ if (process.env.BENCHMARK_CHILD === '1') {
       'no-special-characters',
     ];
     const configs = names.map(n => ({ rule: TEXT_RULE_IMPORTS[n]() }));
-    const result = runLint(input, configs);
-    const reports = result.ruleManager.getReportData();
-    const fixes = result.ruleManager.getAllFixes();
+    const result = runLint(input, configs, { computeFixes: true });
+    const reports = result.reports;
+    const fixes = result.fixes;
     return { reportCount: reports.length, fixCount: fixes.length, runLintCalls: 1 };
   }
 
@@ -103,9 +103,9 @@ if (process.env.BENCHMARK_CHILD === '1') {
     const ruleFactory = TEXT_RULE_IMPORTS[ruleName];
     if (!ruleFactory)
       throw new Error(`Unknown rule: ${ruleName}`);
-    const result = runLint(input, [{ rule: ruleFactory() }]);
-    const reports = result.ruleManager.getReportData();
-    const fixes = result.ruleManager.getAllFixes();
+    const result = runLint(input, [{ rule: ruleFactory() }], { computeFixes: true });
+    const reports = result.reports;
+    const fixes = result.fixes;
     return { reportCount: reports.length, fixCount: fixes.length, runLintCalls: 1 };
   }
 

--- a/src/core/handle-fix-mode.ts
+++ b/src/core/handle-fix-mode.ts
@@ -32,7 +32,11 @@ export const handleFixMode = (
     // 记录本轮输入文本，供后续判断是否回到历史状态。
     seenTexts.add(current);
 
-    const lintResult = runLint(current, rules, { ruleErrorPolicy: policy, round: lintTimes });
+    const lintResult = runLint(current, rules, {
+      ruleErrorPolicy: policy,
+      round: lintTimes,
+      computeFixes: true
+    });
 
     if (lintTimes === 0) {
       initialLintResult = lintResult;
@@ -40,14 +44,10 @@ export const handleFixMode = (
 
     lintTimes++;
 
-    // 先取 fix 列表：fix() 回调在 getAllFixes() 内执行，其错误已并入 ruleManager 的 collector，
-    // 并反映到 runLint 返回的 executionErrors 中。聚合必须放在 getAllFixes 之后，否则会丢 fix 阶段错误。
-    const fixes = lintResult.ruleManager.getAllFixes();
+    const { fixes } = lintResult;
 
-    // 累加本轮错误（含 create/selector 与 fix 阶段；严格模式下可能已抛 RuleExecutionFailure）。
-    // `runLint().executionErrors` 是调用完成时的快照；fix() 在 getAllFixes()
-    // 中才会执行，因此这里从 manager 重新读取，确保本轮 fix 阶段错误也被聚合。
-    allExecutionErrors.push(...lintResult.ruleManager.getExecutionErrors());
+    // The round result includes create, selector, and fix errors.
+    allExecutionErrors.push(...lintResult.executionErrors);
 
     // 无 fix 可应用 => 正常收敛。
     if (!fixes.length) {

--- a/src/core/lint-markdown.ts
+++ b/src/core/lint-markdown.ts
@@ -79,7 +79,7 @@ const buildLintResult = (
   executionResult: ReturnType<typeof lintMarkdownInternal>
 ): LintMdResult => {
   const { fixedResult, lintResult, executionErrors } = executionResult;
-  const reportData = lintResult.ruleManager.getReportData();
+  const reportData = lintResult.reports;
   let fixableErrorCount = 0;
   let fixableWarningCount = 0;
 

--- a/src/core/run-lint.ts
+++ b/src/core/run-lint.ts
@@ -1,11 +1,29 @@
 import { parseMdWithSourceMap } from '@lint-md/parser';
-import type { LintMdRuleWithOptions, RunLintOptions } from '../types';
+import type {
+  LintMdRuleWithOptions,
+  ReportOption,
+  RuleExecutionError,
+  RuleFixConfig,
+  RunLintOptions
+} from '../types';
 import { createEmitter } from '../utils/emitter';
 import { createTraverser } from '../utils/traverser';
 import { createRuleManager } from '../utils/rule-manager';
 import { createRuleErrorCollector } from '../utils/rule-execution-errors';
 import { createLintSourceCode } from '../utils/source-code';
 import { isSourceMapError } from '../utils/source-code-errors';
+
+interface RunLintRoundOptions extends RunLintOptions {
+  /** Run reported fix callbacks before this function returns. */
+  computeFixes?: boolean
+}
+
+export interface RunLintResult {
+  reports: ReportOption[]
+  fixes: RuleFixConfig[]
+  executionErrors: RuleExecutionError[]
+  fallbackHits: number
+}
 
 /**
  * 基于各种 rules 对 Markdown 文本进行校验
@@ -23,12 +41,12 @@ import { isSourceMapError } from '../utils/source-code-errors';
 export const runLint = (
   markdown: string,
   allRuleConfigs: LintMdRuleWithOptions[],
-  options: RunLintOptions = {}
-) => {
+  options: RunLintRoundOptions = {}
+): RunLintResult => {
   const policy = options.ruleErrorPolicy ?? 'collect';
   const round = options.round ?? 0;
 
-  // 先创建收集器，再创建 ruleManager：getAllFixes() 内的 fix() 阶段错误才能接入收集器。
+  // The collector must exist before fix callbacks run.
   const collector = createRuleErrorCollector(policy, round);
 
   // Parser owns normalized-text -> original-Markdown mapping.
@@ -37,7 +55,7 @@ export const runLint = (
 
   const sourceCode = createLintSourceCode({ text: markdown, ast, sourceMap });
 
-  // 全局规则管理器（传入 collector，使 fix 阶段捕获生效）
+  // The manager holds mutable state only during this execution round.
   const ruleManager = createRuleManager(markdown, collector);
 
   const emitter = createEmitter();
@@ -95,8 +113,14 @@ export const runLint = (
   // 递归地遍历 ast；selector 失败已在 listener 内逐条处理，此处不再吞错。
   traverser.traverse(ast, null);
 
+  const fixes = options.computeFixes
+    ? ruleManager.getAllFixes()
+    : [];
+
   return {
-    ruleManager,
-    executionErrors: collector.getErrors()
+    reports: [...ruleManager.getReportData()],
+    fixes,
+    executionErrors: collector.getErrors(),
+    fallbackHits: ruleManager.getFallbackHits()
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -244,7 +244,7 @@ export interface FixMetrics {
  * 规则执行错误的捕获阶段。
  * - `create`：rule.create() 初始化回调阶段（每条规则在遍历前执行一次）
  * - `selector`：selector 节点回调阶段（emitter 按 node.type 分发后执行）
- * - `fix`：fix() 回调阶段（applyFix 前 getAllFixes 调用时执行）
+ * - `fix`：fix() 回调阶段（单轮执行计算修复时执行）
  * 仅覆盖规则自身执行路径，不覆盖 parser / 遍历器等基础设施故障。
  */
 export type RuleExecutionPhase = 'create' | 'selector' | 'fix';

--- a/src/utils/rule-manager.ts
+++ b/src/utils/rule-manager.ts
@@ -27,8 +27,7 @@ const resolveReportOffset = (
  * 初始化全局 rule 管理器
  *
  * @param {string} appliedMarkdown 已经应用了规则的 markdown
- * @param collector 可选的规则执行错误收集器；传入后 getAllFixes 中 fix() 抛错会归入规则执行错误，
- *                 否则（如单测直接 new）fix 阶段错误仍按原生异常抛出。
+ * @param collector The optional collector receives fix callback errors.
  */
 export const createRuleManager = (
   appliedMarkdown: string,
@@ -47,9 +46,6 @@ export const createRuleManager = (
   const getFallbackHits = () => fallbackHits;
 
   const getReportData = () => allReportedData;
-
-  // 暴露 collector 中已收集的规则执行错误（含 fix 阶段），供单测与上层聚合读取。
-  const getExecutionErrors = () => collector?.getErrors() ?? [];
 
   const getAllFixes = (): RuleFixConfig[] =>
     allReportedData.flatMap((item) => {
@@ -139,7 +135,6 @@ export const createRuleManager = (
 
   return {
     getReportData,
-    getExecutionErrors,
     getAllFixes,
     getFallbackHits,
     createRuleContext


### PR DESCRIPTION
## What changed

- Return reports, fixes, execution errors, and fallback counts from each lint round.
- Keep the mutable rule manager inside the round Implementation.
- Let callers select whether a round computes fixes.
- Update fix mode, tests, and benchmark scripts to use the new Interface.

## Why

The old Interface returned before fix callbacks ran. Callers had to invoke `getAllFixes()` and then read errors again.

This ordering rule could omit fix errors from the result. The new Interface completes the round before it returns.

## Impact

The public `lintMarkdown()` and `fixMarkdown()` Interface does not change. The official CLI continues to use these public functions.

This change updates the internal `runLint()` Interface. Unsupported deep imports of that function must migrate.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:tests`
- `npm run test:unit -- --runInBand`
- `npm run build`
- `npm run package-contract`
- `npm run api:check`
- `npm run smoke-test`

Closes #238
