### PR TITLE
refactor: centralize source position handling

### DIFF
--- a/__tests__/unit/parser-offset-contract.spec.ts
+++ b/__tests__/unit/parser-offset-contract.spec.ts
@@ -1,5 +1,5 @@
 import { parseMd } from '@lint-md/parser';
-import { isValidOffset } from '../../src/utils/rule-manager';
+import { isValidOffset } from '../../src/utils/source-code';
 
 interface OffsetContractIssue {
   type: string

--- a/__tests__/unit/rule-context.spec.ts
+++ b/__tests__/unit/rule-context.spec.ts
@@ -1,5 +1,6 @@
-import type { PositionedMarkdownRoot } from '../../src/types';
+import { parseMdWithSourceMap } from '@lint-md/parser';
 import { createRuleManager } from '../../src/utils/rule-manager';
+import { createLintSourceCode } from '../../src/utils/source-code';
 
 const fakeRule = {
   rule: {
@@ -9,25 +10,21 @@ const fakeRule = {
   }
 };
 
-const fakeAst = { type: 'root', children: [] } as unknown as PositionedMarkdownRoot;
-
-const fakeSourceCode = {
-  text: '',
-  ast: fakeAst,
-  getRaw: () => '',
-  getTextRange: () => [0, 0] as [number, number]
-} as any;
+const createManager = (markdown = '') => {
+  const { ast, sourceMap } = parseMdWithSourceMap(markdown);
+  return createRuleManager(createLintSourceCode({ text: markdown, ast, sourceMap }));
+};
 
 describe('test rule context', () => {
   test('test rule context creation', () => {
-    const ctx = createRuleManager('');
+    const ctx = createManager();
     expect(ctx).toBeTruthy();
-    expect(typeof ctx.createRuleContext(fakeRule as any, { ast: fakeAst, markdown: '', sourceCode: fakeSourceCode }).report).toStrictEqual('function');
+    expect(typeof ctx.createRuleContext(fakeRule as any).report).toStrictEqual('function');
   });
 
   test('test rule context report() call', () => {
-    const manager = createRuleManager('');
-    manager.createRuleContext(fakeRule as any, { ast: fakeAst, markdown: '', sourceCode: fakeSourceCode }).report({
+    const manager = createManager();
+    manager.createRuleContext(fakeRule as any).report({
       message: 'message 1',
       loc: {
         start: {
@@ -40,7 +37,7 @@ describe('test rule context', () => {
         }
       }
     });
-    manager.createRuleContext(fakeRule as any, { ast: fakeAst, markdown: '', sourceCode: fakeSourceCode }).report({
+    manager.createRuleContext(fakeRule as any).report({
       message: 'message 2',
       loc: {
         start: {

--- a/__tests__/unit/rule-manager-offset-fallback.spec.ts
+++ b/__tests__/unit/rule-manager-offset-fallback.spec.ts
@@ -1,6 +1,6 @@
 import { runLint } from '../../src/core/run-lint';
 import type { LintMdRule, PositionedTextNode, ReportOption } from '../../src/types';
-import { isValidOffset } from '../../src/utils/rule-manager';
+import { isValidOffset } from '../../src/utils/source-code';
 import noLongCode from '../../src/rules/no-long-code';
 import noHalfWidthPunctuation from '../../src/rules/no-half-width-punctuation';
 import useStandardEllipsis from '../../src/rules/use-standard-ellipsis';
@@ -104,6 +104,8 @@ describe('rule-manager offset contract: resolveOffset fallback slices correctly 
 
     expect(fallbackHits).toBe(1);
     expect(data).toHaveLength(1);
+    expect(data[0].loc.start.offset).toBeUndefined();
+    expect(data[0].loc.end.offset).toBeUndefined();
     // 兜底切片应只截取报告位置附近内容（整篇文档的子串），而非整篇文档。
     expect(data[0].content.length).toBeGreaterThan(0);
     expect(data[0].content.length).toBeLessThan(md.length);

--- a/__tests__/unit/source-code.spec.ts
+++ b/__tests__/unit/source-code.spec.ts
@@ -263,4 +263,58 @@ describe('LintSourceCode', () => {
       expect(() => sc.getLocation([0, 100])).toThrow(InvalidRuleRangeError);
     });
   });
+
+  describe('report locations', () => {
+    const text = 'first\r\nsecond\rthird\nfourth TARGET tail';
+    const sc = createLintSourceCode({
+      text,
+      ast: {} as any,
+      sourceMap: {} as any
+    });
+
+    test.each([
+      ['CRLF', { line: 2, column: 1 }, text.indexOf('second')],
+      ['CR', { line: 3, column: 1 }, text.indexOf('third')],
+      ['LF', { line: 4, column: 8 }, text.indexOf('TARGET')]
+    ])('getOffset resolves a position after %s', (_label, position, expected) => {
+      expect(sc.getOffset(position)).toBe(expected);
+    });
+
+    test.each([NaN, Infinity, -1])('getOffset treats offset %s as missing', (offset) => {
+      expect(sc.getOffset({ line: 4, column: 8, offset })).toBe(text.indexOf('TARGET'));
+    });
+
+    test('getOffset keeps a valid rule offset', () => {
+      expect(sc.getOffset({ line: 99, column: 99, offset: 2 })).toBe(2);
+    });
+
+    test('normalizeReportLocation preserves a legacy loc and resolves its range', () => {
+      const loc = {
+        start: { line: 4, column: 8 },
+        end: { line: 4, column: 14 }
+      };
+
+      expect(sc.normalizeReportLocation({ loc })).toEqual({
+        loc,
+        range: [text.indexOf('TARGET'), text.indexOf('TARGET') + 'TARGET'.length],
+        usedFallback: true
+      });
+    });
+
+    test('normalizeReportLocation converts a range without fallback', () => {
+      const start = text.indexOf('TARGET');
+      const range = [start, start + 'TARGET'.length] as const;
+
+      expect(sc.normalizeReportLocation({ range })).toEqual({
+        loc: sc.getLocation(range),
+        range,
+        usedFallback: false
+      });
+    });
+
+    test('getContext returns the requested source window', () => {
+      const start = text.indexOf('TARGET');
+      expect(sc.getContext([start, start + 'TARGET'.length])).toBe('urth TARGET tail');
+    });
+  });
 });

--- a/__tests__/unit/utils/rule-manager.spec.ts
+++ b/__tests__/unit/utils/rule-manager.spec.ts
@@ -1,19 +1,19 @@
+import { parseMdWithSourceMap } from '@lint-md/parser';
 import { createRuleManager } from '../../../src/utils/rule-manager';
+import { createLintSourceCode } from '../../../src/utils/source-code';
 
-const fakeSourceCode = {
-  text: '',
-  ast: {} as any,
-  getRaw: () => '',
-  getTextRange: () => [0, 0] as [number, number]
-} as any;
+const createManager = (markdown: string) => {
+  const { ast, sourceMap } = parseMdWithSourceMap(markdown);
+  const sourceCode = createLintSourceCode({ text: markdown, ast, sourceMap });
+  return createRuleManager(sourceCode);
+};
 
 describe('test rule-manager report content fallback', () => {
   test('report with offset slices only the reported range', () => {
     const markdown = 'line1\nline2\nline3';
-    const manager = createRuleManager(markdown);
+    const manager = createManager(markdown);
     const context = manager.createRuleContext(
-      { rule: { meta: { name: 'demo' }, create: () => ({}) } as any, options: {} },
-      { ast: {} as any, markdown, sourceCode: fakeSourceCode }
+      { rule: { meta: { name: 'demo' }, create: () => ({}) } as any, options: {} }
     );
 
     context.report({
@@ -32,10 +32,9 @@ describe('test rule-manager report content fallback', () => {
 
   test('report without offset falls back to line/column, not whole doc', () => {
     const markdown = 'aaaa\nbbbb\ncccc\ndddd';
-    const manager = createRuleManager(markdown);
+    const manager = createManager(markdown);
     const context = manager.createRuleContext(
-      { rule: { meta: { name: 'demo' }, create: () => ({}) } as any, options: {} },
-      { ast: {} as any, markdown, sourceCode: fakeSourceCode }
+      { rule: { meta: { name: 'demo' }, create: () => ({}) } as any, options: {} }
     );
 
     context.report({

--- a/src/core/run-lint.ts
+++ b/src/core/run-lint.ts
@@ -73,7 +73,7 @@ export const runLint = (
   );
 
   // The manager holds mutable state only during this execution round.
-  const ruleManager = createRuleManager(markdown, collector);
+  const ruleManager = createRuleManager(sourceCode, collector);
 
   const emitter = createEmitter();
 
@@ -89,10 +89,7 @@ export const runLint = (
   // 遍历所有的 rules，并拿到它们的选择器，为每一个选择器订阅相关事件。
   // 注册时逐个包装 selector：同一节点上某坏规则抛错不会阻断其它规则，且能准确记录 ruleName。
   for (const { rule, options: ruleOptions } of allRuleConfigs) {
-    const ruleContext = ruleManager.createRuleContext(
-      { rule, options: ruleOptions },
-      { ast, markdown, sourceCode }
-    );
+    const ruleContext = ruleManager.createRuleContext({ rule, options: ruleOptions });
 
     // create 阶段也可能抛错，需在调用 create 处捕获并归入规则执行错误。
     let ruleSelectors: Record<string, (node: any) => void>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,7 +82,7 @@ export interface ReportOption {
   /**
    * 诊断位置。`offset` 字段对规则作者可选：
    * - 来自节点 `node.position`（如 `parseMd` 输出）的报告，offset 必填
-   * - 规则侧合成的位置（如多行超长代码的某一行）可省略，由 rule-manager 兜底
+   * - Rules can omit offset for synthetic positions. SourceCode resolves it.
    */
   loc: {
     start: ReportPosition

--- a/src/utils/rule-manager.ts
+++ b/src/utils/rule-manager.ts
@@ -2,35 +2,22 @@ import type {
   LintMdRuleContext,
   LintMdRuleWithOptions,
   ReportOption,
-  ReportPosition,
   RuleFixConfig,
   RuleReportInput
 } from '../types';
+import type { ReportSourceCode } from './source-code';
 import type { createRuleErrorCollector } from './rule-execution-errors';
 import { createFixer } from './fixer';
 import { isSourceMapError } from './source-code-errors';
 
-/** 合法 offset 必须是有限非负整数：排除 NaN / Infinity / 负数，避免第三方规则传入非法值绕过兜底。 */
-export const isValidOffset = (value: unknown): value is number =>
-  typeof value === 'number' && Number.isInteger(value) && value >= 0;
-
-/** 优先用节点真实 offset；缺失或非法时退回 (line, column) 兜底换算。 */
-const resolveReportOffset = (
-  position: ReportPosition,
-  resolveOffset: (line: number, column: number) => number
-): number =>
-  isValidOffset(position.offset)
-    ? position.offset
-    : resolveOffset(position.line, position.column);
-
 /**
  * 初始化全局 rule 管理器
  *
- * @param {string} appliedMarkdown 已经应用了规则的 markdown
+ * @param sourceCode The current document source and position Module.
  * @param collector The optional collector receives fix callback errors.
  */
 export const createRuleManager = (
-  appliedMarkdown: string,
+  sourceCode: ReportSourceCode,
   collector?: ReturnType<typeof createRuleErrorCollector>
 ) => {
   // 修复器
@@ -72,54 +59,22 @@ export const createRuleManager = (
 
   // 初始化一个 rule context
   const createRuleContext = (
-    ruleConfig: LintMdRuleWithOptions,
-    extra: Pick<LintMdRuleContext, 'ast' | 'markdown' | 'sourceCode'>
+    ruleConfig: LintMdRuleWithOptions
   ): LintMdRuleContext => {
     const { rule, options } = ruleConfig;
-    const { ast, markdown, sourceCode } = extra;
-
-    // 将 (line, column) 换算成文档中的真实偏移；供 offset 缺失时的兜底，避免切片退化成整篇文档。
-    const resolveOffset = (line: number, column: number): number => {
-      let offset = 0;
-      let currentLine = 1;
-      while (currentLine < line && offset < appliedMarkdown.length) {
-        const char = appliedMarkdown[offset];
-        if (char === '\r') {
-          offset += appliedMarkdown[offset + 1] === '\n' ? 2 : 1;
-          currentLine += 1;
-        }
-        else if (char === '\n') {
-          offset += 1;
-          currentLine += 1;
-        }
-        else {
-          offset += 1;
-        }
-      }
-      return Math.min(appliedMarkdown.length, offset + Math.max(0, column - 1));
-    };
 
     // 上报方法，供选择器内部调用
     const report = (option: RuleReportInput) => {
-      const loc: ReportOption['loc'] = 'range' in option
-        ? sourceCode.getLocation(option.range)
-        : option.loc;
-
-      const needsFallback
-        = !isValidOffset(loc.start.offset) || !isValidOffset(loc.end.offset);
-      if (needsFallback) {
+      const { loc, range, usedFallback }
+        = sourceCode.normalizeReportLocation(option);
+      if (usedFallback) {
         fallbackHits++;
       }
-
-      const startOffset = resolveReportOffset(loc.start, resolveOffset);
-      const endOffset = resolveReportOffset(loc.end, resolveOffset);
-      const markStart = Math.max(0, startOffset - 5);
-      const markEnd = Math.min(appliedMarkdown.length, endOffset + 5);
 
       allReportedData.push({
         ...option,
         loc,
-        content: appliedMarkdown.slice(markStart, markEnd),
+        content: sourceCode.getContext(range),
         name: rule.meta.name
       } as ReportOption);
     };
@@ -127,8 +82,8 @@ export const createRuleManager = (
     return {
       report,
       options: options || {},
-      ast,
-      markdown,
+      ast: sourceCode.ast,
+      markdown: sourceCode.text,
       sourceCode
     };
   };

--- a/src/utils/source-code.ts
+++ b/src/utils/source-code.ts
@@ -4,7 +4,7 @@ import type {
   MarkdownTextNode as ParserMarkdownTextNode
 } from '@lint-md/parser';
 import { SourceMapUnavailableError } from '@lint-md/parser';
-import type { LintSourceCode, MarkdownPosition, PositionedInlineCodeNode, PositionedMarkdownNode, PositionedMarkdownRoot, PositionedTextNode, TextRange } from '../types';
+import type { LintSourceCode, MarkdownPosition, PositionedInlineCodeNode, PositionedMarkdownNode, PositionedMarkdownRoot, PositionedTextNode, ReportOption, ReportPosition, TextRange } from '../types';
 import { InvalidRuleRangeError, isSourceMapError } from './source-code-errors';
 
 interface SourceCodeOptions {
@@ -13,12 +13,105 @@ interface SourceCodeOptions {
   sourceMap: MarkdownSourceMap
 }
 
+type ReportLocationInput =
+  | { loc: ReportOption['loc'] }
+  | { range: TextRange };
+
+interface NormalizedReportLocation {
+  loc: ReportOption['loc']
+  range: TextRange
+  usedFallback: boolean
+}
+
+/** Core report helpers that use the current document source. */
+export interface ReportSourceCode extends LintSourceCode {
+  getOffset(position: ReportPosition): number
+  normalizeReportLocation(input: ReportLocationInput): NormalizedReportLocation
+  getContext(range: TextRange, padding?: number): string
+}
+
+/** A usable offset is a finite, non-negative integer. */
+export const isValidOffset = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isInteger(value) && value >= 0;
+
 export const createLintSourceCode = ({
   text,
   ast,
   sourceMap
-}: SourceCodeOptions): LintSourceCode => {
+}: SourceCodeOptions): ReportSourceCode => {
   const lineStarts = buildLineStarts(text);
+
+  const getPosition = (offset: number): MarkdownPosition => {
+    if (!Number.isInteger(offset) || offset < 0 || offset > text.length) {
+      throw new InvalidRuleRangeError(
+        `getPosition: offset must be an integer in [0, ${text.length}], got ${offset}`
+      );
+    }
+    return offsetToPosition(lineStarts, offset);
+  };
+
+  const getLocation = (range: TextRange): { start: MarkdownPosition; end: MarkdownPosition } => {
+    const [start, end] = range;
+    if (!Number.isInteger(start) || !Number.isInteger(end)
+      || start < 0 || start > end || end > text.length) {
+      throw new InvalidRuleRangeError(
+        `getLocation: range must satisfy 0 <= start <= end <= ${text.length}, got [${start}, ${end}]`
+      );
+    }
+    return {
+      start: offsetToPosition(lineStarts, start),
+      end: offsetToPosition(lineStarts, end)
+    };
+  };
+
+  const getOffset = (position: ReportPosition): number => {
+    if (isValidOffset(position.offset)) {
+      return position.offset;
+    }
+
+    let lineStart = 0;
+    if (position.line > lineStarts.length) {
+      lineStart = text.length;
+    }
+    else if (position.line > 1) {
+      lineStart = lineStarts[Math.ceil(position.line) - 1] ?? text.length;
+    }
+
+    return Math.min(
+      text.length,
+      lineStart + Math.max(0, position.column - 1)
+    );
+  };
+
+  const normalizeReportLocation = (
+    input: ReportLocationInput
+  ): NormalizedReportLocation => {
+    if ('range' in input) {
+      return {
+        loc: getLocation(input.range),
+        range: input.range,
+        usedFallback: false
+      };
+    }
+
+    const usedFallback
+      = !isValidOffset(input.loc.start.offset)
+        || !isValidOffset(input.loc.end.offset);
+
+    return {
+      loc: input.loc,
+      range: [getOffset(input.loc.start), getOffset(input.loc.end)],
+      usedFallback
+    };
+  };
+
+  const getContext = (range: TextRange, padding = 5): string => {
+    const [start, end] = range;
+    return text.slice(
+      Math.max(0, start - padding),
+      Math.min(text.length, end + padding)
+    );
+  };
 
   return {
     text,
@@ -63,28 +156,11 @@ export const createLintSourceCode = ({
       }
     },
 
-    getPosition(offset: number): MarkdownPosition {
-      if (!Number.isInteger(offset) || offset < 0 || offset > text.length) {
-        throw new InvalidRuleRangeError(
-          `getPosition: offset must be an integer in [0, ${text.length}], got ${offset}`
-        );
-      }
-      return offsetToPosition(lineStarts, offset);
-    },
-
-    getLocation(range: TextRange): { start: MarkdownPosition; end: MarkdownPosition } {
-      const [start, end] = range;
-      if (!Number.isInteger(start) || !Number.isInteger(end)
-        || start < 0 || start > end || end > text.length) {
-        throw new InvalidRuleRangeError(
-          `getLocation: range must satisfy 0 <= start <= end <= ${text.length}, got [${start}, ${end}]`
-        );
-      }
-      return {
-        start: offsetToPosition(lineStarts, start),
-        end: offsetToPosition(lineStarts, end)
-      };
-    }
+    getPosition,
+    getLocation,
+    getOffset,
+    normalizeReportLocation,
+    getContext
   };
 };
 


### PR DESCRIPTION
## Summary

- Move report offset fallback into the per-document `SourceCode` Module.
- Move report location normalization and context generation into `SourceCode`.
- Remove the per-rule linear position scan from `rule-manager`.
- Make `rule-manager` use the document `SourceCode` directly.

## Why

Core had two implementations of source position behavior.

`SourceCode` used precomputed line starts. `rule-manager` scanned Markdown again for each legacy report position.

This change puts newline, UTF-16, range, and context knowledge in one Module.

## Compatibility

The public `LintSourceCode` Interface does not change.

Legacy reports keep their original `loc` values. Missing offsets still increase `fallbackHits` once per report.

LF, CRLF, CR, and invalid offset behavior stays unchanged.

## Validation

- Full Jest test suite
- ESLint
- Source TypeScript check
- Test TypeScript check
- CommonJS and ESM builds
- Package contract check
- API Extractor check
- Benchmark smoke test

Closes #242