### PR TITLE
fix: validate offsets against source length

### DIFF
--- a/__tests__/unit/rule-manager-offset-fallback.spec.ts
+++ b/__tests__/unit/rule-manager-offset-fallback.spec.ts
@@ -161,6 +161,31 @@ describe('rule-manager offset contract: invalid offsets trigger fallback (#180 P
     expect(fallbackHits).toBe(1);
   });
 
+  test('offset beyond the document uses fallback and preserves public loc', () => {
+    const md = 'prefix TARGET suffix';
+    const startOffset = md.length + 10;
+    const endOffset = md.length + 20;
+    const rule: LintMdRule = {
+      meta: { name: 'oversized-offset' },
+      create: context => ({
+        root: () => context.report({
+          loc: {
+            start: { line: 1, column: 8, offset: startOffset },
+            end: { line: 1, column: 14, offset: endOffset }
+          },
+          message: 'oversized offset'
+        })
+      })
+    };
+
+    const { data, fallbackHits } = runRule(md, rule);
+
+    expect(fallbackHits).toBe(1);
+    expect(data[0].loc.start.offset).toBe(startOffset);
+    expect(data[0].loc.end.offset).toBe(endOffset);
+    expect(data[0].content).toBe('efix TARGET suff');
+  });
+
   test('valid integer offset does not trigger fallback and slices exactly', () => {
     const md = 'aaa\r\nbbbZZccc\r\n';
     const start = md.indexOf('ZZ');

--- a/__tests__/unit/source-code.spec.ts
+++ b/__tests__/unit/source-code.spec.ts
@@ -6,7 +6,7 @@ import {
 import type { LintMdRule, LintMdRuleContext, LintSourceCode } from '../../src/types';
 import { lintMarkdownInternal } from '../../src/core/lint-markdown';
 import { runLint } from '../../src/core/run-lint';
-import { createLintSourceCode } from '../../src/utils/source-code';
+import { createLintSourceCode, isValidOffset } from '../../src/utils/source-code';
 import { InvalidRuleRangeError } from '../../src/utils/source-code-errors';
 
 describe('LintSourceCode', () => {
@@ -288,6 +288,22 @@ describe('LintSourceCode', () => {
       expect(sc.getOffset({ line: 99, column: 99, offset: 2 })).toBe(2);
     });
 
+    test('getOffset accepts an offset at the end of the document', () => {
+      expect(sc.getOffset({ line: 99, column: 99, offset: text.length }))
+        .toBe(text.length);
+    });
+
+    test('getOffset treats an offset beyond the document as missing', () => {
+      expect(sc.getOffset({ line: 4, column: 8, offset: text.length + 1 }))
+        .toBe(text.indexOf('TARGET'));
+    });
+
+    test('isValidOffset applies an optional document length', () => {
+      expect(isValidOffset(text.length, text.length)).toBe(true);
+      expect(isValidOffset(text.length + 1, text.length)).toBe(false);
+      expect(isValidOffset(text.length + 1)).toBe(true);
+    });
+
     test('normalizeReportLocation preserves a legacy loc and resolves its range', () => {
       const loc = {
         start: { line: 4, column: 8 },
@@ -309,6 +325,19 @@ describe('LintSourceCode', () => {
         loc: sc.getLocation(range),
         range,
         usedFallback: false
+      });
+    });
+
+    test('normalizeReportLocation flags offsets beyond the document', () => {
+      const loc = {
+        start: { line: 4, column: 8, offset: text.length + 1 },
+        end: { line: 4, column: 14, offset: text.length + 2 }
+      };
+
+      expect(sc.normalizeReportLocation({ loc })).toEqual({
+        loc,
+        range: [text.indexOf('TARGET'), text.indexOf('TARGET') + 'TARGET'.length],
+        usedFallback: true
       });
     });
 

--- a/src/utils/source-code.ts
+++ b/src/utils/source-code.ts
@@ -30,9 +30,15 @@ export interface ReportSourceCode extends LintSourceCode {
   getContext(range: TextRange, padding?: number): string
 }
 
-/** A usable offset is a finite, non-negative integer. */
-export const isValidOffset = (value: unknown): value is number =>
-  typeof value === 'number' && Number.isInteger(value) && value >= 0;
+/** A usable offset is a finite, non-negative integer within an optional document length. */
+export const isValidOffset = (
+  value: unknown,
+  length?: number
+): value is number =>
+  typeof value === 'number'
+  && Number.isInteger(value)
+  && value >= 0
+  && (length === undefined || value <= length);
 
 export const createLintSourceCode = ({
   text,
@@ -65,7 +71,7 @@ export const createLintSourceCode = ({
   };
 
   const getOffset = (position: ReportPosition): number => {
-    if (isValidOffset(position.offset)) {
+    if (isValidOffset(position.offset, text.length)) {
       return position.offset;
     }
 
@@ -95,8 +101,8 @@ export const createLintSourceCode = ({
     }
 
     const usedFallback
-      = !isValidOffset(input.loc.start.offset)
-        || !isValidOffset(input.loc.end.offset);
+      = !isValidOffset(input.loc.start.offset, text.length)
+        || !isValidOffset(input.loc.end.offset, text.length);
 
     return {
       loc: input.loc,


### PR DESCRIPTION
## Summary

- Add an optional document length to `isValidOffset()`.
- Reject report offsets beyond the current source length.
- Use the existing line and column fallback for oversized offsets.
- Keep the original public report `loc` unchanged.

## Root cause

`isValidOffset()` checked integer form and a non-negative value. It did not check the current document length.

`getOffset()` trusted oversized values. Context slicing then used a source range outside the document.

## Impact

An oversized offset now increases `fallbackHits` once for its report.

`SourceCode` resolves the internal range from line and column. Public report locations keep their previous shape and values.

An offset equal to `text.length` remains valid.

## Validation

- Full Jest test suite
- ESLint
- Source TypeScript check
- Test TypeScript check
- CommonJS and ESM builds
- Package contract check
- API Extractor check
- Benchmark smoke test

Follow-up to #243.
Refs #242.