### PR TITLE
refactor: simplify traverser interface

### DIFF
--- a/__tests__/unit/traverser.spec.ts
+++ b/__tests__/unit/traverser.spec.ts
@@ -109,7 +109,8 @@ console.log('!');
     expect(parentNodeQueue.length).toStrictEqual(0);
   });
 
-  test('test legacy traverser compatibility', () => {
+  test('test legacy traverser keeps the explicit parent', () => {
+    const customParent = parseMd('# Parent');
     const traverser = createTraverser({
       onEnter: (node, parent) => {
         nodeQueue.push(node);
@@ -117,8 +118,8 @@ console.log('!');
       }
     });
 
-    traverser.traverse(ast, null);
+    traverser.traverse(ast, customParent);
     expect(nodeQueue[0].type).toStrictEqual('root');
-    expect(parentNodeQueue[0]).toBeNull();
+    expect(parentNodeQueue[0]).toBe(customParent);
   });
 });

--- a/__tests__/unit/traverser.spec.ts
+++ b/__tests__/unit/traverser.spec.ts
@@ -1,6 +1,9 @@
 import { parseMd } from '@lint-md/parser';
 import type { PositionedMarkdownNode } from '../../src/types';
-import { createTraverser } from '../../src/utils/traverser';
+import {
+  createTraverser,
+  traverseMarkdown
+} from '../../src/utils/traverser';
 
 describe('test node traverser', () => {
   let nodeQueue: PositionedMarkdownNode[] = [];
@@ -22,15 +25,14 @@ console.log('!');
     parentNodeQueue = [];
   });
 
-  test('test onLeave in options should be called correctly', () => {
-    const traverser = createTraverser({
-      onLeave: (node, parent) => {
+  test('test leave in options should be called correctly', () => {
+    traverseMarkdown(ast, {
+      leave: (node, parent) => {
         nodeQueue.push(node);
         parentNodeQueue.push(parent);
       }
     });
 
-    traverser.traverse(ast, null);
     expect(nodeQueue.map(item => item.type)).toStrictEqual([
       'text',
       'heading',
@@ -59,15 +61,14 @@ console.log('!');
     ]);
   });
 
-  test('test onEnter in options should be called correctly', () => {
-    const traverser = createTraverser({
-      onEnter: (node, parent) => {
+  test('test enter in options should be called correctly', () => {
+    traverseMarkdown(ast, {
+      enter: (node, parent) => {
         nodeQueue.push(node);
         parentNodeQueue.push(parent);
       }
     });
 
-    traverser.traverse(ast, null);
     expect(nodeQueue.map(item => item.type)).toStrictEqual([
       'root',
       'heading',
@@ -97,15 +98,27 @@ console.log('!');
   });
 
   test('test invalid node', () => {
-    const traverser = createTraverser({
-      onLeave: (node, parent) => {
+    traverseMarkdown(null, {
+      leave: (node, parent) => {
         nodeQueue.push(node);
         parentNodeQueue.push(parent);
       }
     });
 
-    traverser.traverse(null, null);
     expect(nodeQueue.length).toStrictEqual(0);
     expect(parentNodeQueue.length).toStrictEqual(0);
+  });
+
+  test('test legacy traverser compatibility', () => {
+    const traverser = createTraverser({
+      onEnter: (node, parent) => {
+        nodeQueue.push(node);
+        parentNodeQueue.push(parent);
+      }
+    });
+
+    traverser.traverse(ast, null);
+    expect(nodeQueue[0].type).toStrictEqual('root');
+    expect(parentNodeQueue[0]).toBeNull();
   });
 });

--- a/src/core/run-lint.ts
+++ b/src/core/run-lint.ts
@@ -8,7 +8,7 @@ import type {
   RunLintOptions
 } from '../types';
 import { RULE_SEVERITY } from '../types';
-import { createTraverser } from '../utils/traverser';
+import { traverseMarkdown } from '../utils/traverser';
 import { createRuleManager } from '../utils/rule-manager';
 import { createRuleErrorCollector } from '../utils/rule-execution-errors';
 import { createLintSourceCode } from '../utils/source-code';
@@ -115,8 +115,8 @@ export const runLint = (
     }
   }
 
-  const traverser = createTraverser({
-    onEnter: (node) => {
+  traverseMarkdown(ast, {
+    enter: (node) => {
       const registered = selectorsByType.get(node.type);
       if (!registered) {
         return;
@@ -136,9 +136,6 @@ export const runLint = (
       }
     }
   });
-
-  // 递归地遍历 ast；selector 失败已在分发循环内逐条处理，此处不再吞错。
-  traverser.traverse(ast, null);
 
   const fixes = options.computeFixes
     ? ruleManager.getAllFixes()

--- a/src/rules/no-multiple-blank-lines.ts
+++ b/src/rules/no-multiple-blank-lines.ts
@@ -1,5 +1,5 @@
 import type { LintMdRule } from '../types';
-import { createTraverser } from '../utils/traverser';
+import { traverseMarkdown } from '../utils/traverser';
 
 const PROTECTED_NODE_TYPES = new Set([
   'code',
@@ -17,8 +17,8 @@ const noMultipleBlankLines: LintMdRule = {
   create(context) {
     const protectedRanges: Array<[number, number]> = [];
 
-    createTraverser({
-      onEnter(node) {
+    traverseMarkdown(context.ast, {
+      enter(node) {
         if (PROTECTED_NODE_TYPES.has(node.type)) {
           protectedRanges.push([
             node.position.start.offset,
@@ -26,7 +26,7 @@ const noMultipleBlankLines: LintMdRule = {
           ]);
         }
       }
-    }).traverse(context.ast, null);
+    });
 
     const overlapsProtectedRange = (start: number, end: number): boolean => {
       return protectedRanges.some(([protectedStart, protectedEnd]) => {

--- a/src/rules/space-around-link.ts
+++ b/src/rules/space-around-link.ts
@@ -2,7 +2,7 @@ import type {
   LintMdRule,
   PositionedMarkdownNode
 } from '../types';
-import { createTraverser } from '../utils/traverser';
+import { traverseMarkdown } from '../utils/traverser';
 
 type PositionedLinkLikeNode = Extract<
   PositionedMarkdownNode,
@@ -42,14 +42,14 @@ const spaceAroundLink: LintMdRule = {
     >();
     const reportedOffsets = new Set<number>();
 
-    createTraverser({
-      onEnter(node, parent) {
+    traverseMarkdown(context.ast, {
+      enter(node, parent) {
         parents.set(node, parent);
         if (node.type === 'link' || node.type === 'linkReference') {
           links.push(node);
         }
       }
-    }).traverse(context.ast, null);
+    });
 
     const getBoundaryNode = (
       node: PositionedMarkdownNode,

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,12 +158,14 @@ export interface LintMdRule {
 }
 
 /** 节点队列 */
+/** @deprecated This legacy type remains for package root compatibility. */
 export interface NodeQueue {
   node: PositionedMarkdownNode
   isEntering: boolean
 }
 
 /** 遍历器的相关选项 */
+/** @deprecated Internal traversal now uses traverseMarkdown options. */
 export interface TraverserOptions {
   /**
    * 在节点进入时做些什么

--- a/src/utils/traverser.ts
+++ b/src/utils/traverser.ts
@@ -4,33 +4,61 @@ import { isNode } from './common';
 
 const noop = () => {};
 
-/**
- * 初始化遍历器
- *
- * @date 2021-12-12 22:04:25
- */
-export const createTraverser = (options: TraverserOptions) => {
-  const { onLeave = noop, onEnter = noop } = options;
+interface TraverseMarkdownOptions {
+  enter?: (node: PositionedMarkdownNode, parent: PositionedMarkdownNode | null) => void
+  leave?: (node: PositionedMarkdownNode, parent: PositionedMarkdownNode | null) => void
+}
 
-  const traverse = (node: PositionedMarkdownNode | null, parent: PositionedMarkdownNode | null) => {
-    if (!isNode(node)) {
+const traverseNode = (
+  node: PositionedMarkdownNode | null,
+  parent: PositionedMarkdownNode | null,
+  options: TraverseMarkdownOptions
+): void => {
+  const { enter = noop, leave = noop } = options;
+
+  const visit = (
+    current: PositionedMarkdownNode | null,
+    currentParent: PositionedMarkdownNode | null
+  ): void => {
+    if (!isNode(current)) {
       return;
     }
 
-    onEnter(node, parent);
+    enter(current, currentParent);
 
-    const children = 'children' in node && Array.isArray((node as { children?: unknown }).children)
-      ? (node as { children: PositionedMarkdownNode[] }).children
+    const children = 'children' in current
+      && Array.isArray((current as { children?: unknown }).children)
+      ? (current as { children: PositionedMarkdownNode[] }).children
       : [];
 
     for (const child of children) {
-      traverse(child, node);
+      visit(child, current);
     }
 
-    onLeave(node, parent);
+    leave(current, currentParent);
+  };
+
+  visit(node, parent);
+};
+
+export const traverseMarkdown = (
+  node: PositionedMarkdownNode | null,
+  options: TraverseMarkdownOptions
+): void => {
+  traverseNode(node, null, options);
+};
+
+/** @deprecated Use traverseMarkdown. */
+export const createTraverser = (options: TraverserOptions) => {
+  const traversalOptions: TraverseMarkdownOptions = {
+    enter: options.onEnter,
+    leave: options.onLeave
   };
 
   return {
-    traverse
+    traverse: (
+      node: PositionedMarkdownNode | null,
+      parent: PositionedMarkdownNode | null
+    ): void => traverseNode(node, parent, traversalOptions)
   };
 };


### PR DESCRIPTION
## Summary

- Add the direct `traverseMarkdown()` interface.
- Migrate the three internal traversal callers.
- Keep the old factory and public types as deprecated interfaces.
- Add direct traversal and legacy compatibility tests.

## Reason

The old factory adds a shallow layer around one traversal operation.

The new interface keeps traversal order and parent tracking in one module.

## Compatibility and impact

This change does not alter the package root API.

`NodeQueue` and `TraverserOptions` remain available from the package root.

The unsupported deep import of `createTraverser()` also remains available.

Lint results, fix results, and diagnostics stay unchanged.

## Validation

- `npm test -- --runInBand`: 45 suites and 397 tests passed.
- `npm run lint`: passed.
- `npm run typecheck`: passed.
- `npm run typecheck:tests`: passed.
- `npm run build`: passed.
- `npm run api:check`: passed.
- `npm run package-contract`: passed.
- `npm run smoke-test`: passed.
- `git diff --check`: passed.

Closes #247
