### PR TITLE
refactor: make fix loop injectable

### DIFF
--- a/__tests__/unit/handle-fix-mode.spec.ts
+++ b/__tests__/unit/handle-fix-mode.spec.ts
@@ -1,227 +1,19 @@
 import { handleFixMode } from '../../src/core/handle-fix-mode';
 import { MAX_LINT_AND_FIX_CALL_TIMES } from '../../src/common/constant';
-import type { LintMdRule, LintMdRuleContext } from '../../src/types';
+import type { LintMdRule } from '../../src/types';
 import { FixConvergence } from '../../src/types';
 
-function makeRule(config: {
-  name: string
-  selector: string
-  reportFn: (ctx: LintMdRuleContext, node: any) => void
-}): LintMdRule {
-  return {
-    meta: { name: config.name },
-    create: ctx => ({
-      [config.selector]: (node: any) => config.reportFn(ctx, node)
-    })
-  };
-}
-
 describe('handleFixMode', () => {
-  test('no fixes available — exits immediately', () => {
-    const rule = makeRule({
-      name: 'no-op',
-      selector: 'text',
-      reportFn: () => { /* no report */ }
-    });
+  test('connects the production round adapter to the fix loop', () => {
+    const rule: LintMdRule = {
+      meta: { name: 'replace-foo' },
+      create: context => ({
+        text: (node) => {
+          if (node.type !== 'text' || node.value !== 'foo') {
+            return;
+          }
 
-    const result = handleFixMode('hello world', [{ rule }]);
-    expect(result.fixedResult.result).toBe('hello world');
-    expect(result.fixedResult.notAppliedFixes).toStrictEqual([]);
-  });
-
-  test('single fix applied cleanly', () => {
-    const rule = makeRule({
-      name: 'replace-foo',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'foo') {
-          ctx.report({
-            loc: node.position,
-            message: 'replace foo',
-            fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: 'bar' })
-          });
-        }
-      }
-    });
-
-    const result = handleFixMode('foo', [{ rule }]);
-    expect(result.fixedResult.result).toBe('bar');
-    expect(result.fixedResult.notAppliedFixes).toStrictEqual([]);
-  });
-
-  test('cascading fix — round 1 fix triggers round 2 violation', () => {
-    // Rule A: replace "aa" with "bb"
-    // Rule B: replace "bb" with "cc"
-    // Round 1: "aa" → "bb" (rule A fixes)
-    // Round 2: "bb" → "cc" (rule B fixes on new text)
-    const ruleA = makeRule({
-      name: 'a-aa-to-bb',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'aa') {
-          ctx.report({
-            loc: node.position,
-            message: 'replace aa',
-            fix: () => ({
-              range: [node.position.start.offset, node.position.end.offset],
-              text: 'bb'
-            })
-          });
-        }
-      }
-    });
-
-    const ruleB = makeRule({
-      name: 'b-bb-to-cc',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'bb') {
-          ctx.report({
-            loc: node.position,
-            message: 'replace bb',
-            fix: () => ({
-              range: [node.position.start.offset, node.position.end.offset],
-              text: 'cc'
-            })
-          });
-        }
-      }
-    });
-
-    const result = handleFixMode('aa', [{ rule: ruleA }, { rule: ruleB }]);
-    expect(result.fixedResult.result).toBe('cc');
-    expect(result.fixedResult.notAppliedFixes).toStrictEqual([]);
-  });
-
-  test('conflict fixes — overlapping ranges, only one applied', () => {
-    // Two rules both target the same text node with overlapping ranges.
-    // Rule A: [0, 3) → "X"  (wider range)
-    // Rule B: [1, 2) → "Y"  (narrower range, conflicts with A)
-    // Round 1: A wins (first in sort), B is notAppliedFixes
-    // Round 2: text is "X", no violations → exit
-    const ruleA = makeRule({
-      name: 'wide-replace',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'abc') {
-          ctx.report({
-            loc: node.position,
-            message: 'wide replace',
-            fix: () => ({
-              range: [node.position.start.offset, node.position.end.offset],
-              text: 'X'
-            })
-          });
-        }
-      }
-    });
-
-    const ruleB = makeRule({
-      name: 'narrow-replace',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'abc') {
-          const start = node.position.start.offset;
-          ctx.report({
-            loc: node.position,
-            message: 'narrow replace',
-            fix: () => ({
-              range: [start + 1, start + 2],
-              text: 'Y'
-            })
-          });
-        }
-      }
-    });
-
-    const result = handleFixMode('abc', [{ rule: ruleA }, { rule: ruleB }]);
-    // ruleA applied, ruleB's fix was dropped (conflict)
-    expect(result.fixedResult.result).toBe('X');
-    expect(result.fixedResult.result).not.toContain('Y');
-    // Loop completed in 2 rounds: round 1 applied A, round 2 found no fixes
-    expect(result.lintResult.reports.length).toBe(2);
-  });
-
-  test('text unchanged (all fixes conflict) — exits loop', () => {
-    // Both rules target the exact same range [0, 3)
-    // Rule A: [0, 3) → "X"
-    // Rule B: [0, 3) → "Y"
-    // Sort by range[0], both are 0. Rule A comes first (stable sort), B conflicts.
-    // applyFix: A applied, B in notAppliedFixes.
-    // Next round: text is "X", neither rule matches → no fixes → exit.
-    const ruleA = makeRule({
-      name: 'replace-to-x',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'abc') {
-          ctx.report({
-            loc: node.position,
-            message: 'to X',
-            fix: () => ({
-              range: [node.position.start.offset, node.position.end.offset],
-              text: 'X'
-            })
-          });
-        }
-      }
-    });
-
-    const ruleB = makeRule({
-      name: 'replace-to-y',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'abc') {
-          ctx.report({
-            loc: node.position,
-            message: 'to Y',
-            fix: () => ({
-              range: [node.position.start.offset, node.position.end.offset],
-              text: 'Y'
-            })
-          });
-        }
-      }
-    });
-
-    const result = handleFixMode('abc', [{ rule: ruleA }, { rule: ruleB }]);
-    expect(result.fixedResult.result).toBe('X');
-  });
-
-  test('does not exceed MAX_LINT_AND_FIX_CALL_TIMES', () => {
-    // Rule that doubles "a" → "aa" → "aaaa" → ... each round.
-    // Text always changes, always produces a violation → loop would be infinite without the guard.
-    let callCount = 0;
-    const rule = makeRule({
-      name: 'double-a',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'a'.repeat(2 ** callCount)) {
-          callCount++;
-          ctx.report({
-            loc: node.position,
-            message: 'double it',
-            fix: () => ({
-              range: [node.position.start.offset, node.position.end.offset],
-              text: node.value + node.value // a → aa → aaaa → ...
-            })
-          });
-        }
-      }
-    });
-
-    const result = handleFixMode('a', [{ rule }]);
-    // Should hit MAX guard, not exit early
-    expect(callCount).toBe(MAX_LINT_AND_FIX_CALL_TIMES);
-    expect(result.fixedResult.result).toBe('a'.repeat(2 ** MAX_LINT_AND_FIX_CALL_TIMES));
-  });
-
-  test('initialLintResult reflects first round', () => {
-    const rule = makeRule({
-      name: 'replace-foo',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'foo') {
-          ctx.report({
+          context.report({
             loc: node.position,
             message: 'replace foo',
             fix: () => ({
@@ -230,287 +22,55 @@ describe('handleFixMode', () => {
             })
           });
         }
-      }
-    });
+      })
+    };
 
     const result = handleFixMode('foo', [{ rule }]);
-    // initialLintResult is from first round — should have 1 report
-    expect(result.lintResult.reports.length).toBe(1);
-    expect(result.lintResult.reports[0].message).toBe('replace foo');
-  });
 
-  test('notAppliedFixes reflects only last round, not historical', () => {
-    // Round 1: ruleA replaces "abc"→"X", ruleB replaces "abc"→"Y" (conflict, B skipped)
-    // Round 2: text is "X", ruleC replaces "X"→"Z" (applied cleanly, no conflict)
-    // If accumulated: notAppliedFixes would contain stale B fix (wrong)
-    // If last-round only: notAppliedFixes is [] (correct — round 2 had no conflict)
-    const ruleA = makeRule({
-      name: 'a',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'abc') {
-          ctx.report({
-            loc: node.position,
-            message: 'a',
-            fix: () => ({
-              range: [node.position.start.offset, node.position.end.offset],
-              text: 'X'
-            })
-          });
-        }
-      }
-    });
-
-    const ruleB = makeRule({
-      name: 'b',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'abc') {
-          ctx.report({
-            loc: node.position,
-            message: 'b',
-            fix: () => ({
-              range: [node.position.start.offset, node.position.end.offset],
-              text: 'Y'
-            })
-          });
-        }
-      }
-    });
-
-    const ruleC = makeRule({
-      name: 'c',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'X') {
-          ctx.report({
-            loc: node.position,
-            message: 'c',
-            fix: () => ({
-              range: [node.position.start.offset, node.position.end.offset],
-              text: 'Z'
-            })
-          });
-        }
-      }
-    });
-
-    const result = handleFixMode('abc', [{ rule: ruleA }, { rule: ruleB }, { rule: ruleC }]);
-    // Final text: "Z" (round 1: abc→X, round 2: X→Z)
-    expect(result.fixedResult.result).toBe('Z');
-    // Round 2 had no conflict → notAppliedFixes should be empty
-    // NOT: [ruleB's stale fix from round 1]
-    expect(result.fixedResult.notAppliedFixes).toStrictEqual([]);
-  });
-
-  test('notAppliedFixes from last round when text converges with conflicts', () => {
-    // Round 1: "abc" → ruleA wins "abc"→"X", ruleB conflict skipped
-    // Round 2: "X" → ruleA wins "X"→"W", ruleB conflict skipped
-    // Round 3: "W" → no fixes → exit
-    // lastNotAppliedFixes should be round 2's [ruleB fix], not accumulated [ruleB, ruleB]
-    const ruleA = makeRule({
-      name: 'a',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'abc' || node.value === 'X') {
-          ctx.report({
-            loc: node.position,
-            message: 'a',
-            fix: () => ({
-              range: [node.position.start.offset, node.position.end.offset],
-              text: node.value === 'abc' ? 'X' : 'W'
-            })
-          });
-        }
-      }
-    });
-
-    const ruleB = makeRule({
-      name: 'b',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'abc' || node.value === 'X') {
-          ctx.report({
-            loc: node.position,
-            message: 'b',
-            fix: () => ({
-              range: [node.position.start.offset, node.position.end.offset],
-              text: 'Y'
-            })
-          });
-        }
-      }
-    });
-
-    const result = handleFixMode('abc', [{ rule: ruleA }, { rule: ruleB }]);
-    expect(result.fixedResult.result).toBe('W');
-    // last round (round 2) had a conflict → 1 entry
-    expect(result.fixedResult.notAppliedFixes.length).toBe(1);
-    expect(result.fixedResult.notAppliedFixes[0].text).toBe('Y');
-  });
-
-  test('A -> B -> A oscillation: stops after 2 rounds, returns applied A', () => {
-    // Round 1: "A" -> ruleA "A"->"B"
-    // Round 2: "B" -> ruleB "B"->"A"
-    // After round 2 applies the fix (B -> A), current becomes "A" which was already
-    // seen in round 1 => CYCLE_DETECTED, break. Returns the A applied in round 2,
-    // NOT the round-1 B.
-    const ruleA = makeRule({
-      name: 'a-to-b',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'A') {
-          ctx.report({
-            loc: node.position,
-            message: 'A to B',
-            fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: 'B' })
-          });
-        }
-      }
-    });
-
-    const ruleB = makeRule({
-      name: 'b-to-a',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'B') {
-          ctx.report({
-            loc: node.position,
-            message: 'B to A',
-            fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: 'A' })
-          });
-        }
-      }
-    });
-
-    const result = handleFixMode('A', [{ rule: ruleA }, { rule: ruleB }]);
-    expect(result.fixedResult.result).toBe('A');
-    expect(result.fixedResult.rounds).toBe(2);
-    expect(result.fixedResult.convergence).toBe(FixConvergence.CYCLE_DETECTED);
-  });
-
-  test('stable cascade ends STABLE with one extra no-fix round', () => {
-    // Round 1: 'aa' -> 'cc' (ruleA then ruleB); Round 2: 'cc' -> no fixes => STABLE
-    const ruleA = makeRule({
-      name: 'a-aa-to-bb',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'aa') {
-          ctx.report({ loc: node.position, message: 'aa', fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: 'bb' }) });
-        }
-      }
-    });
-    const ruleB = makeRule({
-      name: 'b-bb-to-cc',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'bb') {
-          ctx.report({ loc: node.position, message: 'bb', fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: 'cc' }) });
-        }
-      }
-    });
-
-    const result = handleFixMode('aa', [{ rule: ruleA }, { rule: ruleB }]);
-    expect(result.fixedResult.result).toBe('cc');
+    expect(result.lintResult.reports).toHaveLength(1);
+    expect(result.fixedResult.result).toBe('bar');
     expect(result.fixedResult.convergence).toBe(FixConvergence.STABLE);
-    // round1: aa->bb, round2: bb->cc, round3: no-fix check => 3 rounds
-    expect(result.fixedResult.rounds).toBe(3);
+    expect(result.fixedResult.rounds).toBe(2);
   });
 
-  test('text unchanged with conflict is STABLE via result===current branch', () => {
-    // ruleA replaces 'abc' -> 'abc' (text unchanged), ruleB 'abc' -> 'Y' conflicts with it.
-    // After applyFix, text stays 'abc' => STABLE on the FIRST round (result === current).
-    const ruleA = makeRule({
-      name: 'same',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'abc') {
-          ctx.report({ loc: node.position, message: 'same', fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: 'abc' }) });
-        }
-      }
-    });
-    const ruleB = makeRule({
-      name: 'to-y',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'abc') {
-          ctx.report({ loc: node.position, message: 'y', fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: 'Y' }) });
-        }
-      }
-    });
+  test('returns stable output when production rules report no fixes', () => {
+    const rule: LintMdRule = {
+      meta: { name: 'no-fix' },
+      create: () => ({ text: () => {} })
+    };
 
-    const result = handleFixMode('abc', [{ rule: ruleA }, { rule: ruleB }]);
-    expect(result.fixedResult.result).toBe('abc');
+    const result = handleFixMode('hello', [{ rule }]);
+
+    expect(result.fixedResult.result).toBe('hello');
+    expect(result.fixedResult.notAppliedFixes).toStrictEqual([]);
     expect(result.fixedResult.convergence).toBe(FixConvergence.STABLE);
     expect(result.fixedResult.rounds).toBe(1);
-    // ruleB's fix was dropped (conflict), still reported in last round
-    expect(result.fixedResult.notAppliedFixes.length).toBe(1);
-    expect(result.fixedResult.notAppliedFixes[0].text).toBe('Y');
   });
 
-  test('cycle of length MAX is detected, not mislabeled MAX_ROUNDS', () => {
-    // S0 -> S1 -> ... -> S9 -> S0, where S_i is the string i repeated.
-    // After the 10th round, current returns to S0 which was already seen,
-    // so it must be CYCLE_DETECTED (not MAX_ROUNDS / rounds 10 truncation).
-    const states = Array.from({ length: MAX_LINT_AND_FIX_CALL_TIMES }, (_, i) => String(i).repeat(3));
-    const rules = states.map((state, i) => {
-      const next = states[(i + 1) % states.length];
-      return makeRule({
-        name: `s${i}-to-s${(i + 1) % states.length}`,
-        selector: 'text',
-        reportFn: (ctx, node) => {
-          if (node.value === state) {
-            ctx.report({ loc: node.position, message: 'step', fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: next }) });
+  test('uses the production round limit', () => {
+    const rule: LintMdRule = {
+      meta: { name: 'append-a' },
+      create: context => ({
+        text: (node) => {
+          if (node.type !== 'text') {
+            return;
           }
-        }
-      });
-    });
 
-    const result = handleFixMode(states[0], rules.map(rule => ({ rule })));
-    expect(result.fixedResult.rounds).toBe(MAX_LINT_AND_FIX_CALL_TIMES);
-    expect(result.fixedResult.convergence).toBe(FixConvergence.CYCLE_DETECTED);
-  });
-
-  test('monotonic growth hits MAX_ROUNDS at 10, not mis-detected as cycle', () => {
-    let callCount = 0;
-    const rule = makeRule({
-      name: 'double-a',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'a'.repeat(2 ** callCount)) {
-          callCount++;
-          ctx.report({ loc: node.position, message: 'double', fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: node.value + node.value }) });
+          context.report({
+            loc: node.position,
+            message: 'append a',
+            fix: () => ({
+              range: [node.position.start.offset, node.position.end.offset],
+              text: `${node.value}a`
+            })
+          });
         }
-      }
-    });
+      })
+    };
 
     const result = handleFixMode('a', [{ rule }]);
-    expect(callCount).toBe(MAX_LINT_AND_FIX_CALL_TIMES);
+
     expect(result.fixedResult.rounds).toBe(MAX_LINT_AND_FIX_CALL_TIMES);
     expect(result.fixedResult.convergence).toBe(FixConvergence.MAX_ROUNDS);
-  });
-
-  test('no fixes => STABLE with rounds === 1', () => {
-    const rule = makeRule({ name: 'no-op', selector: 'text', reportFn: () => {} });
-    const result = handleFixMode('hello world', [{ rule }]);
-    expect(result.fixedResult.convergence).toBe(FixConvergence.STABLE);
-    expect(result.fixedResult.rounds).toBe(1);
-  });
-
-  test('metrics records rounds and per-round wall times', () => {
-    const rule = makeRule({
-      name: 'replace-foo',
-      selector: 'text',
-      reportFn: (ctx, node) => {
-        if (node.value === 'foo') {
-          ctx.report({ loc: node.position, message: 'foo', fix: () => ({ range: [node.position.start.offset, node.position.end.offset], text: 'bar' }) });
-        }
-      }
-    });
-
-    const result = handleFixMode('foo', [{ rule }]);
-    expect(result.fixedResult.metrics).toBeDefined();
-    expect(result.fixedResult.metrics!.rounds).toBe(result.fixedResult.rounds);
-    expect(result.fixedResult.metrics!.perRound).toHaveLength(result.fixedResult.rounds);
   });
 });

--- a/__tests__/unit/run-fix-loop.spec.ts
+++ b/__tests__/unit/run-fix-loop.spec.ts
@@ -1,0 +1,258 @@
+import { runFixLoop } from '../../src/core/handle-fix-mode';
+import type { RunLintReport, RunLintResult } from '../../src/core/run-lint';
+import type {
+  LintMdRuleWithOptions,
+  RuleExecutionError,
+  RuleFixConfig
+} from '../../src/types';
+import {
+  FixConvergence,
+  FixNotAppliedReason,
+  RULE_SEVERITY
+} from '../../src/types';
+
+const rules: LintMdRuleWithOptions[] = [];
+
+const makeFix = (
+  text: string,
+  range: readonly [number, number] = [0, 1],
+  targetRule = 'test-rule'
+): RuleFixConfig => ({ range, text, targetRule });
+
+const makeRound = (
+  overrides: Partial<RunLintResult> = {}
+): RunLintResult => ({
+  reports: [],
+  fixes: [],
+  executionErrors: [],
+  fallbackHits: 0,
+  ...overrides
+});
+
+const makeReport = (message: string): RunLintReport => ({
+  name: 'test-rule',
+  content: 'A',
+  message,
+  loc: {
+    start: { line: 1, column: 1, offset: 0 },
+    end: { line: 1, column: 2, offset: 1 }
+  },
+  severity: RULE_SEVERITY.ERROR
+});
+
+describe('runFixLoop', () => {
+  test.each([0, -1, 1.5])('rejects invalid maxRounds value %p', (maxRounds) => {
+    expect(() => runFixLoop('A', rules, {
+      runRound: () => makeRound(),
+      now: () => 0,
+      maxRounds
+    })).toThrow('[lint-md] maxRounds must be a positive integer');
+  });
+
+  test('returns the first round and stops when no fixes exist', () => {
+    const firstRound = makeRound({ reports: [makeReport('first')] });
+    const runRound = jest.fn(() => firstRound);
+
+    const result = runFixLoop('A', rules, {
+      runRound,
+      now: () => 0,
+      maxRounds: 3
+    });
+
+    expect(runRound).toHaveBeenCalledWith('A', rules, 0);
+    expect(runRound).toHaveBeenCalledTimes(1);
+    expect(result.lintResult).toBe(firstRound);
+    expect(result.fixedResult).toMatchObject({
+      result: 'A',
+      convergence: FixConvergence.STABLE,
+      rounds: 1
+    });
+  });
+
+  test('applies cascading fixes until a no-fix round', () => {
+    const rounds = [
+      makeRound({ fixes: [makeFix('B')] }),
+      makeRound({ fixes: [makeFix('C')] }),
+      makeRound()
+    ];
+    const inputs: Array<[string, number]> = [];
+
+    const result = runFixLoop('A', rules, {
+      runRound: (markdown, _rules, round) => {
+        inputs.push([markdown, round]);
+        return rounds[round];
+      },
+      now: () => 0,
+      maxRounds: 5
+    });
+
+    expect(inputs).toStrictEqual([['A', 0], ['B', 1], ['C', 2]]);
+    expect(result.fixedResult).toMatchObject({
+      result: 'C',
+      convergence: FixConvergence.STABLE,
+      rounds: 3
+    });
+  });
+
+  test('detects a cycle after the applied text repeats', () => {
+    const rounds = [
+      makeRound({ fixes: [makeFix('B')] }),
+      makeRound({ fixes: [makeFix('A')] })
+    ];
+
+    const result = runFixLoop('A', rules, {
+      runRound: (_markdown, _rules, round) => rounds[round],
+      now: () => 0,
+      maxRounds: 2
+    });
+
+    expect(result.fixedResult).toMatchObject({
+      result: 'A',
+      convergence: FixConvergence.CYCLE_DETECTED,
+      rounds: 2
+    });
+  });
+
+  test('propagates round adapter failures', () => {
+    const failure = new Error('round failed');
+
+    expect(() => runFixLoop('A', rules, {
+      runRound: () => {
+        throw failure;
+      },
+      now: () => 0,
+      maxRounds: 1
+    })).toThrow(failure);
+  });
+
+  test('stops at the injected round limit', () => {
+    const runRound = jest.fn((markdown: string) => makeRound({
+      fixes: [makeFix(`${markdown}${markdown}`, [0, markdown.length])]
+    }));
+
+    const result = runFixLoop('A', rules, {
+      runRound,
+      now: () => 0,
+      maxRounds: 2
+    });
+
+    expect(runRound).toHaveBeenCalledTimes(2);
+    expect(result.fixedResult).toMatchObject({
+      result: 'AAAA',
+      convergence: FixConvergence.MAX_ROUNDS,
+      rounds: 2
+    });
+  });
+
+  test('stops as stable when applied fixes do not change text', () => {
+    const fixes = [
+      makeFix('A', [0, 1], 'same'),
+      makeFix('B', [0, 1], 'conflict')
+    ];
+
+    const result = runFixLoop('A', rules, {
+      runRound: () => makeRound({ fixes }),
+      now: () => 0,
+      maxRounds: 3
+    });
+
+    expect(result.fixedResult).toMatchObject({
+      result: 'A',
+      convergence: FixConvergence.STABLE,
+      rounds: 1
+    });
+    expect(result.fixedResult.notAppliedFixes).toStrictEqual([{
+      ...fixes[1],
+      reason: FixNotAppliedReason.OVERLAP
+    }]);
+    expect(fixes.map(fix => fix.targetRule)).toStrictEqual(['same', 'conflict']);
+  });
+
+  test('keeps only conflicts from the last fix-bearing round', () => {
+    const oldConflict = makeFix('X', [0, 1], 'old-conflict');
+    const newConflict = makeFix('Y', [0, 1], 'new-conflict');
+    const rounds = [
+      makeRound({ fixes: [makeFix('B', [0, 1], 'first'), oldConflict] }),
+      makeRound({ fixes: [makeFix('C', [0, 1], 'second'), newConflict] }),
+      makeRound()
+    ];
+
+    const result = runFixLoop('A', rules, {
+      runRound: (_markdown, _rules, round) => rounds[round],
+      now: () => 0,
+      maxRounds: 5
+    });
+
+    expect(result.fixedResult.notAppliedFixes).toStrictEqual([{
+      ...newConflict,
+      reason: FixNotAppliedReason.OVERLAP
+    }]);
+  });
+
+  test('does not reorder fixes returned by the round adapter', () => {
+    const fixes = [
+      makeFix('C', [1, 2], 'later'),
+      makeFix('B', [0, 1], 'earlier')
+    ];
+
+    runFixLoop('AB', rules, {
+      runRound: () => makeRound({ fixes }),
+      now: () => 0,
+      maxRounds: 1
+    });
+
+    expect(fixes.map(fix => fix.targetRule)).toStrictEqual(['later', 'earlier']);
+  });
+
+  test('aggregates execution errors across rounds', () => {
+    const firstError: RuleExecutionError = {
+      ruleName: 'first',
+      message: 'first failure',
+      round: 0,
+      phase: 'selector'
+    };
+    const secondError: RuleExecutionError = {
+      ruleName: 'second',
+      message: 'second failure',
+      round: 1,
+      phase: 'fix'
+    };
+    const rounds = [
+      makeRound({
+        fixes: [makeFix('B')],
+        executionErrors: [firstError]
+      }),
+      makeRound({ executionErrors: [secondError] })
+    ];
+
+    const result = runFixLoop('A', rules, {
+      runRound: (_markdown, _rules, round) => rounds[round],
+      now: () => 0,
+      maxRounds: 3
+    });
+
+    expect(result.executionErrors).toStrictEqual([firstError, secondError]);
+  });
+
+  test('uses the injected clock for round and total metrics', () => {
+    const readings = [10, 12, 17, 20, 28, 30];
+    const readTime = jest.fn(() => readings.shift() as number);
+    const rounds = [
+      makeRound({ fixes: [makeFix('B')] }),
+      makeRound()
+    ];
+
+    const result = runFixLoop('A', rules, {
+      runRound: (_markdown, _rules, round) => rounds[round],
+      now: readTime,
+      maxRounds: 3
+    });
+
+    expect(result.fixedResult.metrics).toStrictEqual({
+      rounds: 2,
+      wallTime: 20,
+      perRound: [5, 8]
+    });
+    expect(readTime).toHaveBeenCalledTimes(6);
+  });
+});

--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -1,5 +1,5 @@
 /**
- * fix 模式下 lint + applyFix 的最大循环次数。
- * 防止级联 fix、冲突 fix 重试、no-op fix 等场景导致死循环。
+ * Limit production fix rounds.
+ * This limit stops endless cascading, conflicting, or no-op fixes.
  */
 export const MAX_LINT_AND_FIX_CALL_TIMES = 10;

--- a/src/core/handle-fix-mode.ts
+++ b/src/core/handle-fix-mode.ts
@@ -1,107 +1,121 @@
-import type { FixMetrics, LintMdRuleWithOptions, NotAppliedFix } from '../types';
+import type {
+  FixedResult,
+  LintMdRuleWithOptions,
+  NotAppliedFix,
+  RuleExecutionError
+} from '../types';
 import { FixConvergence } from '../types';
 import { MAX_LINT_AND_FIX_CALL_TIMES } from '../common/constant';
 import { applyFix } from '../utils/apply-fix';
+import { now } from '../utils/time';
+import type { RunLintResult } from './run-lint';
 import { runLint } from './run-lint';
 
-export const handleFixMode = (
+interface RunFixLoopOptions {
+  runRound: (
+    markdown: string,
+    rules: LintMdRuleWithOptions[],
+    round: number
+  ) => RunLintResult
+  now: () => number
+  maxRounds: number
+}
+
+interface FixLoopResult {
+  lintResult: RunLintResult
+  fixedResult: FixedResult
+  executionErrors: RuleExecutionError[]
+}
+
+export const runFixLoop = (
   markdown: string,
   rules: LintMdRuleWithOptions[],
-  policy: 'collect' | 'strict' = 'collect'
-) => {
-  let lintTimes = 0;
-  let initialLintResult = {} as ReturnType<typeof runLint>;
+  options: RunFixLoopOptions
+): FixLoopResult => {
+  const { runRound, now: readTime, maxRounds } = options;
 
-  // 聚合所有 fix 轮次的规则执行错误（lint-only 恒为 0 轮）；严格模式下任一失败即抛 RuleExecutionFailure。
-  const allExecutionErrors: ReturnType<typeof runLint>['executionErrors'] = [];
+  if (!Number.isInteger(maxRounds) || maxRounds < 1) {
+    throw new TypeError('[lint-md] maxRounds must be a positive integer');
+  }
 
+  let rounds = 0;
+  let initialLintResult!: RunLintResult;
+  const executionErrors: RuleExecutionError[] = [];
   let current = markdown;
   let lastNotAppliedFixes: NotAppliedFix[] = [];
-
-  // 记录已处理过的文本状态，用于检测振荡循环（如 A -> B -> A）。
   const seenTexts = new Set<string>();
   let convergence: FixConvergence | undefined;
-
-  // 性能基线：记录每一轮完整 wall time（parse + AST 遍历 + 规则执行 + applyFix）。
   const perRound: number[] = [];
-  const startAll = performance.now();
+  const startAll = readTime();
 
-  while (lintTimes < MAX_LINT_AND_FIX_CALL_TIMES) {
-    const roundStart = performance.now();
-
-    // 记录本轮输入文本，供后续判断是否回到历史状态。
+  while (rounds < maxRounds) {
+    const roundStart = readTime();
     seenTexts.add(current);
 
-    const lintResult = runLint(current, rules, {
-      ruleErrorPolicy: policy,
-      round: lintTimes,
-      computeFixes: true
-    });
+    const lintResult = runRound(current, rules, rounds);
 
-    if (lintTimes === 0) {
+    if (rounds === 0) {
       initialLintResult = lintResult;
     }
 
-    lintTimes++;
+    rounds++;
+    executionErrors.push(...lintResult.executionErrors);
 
-    const { fixes } = lintResult;
-
-    // The round result includes create, selector, and fix errors.
-    allExecutionErrors.push(...lintResult.executionErrors);
-
-    // 无 fix 可应用 => 正常收敛。
-    if (!fixes.length) {
-      perRound.push(performance.now() - roundStart);
+    if (!lintResult.fixes.length) {
       convergence = FixConvergence.STABLE;
-      break;
+    }
+    else {
+      const nextFixedResult = applyFix(current, [...lintResult.fixes]);
+      lastNotAppliedFixes = nextFixedResult.notAppliedFixes;
+
+      if (nextFixedResult.result === current) {
+        convergence = FixConvergence.STABLE;
+      }
+      else {
+        current = nextFixedResult.result;
+
+        if (seenTexts.has(current)) {
+          convergence = FixConvergence.CYCLE_DETECTED;
+        }
+      }
     }
 
-    const nextFixedResult = applyFix(current, fixes);
+    perRound.push(readTime() - roundStart);
 
-    // 仅保留最后一轮 applyFix 返回的 notAppliedFixes
-    // 不跨轮累积：不同轮次的 fix range 基于各自输入文本，跨轮混用会导致 range 失效
-    lastNotAppliedFixes = nextFixedResult.notAppliedFixes;
-
-    // 文本不再变化 => 正常收敛（即便该轮存在冲突未应用的 fix）。
-    if (nextFixedResult.result === current) {
-      perRound.push(performance.now() - roundStart);
-      convergence = FixConvergence.STABLE;
+    if (convergence) {
       break;
     }
-
-    current = nextFixedResult.result;
-
-    // 文本回到了某个已处理过的状态 => 检测到循环，提前停止。
-    // 放在文本不变判断之后，自替换规则仍归类为 STABLE。
-    if (seenTexts.has(current)) {
-      perRound.push(performance.now() - roundStart);
-      convergence = FixConvergence.CYCLE_DETECTED;
-      break;
-    }
-
-    perRound.push(performance.now() - roundStart);
   }
 
-  // 走到上限仍未收敛 => 被截断。
-  if (!convergence) {
-    convergence = FixConvergence.MAX_ROUNDS;
-  }
-
-  const fixedResult = {
+  const fixedResult: FixedResult = {
     result: current,
     notAppliedFixes: lastNotAppliedFixes,
-    convergence,
-    rounds: lintTimes,
+    convergence: convergence ?? FixConvergence.MAX_ROUNDS,
+    rounds,
     metrics: {
-      rounds: lintTimes,
-      wallTime: performance.now() - startAll,
+      rounds,
+      wallTime: readTime() - startAll,
       perRound
-    } as FixMetrics
+    }
   };
 
   return {
     lintResult: initialLintResult,
     fixedResult,
-    executionErrors: allExecutionErrors
+    executionErrors
   };
 };
+
+export const handleFixMode = (
+  markdown: string,
+  rules: LintMdRuleWithOptions[],
+  policy: 'collect' | 'strict' = 'collect'
+): FixLoopResult => runFixLoop(markdown, rules, {
+  runRound: (current, currentRules, round) => runLint(current, currentRules, {
+    ruleErrorPolicy: policy,
+    round,
+    computeFixes: true
+  }),
+  now,
+  maxRounds: MAX_LINT_AND_FIX_CALL_TIMES
+});


### PR DESCRIPTION
## Summary

- Add the injectable `runFixLoop()` state machine.
- Inject the round runner, clock, and round limit.
- Keep `handleFixMode()` as the production adapter.
- Replace parser-heavy convergence tests with synthetic round tests.
- Keep focused tests for production adapter wiring.

## Reason

`handleFixMode()` mixed convergence state with production dependencies.

Tests had to construct real parser behavior for each state transition.

The new seam keeps convergence rules in one module.

## Compatibility and impact

The `handleFixMode()` interface remains unchanged.

The package root API remains unchanged.

`lintMarkdown()` and `fixMarkdown()` return the same result shapes.

The state machine copies fix arrays before sorting them.

This prevents mutation of round adapter results.

## Validation

- `npm test -- --runInBand`: 46 suites and 397 tests passed.
- `npm run lint`: passed.
- `npm run typecheck`: passed.
- `npm run typecheck:tests`: passed.
- `npm run build`: passed.
- `npm run api:check`: passed.
- `npm run package-contract`: passed.
- `npm run smoke-test`: passed.
- `git diff --check`: passed.

Closes #249
