### PR TITLE
chore(parser): update parser to 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "chinese"
   ],
   "dependencies": {
-    "@lint-md/parser": "~0.2.0"
+    "@lint-md/parser": "~0.2.1"
   },
   "devDependencies": {
     "@attachments/eslint-config": "^0.3.3",


### PR DESCRIPTION
## Summary
- update `@lint-md/parser` from `0.2.0` to `0.2.1`
- keep the dependency range aligned with the new upstream release

## Verification
- `npm run typecheck`
- `npm run typecheck:tests`
- `npm run build`
- `npm test -- --runInBand`

The existing lint baseline still reports unrelated repository errors.