### PR TITLE
chore(release): prepare 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [2.3.1](https://github.com/lint-md/lint-md/compare/v2.3.0...v2.3.1) - 2026-08-10
+
+### Chores
+
+- **parser**: update `@lint-md/parser` to 0.2.1
+
 ### Refactoring
 
 - **run-lint**: return reports, fixes, execution errors, and fallback metrics as one round result

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lint-md/core",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Core of lint-md which used to lint your markdown file for Chinese.",
   "main": "lib/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
## Summary
- bump `@lint-md/core` from `2.3.0` to `2.3.1`
- record the `@lint-md/parser` 0.2.1 update in the changelog

## Verification
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:tests`
- `npm run build`
- `npm run package-contract`
- `npm run api:check`
- `npm test -- --runInBand`
- `npm pack --dry-run`