### PR TITLE
fix(fix-mode): clear obsolete unapplied fixes

### DIFF
--- a/__tests__/unit/core.spec.ts
+++ b/__tests__/unit/core.spec.ts
@@ -176,7 +176,7 @@ Some **importance**, and \`code\`.
               message: 'to X',
               fix: () => ({
                 range: [node.position.start.offset, node.position.end.offset],
-                text: 'X'
+                text: 'abc'
               })
             });
           }
@@ -209,7 +209,7 @@ Some **importance**, and \`code\`.
     );
 
     expect(res.fixedResult).not.toBeNull();
-    expect(res.fixedResult!.result).toBe('X');
+    expect(res.fixedResult!.result).toBe('abc');
     const unappliedFix: NotAppliedFix = res.fixedResult!.notAppliedFixes[0];
     expect(unappliedFix).toStrictEqual({
       range: [0, 3],

--- a/__tests__/unit/fix-markdown.spec.ts
+++ b/__tests__/unit/fix-markdown.spec.ts
@@ -22,6 +22,13 @@ describe('fixMarkdown', () => {
     expect(result.fixableErrorCount).toBe(1);
   });
 
+  test('removes obsolete conflicts after another fix resolves the lint finding', () => {
+    const result = fixMarkdown('### 问题:\n');
+
+    expect(result.fixedResult.result).toBe('### 问题\n');
+    expect(result.fixedResult.notAppliedFixes).toEqual([]);
+  });
+
   test('forwards the strict rule error policy', () => {
     const throwingRule: LintMdRule = {
       meta: { name: 'throwing-rule' },

--- a/__tests__/unit/run-fix-loop.spec.ts
+++ b/__tests__/unit/run-fix-loop.spec.ts
@@ -168,7 +168,7 @@ describe('runFixLoop', () => {
     expect(fixes.map(fix => fix.targetRule)).toStrictEqual(['same', 'conflict']);
   });
 
-  test('keeps only conflicts from the last fix-bearing round', () => {
+  test('clears conflicts when a later round has no fixes', () => {
     const oldConflict = makeFix('X', [0, 1], 'old-conflict');
     const newConflict = makeFix('Y', [0, 1], 'new-conflict');
     const rounds = [
@@ -183,10 +183,7 @@ describe('runFixLoop', () => {
       maxRounds: 5
     });
 
-    expect(result.fixedResult.notAppliedFixes).toStrictEqual([{
-      ...newConflict,
-      reason: FixNotAppliedReason.OVERLAP
-    }]);
+    expect(result.fixedResult.notAppliedFixes).toStrictEqual([]);
   });
 
   test('does not reorder fixes returned by the round adapter', () => {

--- a/src/core/handle-fix-mode.ts
+++ b/src/core/handle-fix-mode.ts
@@ -62,6 +62,7 @@ export const runFixLoop = (
     executionErrors.push(...lintResult.executionErrors);
 
     if (!lintResult.fixes.length) {
+      lastNotAppliedFixes = [];
       convergence = FixConvergence.STABLE;
     }
     else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -296,7 +296,7 @@ export interface FixedResult {
   /** 修复后的完整 Markdown 文本 */
   result: string
   /**
-   * Fixes that conflict during the final fix round.
+   * Fixes that still conflict when the fix loop stops.
    * Each range uses the input coordinates from that round.
    * A range is not guaranteed to apply directly to result.
    */


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

- Clear stale `notAppliedFixes` when the next fix round reports no fixes.
- Keep conflicts when the loop stops in the same fix-bearing round.
- Add a regression test for overlapping heading punctuation fixes.
- Update the `FixedResult.notAppliedFixes` description.

## Verification

- `npm test -- --runInBand`
- `npm run lint`
- `git diff --check`

Closes #254