### PR TITLE
chore(release): prepare 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [2.3.2](https://github.com/lint-md/lint-md/compare/v2.3.1...v2.3.2) - 2026-08-10
+
+### Bug Fixes
+
+- **fix-mode**: clear obsolete unapplied fixes after a clean fix round (#255)
+
 ## [2.3.1](https://github.com/lint-md/lint-md/compare/v2.3.0...v2.3.1) - 2026-08-10
 
 ### Chores

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lint-md/core",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Core of lint-md which used to lint your markdown file for Chinese.",
   "main": "lib/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
## Summary

- Bump `@lint-md/core` to `2.3.2`.
- Add the `2.3.2` changelog entry for the fix from PR #255.

## Verification

- `npm run prepublishOnly`
- `npm pack --dry-run --json`
- `git diff --check`