### PR TITLE
ci: create GitHub Release for version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            --verify-tag


### PR DESCRIPTION
## What changed

- Add a workflow for pushed `v*` tags.
- Create a GitHub Release for each matching tag.
- Generate release notes and verify the tag.

## Why

Version tags currently do not create GitHub Releases automatically.

## Impact

Maintainers can push a version tag to create its GitHub Release.
This change does not publish the npm package.

## Checks

- `actionlint .github/workflows/release.yml`
- `git diff --check`

Closes #257