### PR TITLE
feat(types): add complete source range to LintDiagnostic

### DIFF
--- a/__tests__/unit/diagnostic-range.spec.ts
+++ b/__tests__/unit/diagnostic-range.spec.ts
@@ -1,5 +1,5 @@
 import { fixMarkdown, lintMarkdown } from '../../src';
-import type { LintDiagnostic, LintMdRule, PositionedMarkdownNode, SourceRange } from '../../src/types';
+import type { LintDiagnostic, LintMdRule, PositionedMarkdownNode } from '../../src/types';
 
 /**
  * 按文档坐标语义（\r\n 记为一个换行、行首指向 \n 之后）独立重算位置，
@@ -40,7 +40,12 @@ function positionOf(text: string, offset: number): { line: number; column: numbe
 function expectCompleteRanges(markdown: string, diagnostics: LintDiagnostic[]): void {
   expect(diagnostics.length).toBeGreaterThan(0);
   for (const diagnostic of diagnostics) {
+    // core 输出运行时恒有 range；类型可选仅为 2.x 构造兼容。
     const { range } = diagnostic;
+    expect(range).toBeDefined();
+    if (!range) {
+      throw new TypeError('core diagnostics must always populate range');
+    }
     expect(Number.isInteger(range.start.offset)).toBe(true);
     expect(Number.isInteger(range.end.offset)).toBe(true);
     expect(range.start.offset).toBeGreaterThanOrEqual(0);
@@ -88,10 +93,14 @@ describe('LintDiagnostic source range (#190)', () => {
     const result = lintMarkdown(markdown, { wholeDocumentRange: [wholeDocumentRule, 2, {}] }, false);
     expect(result.diagnostics).toHaveLength(1);
 
-    const range: SourceRange = result.diagnostics[0].range;
-    expect(range.start).toEqual({ line: 1, column: 1, offset: 0 });
-    expect(range.end.offset).toBe(markdown.length);
-    expect(range.end.line).toBeGreaterThan(range.start.line);
+    const wholeDocRange = result.diagnostics[0].range;
+    expect(wholeDocRange).toBeDefined();
+    if (!wholeDocRange) {
+      throw new TypeError('core diagnostics must always populate range');
+    }
+    expect(wholeDocRange.start).toEqual({ line: 1, column: 1, offset: 0 });
+    expect(wholeDocRange.end.offset).toBe(markdown.length);
+    expect(wholeDocRange.end.line).toBeGreaterThan(wholeDocRange.start.line);
   });
 
   test('offsets follow UTF-16 indexing for astral characters', () => {
@@ -116,11 +125,15 @@ describe('LintDiagnostic source range (#190)', () => {
     );
     expect(result.diagnostics).toHaveLength(1);
 
-    const { range } = result.diagnostics[0];
-    expect(range.start.offset).toBe(emojiWidth);
-    expect(range.end.offset).toBe(emojiWidth + 2);
-    expect(markdown.slice(range.start.offset, range.end.offset)).toBe('中文');
-    expect(range.start.column).toBe(5); // 两个 emoji 各占 2 列后指向第 5 列
+    const markerRange = result.diagnostics[0].range;
+    expect(markerRange).toBeDefined();
+    if (!markerRange) {
+      throw new TypeError('core diagnostics must always populate range');
+    }
+    expect(markerRange.start.offset).toBe(emojiWidth);
+    expect(markerRange.end.offset).toBe(emojiWidth + 2);
+    expect(markdown.slice(markerRange.start.offset, markerRange.end.offset)).toBe('中文');
+    expect(markerRange.start.column).toBe(5); // 两个 emoji 各占 2 列后指向第 5 列
     expectCompleteRanges(markdown, result.diagnostics);
   });
 
@@ -144,8 +157,12 @@ describe('LintDiagnostic source range (#190)', () => {
     const result = lintMarkdown(markdown, { syntheticNoOffset: [syntheticRule, 2, {}] }, false);
     expect(result.diagnostics).toHaveLength(1);
 
-    const { range } = result.diagnostics[0];
-    expect(markdown.slice(range.start.offset, range.end.offset)).toBe('**加粗 中文**');
+    const syntheticRange = result.diagnostics[0].range;
+    expect(syntheticRange).toBeDefined();
+    if (!syntheticRange) {
+      throw new TypeError('core diagnostics must always populate range');
+    }
+    expect(markdown.slice(syntheticRange.start.offset, syntheticRange.end.offset)).toBe('**加粗 中文**');
     expectCompleteRanges(markdown, result.diagnostics);
   });
 
@@ -162,11 +179,57 @@ describe('LintDiagnostic source range (#190)', () => {
     for (let i = 0; i < result.diagnostics.length; i++) {
       const diagnostic = result.diagnostics[i];
       const item = result.lintResult[i];
+      expect(diagnostic.range).toBeDefined();
+      if (!diagnostic.range) {
+        throw new TypeError('core diagnostics must always populate range');
+      }
       const expected = markdown.slice(
         Math.max(0, diagnostic.range.start.offset - 5),
         Math.min(markdown.length, diagnostic.range.end.offset + 5)
       );
       expect(item.content).toBe(expected);
     }
+  });
+
+  test('contradictory loc line/column loses to offset-derived canonical range', () => {
+    const markdown = '中文English 123';
+    const contradictoryRule: LintMdRule = {
+      meta: { name: 'contradictory-loc' },
+      create: context => ({
+        root: () => context.report({
+          loc: {
+            start: { line: 99, column: 99, offset: 0 },
+            end: { line: 99, column: 100, offset: 1 }
+          },
+          message: 'contradictory coordinates'
+        })
+      })
+    };
+
+    const result = lintMarkdown(
+      markdown,
+      {
+        'space-around-alphabet': 0,
+        'space-around-number': 0,
+        'contradictoryLoc': [contradictoryRule, 2, {}]
+      },
+      false
+    );
+    expect(result.diagnostics).toHaveLength(1);
+
+    const diagnostic = result.diagnostics[0];
+    // offsets 合法即权威：range 从 offset 推导，line/column 与 range.start 同源。
+    expect(diagnostic.range).toEqual({
+      start: { line: 1, column: 1, offset: 0 },
+      end: { line: 1, column: 2, offset: 1 }
+    });
+    expect(diagnostic.line).toBe(1);
+    expect(diagnostic.column).toBe(1);
+    expect(diagnostic.line).toBe(diagnostic.range!.start.line);
+    expect(diagnostic.column).toBe(diagnostic.range!.start.column);
+
+    // 兼容投影 lintResult.loc 保持规则原始上报值，透传契约不变。
+    expect(result.lintResult[0].loc.start.line).toBe(99);
+    expect(result.lintResult[0].loc.start.column).toBe(99);
   });
 });

--- a/__tests__/unit/diagnostic-range.spec.ts
+++ b/__tests__/unit/diagnostic-range.spec.ts
@@ -1,0 +1,172 @@
+import { fixMarkdown, lintMarkdown } from '../../src';
+import type { LintDiagnostic, LintMdRule, PositionedMarkdownNode, SourceRange } from '../../src/types';
+
+/**
+ * 按文档坐标语义（\r\n 记为一个换行、行首指向 \n 之后）独立重算位置，
+ * 与 src/utils/source-code.ts 的 buildLineStarts / offsetToPosition 契约一致。
+ */
+function positionOf(text: string, offset: number): { line: number; column: number } {
+  const lineStarts = [0];
+  for (let i = 0; i < text.length;) {
+    const code = text.charCodeAt(i);
+    if (code === 13 && text.charCodeAt(i + 1) === 10) {
+      lineStarts.push(i + 2);
+      i += 2;
+    }
+    else if (code === 13 || code === 10) {
+      lineStarts.push(i + 1);
+      i += 1;
+    }
+    else {
+      i += 1;
+    }
+  }
+
+  let low = 0;
+  let high = lineStarts.length;
+  while (low < high) {
+    const mid = (low + high) >> 1;
+    if (lineStarts[mid] <= offset) {
+      low = mid + 1;
+    }
+    else {
+      high = mid;
+    }
+  }
+  return { line: low, column: offset - lineStarts[low - 1] + 1 };
+}
+
+/** 断言每条诊断的 range 完整、有序、越界安全，且 line/column 与 offset 互相一致。 */
+function expectCompleteRanges(markdown: string, diagnostics: LintDiagnostic[]): void {
+  expect(diagnostics.length).toBeGreaterThan(0);
+  for (const diagnostic of diagnostics) {
+    const { range } = diagnostic;
+    expect(Number.isInteger(range.start.offset)).toBe(true);
+    expect(Number.isInteger(range.end.offset)).toBe(true);
+    expect(range.start.offset).toBeGreaterThanOrEqual(0);
+    expect(range.start.offset).toBeLessThanOrEqual(range.end.offset);
+    expect(range.end.offset).toBeLessThanOrEqual(markdown.length);
+
+    expect(range.start.line).toBe(positionOf(markdown, range.start.offset).line);
+    expect(range.start.column).toBe(positionOf(markdown, range.start.offset).column);
+    expect(range.end.line).toBe(positionOf(markdown, range.end.offset).line);
+    expect(range.end.column).toBe(positionOf(markdown, range.end.offset).column);
+
+    // 兼容字段必须与 range.start 同源，不允许两套坐标并存漂移。
+    expect(diagnostic.line).toBe(range.start.line);
+    expect(diagnostic.column).toBe(range.start.column);
+  }
+}
+
+describe('LintDiagnostic source range (#190)', () => {
+  test('every diagnostic carries a complete range consistent with offsets (LF)', () => {
+    const markdown = ['中文English 混排', '', '第二段有123数字和English结尾。'].join('\n');
+    const result = lintMarkdown(markdown, {}, false);
+    expectCompleteRanges(markdown, result.diagnostics);
+  });
+
+  test('ranges stay consistent under CRLF line endings', () => {
+    const markdown = ['中文English 混排', '第二行123数字'].join('\r\n');
+    const result = lintMarkdown(markdown, {}, false);
+    expectCompleteRanges(markdown, result.diagnostics);
+  });
+
+  test('multiline report spans lines with matching start/end positions', () => {
+    const markdown = '# 中文 title\n\n段落一 内容。\n\n段落二 tail。';
+    const wholeDocumentRule: LintMdRule = {
+      meta: { name: 'whole-document-range' },
+      create: context => ({
+        root: (node: PositionedMarkdownNode) => {
+          context.report({
+            range: [node.position.start.offset, node.position.end.offset],
+            message: 'whole document'
+          });
+        }
+      })
+    };
+
+    const result = lintMarkdown(markdown, { wholeDocumentRange: [wholeDocumentRule, 2, {}] }, false);
+    expect(result.diagnostics).toHaveLength(1);
+
+    const range: SourceRange = result.diagnostics[0].range;
+    expect(range.start).toEqual({ line: 1, column: 1, offset: 0 });
+    expect(range.end.offset).toBe(markdown.length);
+    expect(range.end.line).toBeGreaterThan(range.start.line);
+  });
+
+  test('offsets follow UTF-16 indexing for astral characters', () => {
+    const markdown = '🎉🎉中文abc';
+    const emojiWidth = 4; // 两个代理对，各占 2 个 UTF-16 单元
+    const markerRule: LintMdRule = {
+      meta: { name: 'astral-marker' },
+      create: context => ({
+        root: () => {
+          context.report({
+            range: [emojiWidth, emojiWidth + 2],
+            message: 'chinese span after astral characters'
+          });
+        }
+      })
+    };
+
+    const result = lintMarkdown(
+      markdown,
+      { 'space-around-alphabet': 0, 'astralMarker': [markerRule, 2, {}] },
+      false
+    );
+    expect(result.diagnostics).toHaveLength(1);
+
+    const { range } = result.diagnostics[0];
+    expect(range.start.offset).toBe(emojiWidth);
+    expect(range.end.offset).toBe(emojiWidth + 2);
+    expect(markdown.slice(range.start.offset, range.end.offset)).toBe('中文');
+    expect(range.start.column).toBe(5); // 两个 emoji 各占 2 列后指向第 5 列
+    expectCompleteRanges(markdown, result.diagnostics);
+  });
+
+  test('synthetic loc without offsets still yields a complete resolved range', () => {
+    const markdown = '前置文本 **加粗 中文** 后置文本';
+    const syntheticRule: LintMdRule = {
+      meta: { name: 'synthetic-no-offset' },
+      create: context => ({
+        strong: (node) => {
+          context.report({
+            loc: {
+              start: { line: node.position.start.line, column: node.position.start.column },
+              end: { line: node.position.end.line, column: node.position.end.column }
+            },
+            message: 'report without offsets'
+          });
+        }
+      })
+    };
+
+    const result = lintMarkdown(markdown, { syntheticNoOffset: [syntheticRule, 2, {}] }, false);
+    expect(result.diagnostics).toHaveLength(1);
+
+    const { range } = result.diagnostics[0];
+    expect(markdown.slice(range.start.offset, range.end.offset)).toBe('**加粗 中文**');
+    expectCompleteRanges(markdown, result.diagnostics);
+  });
+
+  test('fix-mode diagnostics carry ranges valid against the original input', () => {
+    const markdown = '中文English 123';
+    const result = fixMarkdown(markdown, { rules: {} });
+    expectCompleteRanges(markdown, result.diagnostics);
+  });
+
+  test('range aligns with the content excerpt window', () => {
+    const markdown = '中文English 123';
+    const result = lintMarkdown(markdown, {}, false);
+
+    for (let i = 0; i < result.diagnostics.length; i++) {
+      const diagnostic = result.diagnostics[i];
+      const item = result.lintResult[i];
+      const expected = markdown.slice(
+        Math.max(0, diagnostic.range.start.offset - 5),
+        Math.min(markdown.length, diagnostic.range.end.offset + 5)
+      );
+      expect(item.content).toBe(expected);
+    }
+  });
+});

--- a/__tests__/unit/diagnostics.spec.ts
+++ b/__tests__/unit/diagnostics.spec.ts
@@ -47,21 +47,10 @@ describe('diagnostics', () => {
   });
 
   describe('toALEOutput()', () => {
-    test('formats diagnostics in ALE-compatible format', () => {
-      const range = {
-        start: { line: 1, column: 3, offset: 2 },
-        end: { line: 1, column: 10, offset: 9 }
-      };
+    test('accepts legacy literals without range (2.x construction compat)', () => {
       const diagnostics: LintDiagnostic[] = [
-        { line: 1, column: 3, range, ruleId: 'space-around-alphabet', message: '中英文之间需要添加空格', severity: 2 },
-        {
-          line: 1,
-          column: 12,
-          range: { start: { line: 1, column: 12, offset: 11 }, end: { line: 1, column: 15, offset: 14 } },
-          ruleId: 'space-around-number',
-          message: '中文与数字之间需要添加空格',
-          severity: 1
-        }
+        { line: 1, column: 3, ruleId: 'space-around-alphabet', message: '中英文之间需要添加空格', severity: 2 },
+        { line: 1, column: 12, ruleId: 'space-around-number', message: '中文与数字之间需要添加空格', severity: 1 }
       ];
       const output = toALEOutput(diagnostics, '/tmp/test.md');
 

--- a/__tests__/unit/diagnostics.spec.ts
+++ b/__tests__/unit/diagnostics.spec.ts
@@ -48,9 +48,20 @@ describe('diagnostics', () => {
 
   describe('toALEOutput()', () => {
     test('formats diagnostics in ALE-compatible format', () => {
+      const range = {
+        start: { line: 1, column: 3, offset: 2 },
+        end: { line: 1, column: 10, offset: 9 }
+      };
       const diagnostics: LintDiagnostic[] = [
-        { line: 1, column: 3, ruleId: 'space-around-alphabet', message: '中英文之间需要添加空格', severity: 2 },
-        { line: 1, column: 12, ruleId: 'space-around-number', message: '中文与数字之间需要添加空格', severity: 1 }
+        { line: 1, column: 3, range, ruleId: 'space-around-alphabet', message: '中英文之间需要添加空格', severity: 2 },
+        {
+          line: 1,
+          column: 12,
+          range: { start: { line: 1, column: 12, offset: 11 }, end: { line: 1, column: 15, offset: 14 } },
+          ruleId: 'space-around-number',
+          message: '中文与数字之间需要添加空格',
+          severity: 1
+        }
       ];
       const output = toALEOutput(diagnostics, '/tmp/test.md');
 

--- a/__tests__/unit/run-fix-loop.spec.ts
+++ b/__tests__/unit/run-fix-loop.spec.ts
@@ -37,6 +37,10 @@ const makeReport = (message: string): RunLintReport => ({
     start: { line: 1, column: 1, offset: 0 },
     end: { line: 1, column: 2, offset: 1 }
   },
+  range: {
+    start: { line: 1, column: 1, offset: 0 },
+    end: { line: 1, column: 2, offset: 1 }
+  },
   severity: RULE_SEVERITY.ERROR
 });
 

--- a/etc/core.api.md
+++ b/etc/core.api.md
@@ -89,7 +89,7 @@ export interface LintDiagnostic {
     // (undocumented)
     message: string;
     // (undocumented)
-    range: SourceRange;
+    range?: SourceRange;
     // (undocumented)
     ruleId: string;
     // (undocumented)

--- a/etc/core.api.md
+++ b/etc/core.api.md
@@ -89,6 +89,8 @@ export interface LintDiagnostic {
     // (undocumented)
     message: string;
     // (undocumented)
+    range: SourceRange;
+    // (undocumented)
     ruleId: string;
     // (undocumented)
     severity: RULE_SEVERITY;
@@ -412,6 +414,14 @@ export { SourceMapConsistencyError }
 export { SourceMapError }
 
 export { SourceMapUnavailableError }
+
+// @public (undocumented)
+export interface SourceRange {
+    // (undocumented)
+    end: MarkdownPosition;
+    // (undocumented)
+    start: MarkdownPosition;
+}
 
 // @public (undocumented)
 export const spaceAroundAlphabet: LintMdRule;

--- a/src/core/lint-markdown.ts
+++ b/src/core/lint-markdown.ts
@@ -85,9 +85,10 @@ const buildLintResult = (
     };
   });
 
-  const diagnostics = reportDataWithSeverity.map(item => ({
+  const diagnostics = reportData.map(item => ({
     line: item.loc.start.line,
     column: item.loc.start.column,
+    range: item.range,
     ruleId: item.name,
     message: item.message,
     severity: item.severity

--- a/src/core/lint-markdown.ts
+++ b/src/core/lint-markdown.ts
@@ -85,9 +85,11 @@ const buildLintResult = (
     };
   });
 
+  // line/column 从规范 range 取值而非透传 item.loc：
+  // 规则可能上报与 offset 矛盾的 loc，range 才是与 content / fix 同一坐标系的权威。
   const diagnostics = reportData.map(item => ({
-    line: item.loc.start.line,
-    column: item.loc.start.column,
+    line: item.range.start.line,
+    column: item.range.start.column,
     range: item.range,
     ruleId: item.name,
     message: item.message,

--- a/src/core/run-lint.ts
+++ b/src/core/run-lint.ts
@@ -5,7 +5,8 @@ import type {
   RuleExecutionError,
   RuleFixConfig,
   RuleSelector,
-  RunLintOptions
+  RunLintOptions,
+  SourceRange
 } from '../types.js';
 import { RULE_SEVERITY } from '../types.js';
 import { traverseMarkdown } from '../utils/traverser.js';
@@ -31,6 +32,8 @@ interface RegisteredSelector {
 
 export interface RunLintReport extends ReportOption {
   severity: number
+  /** 从解析后 offset 推导的规范区间（#190），与 content / fix 使用同一坐标系 */
+  range: SourceRange
 }
 
 export interface RunLintResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,14 @@ export type PositionedMarkdownRoot = ParserPositionedMarkdownRoot;
 /** 节点单个位置点（line / column / offset 全部必填 number） */
 export type MarkdownPosition = ParsedPoint;
 
+/** 完整源码区间，语义为 [start.offset, end.offset)；offset 为权威坐标，line / column 由 offset 推导 */
+export interface SourceRange {
+  /** 起点位置（含） */
+  start: MarkdownPosition
+  /** 终点位置（offset 为排除端，即该 offset 处的字符不属于区间） */
+  end: MarkdownPosition
+}
+
 /** 上报位置点（line / column 必填，offset 可选） */
 export interface ReportPosition {
   line: number
@@ -210,10 +218,12 @@ export type RegisteredRules = Record<string, LintMdRuleWithOptions & { severity:
 
 /** 标准诊断格式，供各集成平台消费 */
 export interface LintDiagnostic {
-  /** 行号（1-indexed） */
+  /** 行号（1-indexed）。等价于 range.start.line，保留以兼容既有消费方 */
   line: number
-  /** 列号（1-indexed） */
+  /** 列号（1-indexed）。等价于 range.start.column，保留以兼容既有消费方 */
   column: number
+  /** 完整源码区间（#190）：offset 为权威坐标，语义 [start.offset, end.offset) */
+  range: SourceRange
   /** 规则名 */
   ruleId: string
   /** 诊断消息 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,12 +218,17 @@ export type RegisteredRules = Record<string, LintMdRuleWithOptions & { severity:
 
 /** 标准诊断格式，供各集成平台消费 */
 export interface LintDiagnostic {
-  /** 行号（1-indexed）。等价于 range.start.line，保留以兼容既有消费方 */
+  /** 行号（1-indexed）。core 输出中与 range.start.line 同源 */
   line: number
-  /** 列号（1-indexed）。等价于 range.start.column，保留以兼容既有消费方 */
+  /** 列号（1-indexed）。core 输出中与 range.start.column 同源 */
   column: number
-  /** 完整源码区间（#190）：offset 为权威坐标，语义 [start.offset, end.offset) */
-  range: SourceRange
+  /**
+   * 完整源码区间（#190）：offset 为权威坐标，语义 [start.offset, end.offset)。
+   * core 返回的诊断运行时恒有此字段；类型上可选是为让 2.x 手工构造
+   * （如测试里组装 toALEOutput 入参）的代码在 minor 升级后仍可编译，
+   * 下一个 major 将改为必填。
+   */
+  range?: SourceRange
   /** 规则名 */
   ruleId: string
   /** 诊断消息 */

--- a/src/utils/rule-manager.ts
+++ b/src/utils/rule-manager.ts
@@ -3,12 +3,16 @@ import type {
   LintMdRuleWithOptions,
   ReportOption,
   RuleFixConfig,
-  RuleReportInput
+  RuleReportInput,
+  SourceRange
 } from '../types.js';
 import type { ReportSourceCode } from './source-code.js';
 import type { createRuleErrorCollector } from './rule-execution-errors.js';
 import { createFixer } from './fixer.js';
 import { isSourceMapError } from './source-code-errors.js';
+
+/** 内部存储的报告：loc 保留规则原始上报值，range 是从解析后 offset 推导的规范坐标 */
+type StoredReport = ReportOption & { range: SourceRange };
 
 /**
  * 初始化全局 rule 管理器
@@ -24,7 +28,7 @@ export const createRuleManager = (
   const fixer = createFixer();
 
   // 已经上报的数据
-  const allReportedData: ReportOption[] = [];
+  const allReportedData: StoredReport[] = [];
 
   // 统计触发兜底的报告数，使防御性 fallback 可观测、可收窄：
   // 计数单位是一条报告，其 start 或 end 任一 offset 缺失/非法计 1（同一报告不重复计）。
@@ -32,7 +36,7 @@ export const createRuleManager = (
 
   const getFallbackHits = () => fallbackHits;
 
-  const getReportData = () => allReportedData;
+  const getReportData = (): StoredReport[] => allReportedData;
 
   const getAllFixes = (): RuleFixConfig[] =>
     allReportedData.flatMap((item) => {
@@ -71,12 +75,23 @@ export const createRuleManager = (
         fallbackHits++;
       }
 
+      // 规范坐标从解析后的 offset 推导（#190）：offset 是唯一权威，
+      // 避免 line/column 与 content、fix 使用的区间互相矛盾。
+      // range 已归一化到 [0, text.length]。规则上报非数字坐标时 getPosition
+      // 抛 InvalidRuleRangeError，按 selector 失败进入 collector，与既有策略一致。
+      // 覆盖 spread 进来的 loc 输入形态可能携带的 range 元组，防止内部结构外泄。
+      const resolvedRange: SourceRange = {
+        start: sourceCode.getPosition(range[0]),
+        end: sourceCode.getPosition(range[1])
+      };
+
       allReportedData.push({
         ...option,
         loc,
+        range: resolvedRange,
         content: sourceCode.getContext(range),
         name: rule.meta.name
-      } as ReportOption);
+      } as StoredReport);
     };
 
     return {


### PR DESCRIPTION
Part of #190（第一步：诊断携带完整 source range）

## 改动

### 公共模型（src/types.ts）

- 新增 `SourceRange`：`{ start: MarkdownPosition; end: MarkdownPosition }`，语义 `[start.offset, end.offset)`，offset 为权威坐标，line / column 由 offset 推导。
- `LintDiagnostic` 新增 `range` 字段：**core 返回的诊断运行时恒有此字段；类型上暂时 optional**，为 2.x 手工构造诊断（如组装 `toALEOutput` 入参）的代码保留编译兼容，下一个 major 改为必填。
- `line` / `column` 保留为兼容字段；实现上从规范 range 取值（见下），与 `range.start` 同源。

### 生成路径

- `rule-manager.report()`：在归一化 offset 的基础上，经 `sourceCode.getPosition()` 推导规范区间，与 `content`、fix 使用同一坐标系；同时覆盖掉 spread 进来的内部 `range` 元组，避免泄漏。规则上报非数字坐标时按既有策略进入 collector（selector 失败）。
- `run-lint.ts`：内部 `RunLintReport` 携带 **必填** `range`（canonical 链路由类型系统强制）。
- `buildLintResult()`：diagnostics 投影出完整 range；`line` / `column` 从 `range.start` 取值而非透传规则原始 loc——规则上报与 offset 矛盾的 loc（如 `line: 99` + `offset: 0`）时以 offset 为准，并有 regression test 锁定该行为。

兼容性说明：

- `lintResult[].loc` 仍保留规则原始上报值（含 fallback 场景 offset 缺失的透传语义），由 `rule-manager-offset-fallback.spec.ts` 原有断言锁定，本 PR 不改变它。
- `toALEOutput()` 行为不变；其测试字面量保持不带 range 的原始写法并通过，作为“2.x 构造方可编译”契约的回归锁定。
- 已知折中：消费方读取 `diagnostics[0].range` 时 TypeScript 视其为可能 undefined。这是 2.x semver 兼容的代价，本 PR 不引入过渡类型，major 升级时随必填化消除。

## 测试

新增 `__tests__/unit/diagnostic-range.spec.ts`：

- 每条诊断 range 完整（整数 offset、`0 <= start <= end <= len`），且 line/column 与独立重算的位置一致
- 兼容字段 line/column 与 range.start 同源
- 矛盾 loc（line:99 + offset:0）→ range 以 offset 推导，diagnostic.line/column === range.start；`lintResult.loc` 仍透传原始值
- 多行区间 start.line < end.line
- CRLF 输入下坐标一致
- astral 字符（代理对）offset 遵循 UTF-16 索引
- 合成 loc（无 offset）仍得到完整解析后的 range
- fix 模式 diagnostics 的 range 对原始输入有效
- range 与 content 摘录窗口互相印证

全量：47 suites / 406 tests 通过；lint / typecheck / typecheck:tests / package-contract（含 packed-install）通过；etc/core.api.md 已重新生成（`range?: SourceRange`）。
