### PR TITLE
feat(diagnostics): expose diagnostic fixability

### DIFF
--- a/__tests__/unit/diagnostic-fixable.spec.ts
+++ b/__tests__/unit/diagnostic-fixable.spec.ts
@@ -1,0 +1,123 @@
+import { lintMarkdown } from '../../src';
+import type { LintDiagnostic, LintMdRule, LintMdRulesConfig } from '../../src/types';
+import { RULE_SEVERITY } from '../../src/types';
+
+const FIX_RANGE: [number, number] = [0, 1];
+
+const fixableMarkerRule: LintMdRule = {
+  meta: { name: 'fixable-marker' },
+  create: context => ({
+    root: () => context.report({
+      range: FIX_RANGE,
+      message: 'fixable finding',
+      fix: () => ({ range: FIX_RANGE, text: 'X' })
+    })
+  })
+};
+
+const plainMarkerRule: LintMdRule = {
+  meta: { name: 'plain-marker' },
+  create: context => ({
+    root: () => context.report({
+      range: FIX_RANGE,
+      message: 'finding without fix'
+    })
+  })
+};
+
+describe('LintDiagnostic.fixable (#190)', () => {
+  test('report with fix callback exposes fixable === true', () => {
+    const result = lintMarkdown(
+      '中文English',
+      { 'space-around-alphabet': 0, 'fixableMarker': [fixableMarkerRule, 2, {}] },
+      false
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].ruleId).toBe('fixable-marker');
+    expect(result.diagnostics[0].fixable).toBe(true);
+  });
+
+  test('report without fix callback exposes fixable === false', () => {
+    const result = lintMarkdown(
+      '中文English',
+      { 'space-around-alphabet': 0, 'plainMarker': [plainMarkerRule, 2, {}] },
+      false
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].fixable).toBe(false);
+  });
+
+  test('fixability holds for both ERROR and WARN severities', () => {
+    const markdown = '中文English';
+    const config = (severity: number): LintMdRulesConfig => ({
+      'space-around-alphabet': 0,
+      'fixableMarker': [fixableMarkerRule, severity, {}]
+    });
+    const errorResult = lintMarkdown(markdown, config(2), false);
+    const warnResult = lintMarkdown(markdown, config(1), false);
+
+    expect(errorResult.diagnostics[0].severity).toBe(RULE_SEVERITY.ERROR);
+    expect(errorResult.diagnostics[0].fixable).toBe(true);
+    expect(warnResult.diagnostics[0].severity).toBe(RULE_SEVERITY.WARN);
+    expect(warnResult.diagnostics[0].fixable).toBe(true);
+
+    // 顶层 counts 仍按各自独立逻辑统计，本 PR 不改变其行为。
+    expect(errorResult.fixableErrorCount).toBe(1);
+    expect(warnResult.fixableWarningCount).toBe(1);
+  });
+
+  test('lint-only mode reports fixable without executing the fix callback', () => {
+    let fixCalled = false;
+    const neverRunRule: LintMdRule = {
+      meta: { name: 'never-run-fix' },
+      create: context => ({
+        root: () => context.report({
+          range: FIX_RANGE,
+          message: 'must not run in lint-only mode',
+          fix: () => {
+            fixCalled = true;
+            throw new Error('should not execute');
+          }
+        })
+      })
+    };
+
+    const result = lintMarkdown(
+      '中文English',
+      { 'space-around-alphabet': 0, 'neverRunFix': [neverRunRule, 2, {}] },
+      false
+    );
+
+    expect(result.diagnostics[0].fixable).toBe(true);
+    expect(fixCalled).toBe(false);
+    expect(result.executionErrors).toHaveLength(0);
+  });
+
+  test('every core diagnostic carries a boolean fixable field', () => {
+    const markdown = ['中文English 混排', '', '第二段有123数字和English结尾。'].join('\n');
+    const result = lintMarkdown(markdown, {}, false);
+
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+    for (const diagnostic of result.diagnostics) {
+      expect(typeof diagnostic.fixable).toBe('boolean');
+    }
+  });
+
+  test('legacy literal without fixable still satisfies LintDiagnostic (2.x construction compat)', () => {
+    const legacy: LintDiagnostic[] = [
+      { line: 1, column: 2, ruleId: 'some-rule', message: 'legacy literal', severity: RULE_SEVERITY.WARN },
+      {
+        line: 1,
+        column: 3,
+        range: { start: { line: 1, column: 3, offset: 2 }, end: { line: 1, column: 5, offset: 4 } },
+        ruleId: 'some-rule',
+        message: 'legacy literal with range',
+        severity: RULE_SEVERITY.ERROR
+      }
+    ];
+
+    expect(legacy).toHaveLength(2);
+  });
+});

--- a/etc/core.api.md
+++ b/etc/core.api.md
@@ -85,6 +85,8 @@ export interface LintDiagnostic {
     // (undocumented)
     column: number;
     // (undocumented)
+    fixable?: boolean;
+    // (undocumented)
     line: number;
     // (undocumented)
     message: string;

--- a/src/core/lint-markdown.ts
+++ b/src/core/lint-markdown.ts
@@ -93,7 +93,10 @@ const buildLintResult = (
     range: item.range,
     ruleId: item.name,
     message: item.message,
-    severity: item.severity
+    severity: item.severity,
+    // 只反映“声明了 fix callback”；lint-only 不执行 fix（computeFixes 才会），
+    // 因此这里绝不能调用 item.fix 来探测可修复性。
+    fixable: typeof item.fix === 'function'
   }));
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,6 +235,13 @@ export interface LintDiagnostic {
   message: string
   /** 严重级别 */
   severity: RULE_SEVERITY
+  /**
+   * 该 report 是否声明了 automatic fix callback（#190）。
+   * 只表示“存在 fix”，不表示 fix 已执行：lint-only 模式不运行 fix callback。
+   * core 返回的诊断运行时恒有此字段；类型上可选的理由同 range，
+   * 下一个 major 将改为必填。
+   */
+  fixable?: boolean
 }
 
 /** fix 收敛状态：调用方据此区分“已稳定”“检测到循环”“达到上限” */


### PR DESCRIPTION
Part of #190（第二步：诊断暴露 fixability）

## 改动

### 公共模型（src/types.ts）

`LintDiagnostic` 新增 `fixable?: boolean`，沿用 #261 的 2.x 兼容策略：

- **运行时契约**：core 返回的诊断恒有此字段（内部 canonical 链路强制）
- **2.x 类型契约**：可选，手工构造诊断的代码在 minor 升级后仍可编译
- **下一个 major**：改为必填

### 语义定义

`fixable` 只表示 **该 report 声明了 automatic fix callback**：

```ts
fixable: typeof item.fix === 'function'
```

不表示 fix 已成功执行。lint-only 模式下 core 根本不执行 fix callback
（只有 `computeFixes` 才会走 `getAllFixes()`），因此这里绝不能调用
`item.fix` 来探测可修复性——那会改变 lint-only 行为并引入副作用。

### 明确不做的事

本 PR 不动 `fixableErrorCount` / `fixableWarningCount`。把 counts 改为从
canonical diagnostics 派生属于 #190 的下一阶段（LintSummary），留给后续
PR；现有独立计数逻辑原样保留并有测试锁定。

## 测试

新增 `__tests__/unit/diagnostic-fixable.spec.ts`，锁定五个契约：

1. 有 fix callback → `diagnostic.fixable === true`
2. 无 fix callback → `false`
3. ERROR / WARN severity 下均正确，且顶层 counts 行为不变
4. **lint-only 模式只报告 fixable、绝不执行 fix callback**：fix 内埋点置位 +
   抛错双保险，断言 `called === false` 且无 executionErrors
5. 手工构造不带 `fixable` / 带 range 的旧字面量仍满足 `LintDiagnostic` 类型

另有一条全默认规则跑批断言：每条诊断的 `fixable` 都是 boolean。

## 验证

48 suites / 412 tests 全绿；lint / typecheck / typecheck:tests /
package-contract（含 packed-install）通过；etc/core.api.md 已重新生成。
