### PR TITLE
feat(diagnostics): derive lint summary from diagnostics

### DIFF
--- a/__tests__/unit/lint-summary.spec.ts
+++ b/__tests__/unit/lint-summary.spec.ts
@@ -1,0 +1,106 @@
+import { lintMarkdown } from '../../src';
+import type { LintDiagnostic, LintMdRule, LintMdRulesConfig } from '../../src/types';
+import { RULE_SEVERITY } from '../../src/types';
+import { summarizeDiagnostics } from '../../src/utils/lint-summary';
+
+const FIX_RANGE: [number, number] = [0, 1];
+
+/** 每条规则只在 root 上报一次，组合出可精确预测的诊断构成。 */
+const makeMarkerRule = (name: string, fixable: boolean): LintMdRule => ({
+  meta: { name },
+  create: context => ({
+    root: () => context.report({
+      range: FIX_RANGE,
+      message: name,
+      ...(fixable ? { fix: () => ({ range: FIX_RANGE, text: 'X' }) } : {})
+    })
+  })
+});
+
+const errorFixable = makeMarkerRule('error-fixable', true);
+const errorPlain = makeMarkerRule('error-plain', false);
+const warnFixable = makeMarkerRule('warn-fixable', true);
+const warnPlain = makeMarkerRule('warn-plain', false);
+
+const MIXED_CONFIG: LintMdRulesConfig = {
+  'space-around-alphabet': 0,
+  'errorFixable': [errorFixable, RULE_SEVERITY.ERROR, {}],
+  'errorPlain': [errorPlain, RULE_SEVERITY.ERROR, {}],
+  'warnFixable': [warnFixable, RULE_SEVERITY.WARN, {}],
+  'warnPlain': [warnPlain, RULE_SEVERITY.WARN, {}]
+};
+
+describe('LintSummary derivation from diagnostics (#190)', () => {
+  test('counts ERROR / WARN / fixable buckets exactly', () => {
+    const result = lintMarkdown('中文English', MIXED_CONFIG, false);
+
+    expect(result.diagnostics).toHaveLength(4);
+    expect(result.summary).toEqual({
+      errorCount: 2,
+      warningCount: 2,
+      fixableErrorCount: 1,
+      fixableWarningCount: 1
+    });
+  });
+
+  test('non-fixable findings never enter fixable counts', () => {
+    const result = lintMarkdown(
+      '中文English',
+      { 'space-around-alphabet': 0, 'errorPlain': [errorPlain, RULE_SEVERITY.ERROR, {}] },
+      false
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].fixable).toBe(false);
+    expect(result.summary.errorCount).toBe(1);
+    expect(result.summary.warningCount).toBe(0);
+    expect(result.summary.fixableErrorCount).toBe(0);
+    expect(result.summary.fixableWarningCount).toBe(0);
+  });
+
+  test('top-level counts are exact projections of summary', () => {
+    const result = lintMarkdown('中文English', MIXED_CONFIG, false);
+
+    expect(result.summary.fixableErrorCount).toBe(result.fixableErrorCount);
+    expect(result.summary.fixableWarningCount).toBe(result.fixableWarningCount);
+  });
+
+  test('summary always equals summarizeDiagnostics(diagnostics)', () => {
+    const mixed = lintMarkdown('中文English', MIXED_CONFIG, false);
+    const defaults = lintMarkdown(['中文English 混排', '', '第二段有123数字和English结尾。'].join('\n'), {}, false);
+    const fixed = lintMarkdown('中文English', {}, false);
+
+    for (const result of [mixed, defaults, fixed]) {
+      expect(result.summary).toEqual(summarizeDiagnostics(result.diagnostics));
+    }
+  });
+
+  test('empty diagnostics produce an all-zero summary', () => {
+    const result = lintMarkdown('# Hello World\n\nThis is clean.', {}, false);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.summary).toEqual({
+      errorCount: 0,
+      warningCount: 0,
+      fixableErrorCount: 0,
+      fixableWarningCount: 0
+    });
+  });
+
+  test('summarizer ignores OFF-severity entries (defensive invariant)', () => {
+    const offEntry: LintDiagnostic = {
+      line: 1,
+      column: 1,
+      ruleId: 'off-rule',
+      message: 'should be ignored',
+      severity: RULE_SEVERITY.OFF
+    };
+
+    expect(summarizeDiagnostics([offEntry])).toEqual({
+      errorCount: 0,
+      warningCount: 0,
+      fixableErrorCount: 0,
+      fixableWarningCount: 0
+    });
+  });
+});

--- a/__tests__/unit/lint-summary.spec.ts
+++ b/__tests__/unit/lint-summary.spec.ts
@@ -1,4 +1,4 @@
-import { lintMarkdown } from '../../src';
+import { fixMarkdown, lintMarkdown } from '../../src';
 import type { LintDiagnostic, LintMdRule, LintMdRulesConfig } from '../../src/types';
 import { RULE_SEVERITY } from '../../src/types';
 import { summarizeDiagnostics } from '../../src/utils/lint-summary';
@@ -68,10 +68,14 @@ describe('LintSummary derivation from diagnostics (#190)', () => {
   test('summary always equals summarizeDiagnostics(diagnostics)', () => {
     const mixed = lintMarkdown('中文English', MIXED_CONFIG, false);
     const defaults = lintMarkdown(['中文English 混排', '', '第二段有123数字和English结尾。'].join('\n'), {}, false);
-    const fixed = lintMarkdown('中文English', {}, false);
+    // fix 模式走 handleFixMode → initialLintResult → diagnostics 的独立路径，
+    // summary 一致性契约必须同样成立。
+    const fixed = fixMarkdown('中文English', { rules: {} });
 
     for (const result of [mixed, defaults, fixed]) {
       expect(result.summary).toEqual(summarizeDiagnostics(result.diagnostics));
+      expect(result.summary.fixableErrorCount).toBe(result.fixableErrorCount);
+      expect(result.summary.fixableWarningCount).toBe(result.fixableWarningCount);
     }
   });
 

--- a/etc/core.api.md
+++ b/etc/core.api.md
@@ -140,6 +140,8 @@ export interface LintMdResultBase {
     fixableWarningCount: number;
     // (undocumented)
     lintResult: LintReportItem[];
+    // (undocumented)
+    summary: LintSummary;
 }
 
 // @public (undocumented)
@@ -211,6 +213,18 @@ export interface LintSourceCode {
     getTextRange(node: PositionedTextNode | PositionedInlineCodeNode, valueStart: number, valueEnd: number): TextRange;
     // (undocumented)
     readonly text: string;
+}
+
+// @public (undocumented)
+export interface LintSummary {
+    // (undocumented)
+    errorCount: number;
+    // (undocumented)
+    fixableErrorCount: number;
+    // (undocumented)
+    fixableWarningCount: number;
+    // (undocumented)
+    warningCount: number;
 }
 
 // @public (undocumented)

--- a/src/core/lint-markdown.ts
+++ b/src/core/lint-markdown.ts
@@ -12,6 +12,7 @@ import type {
 import * as internalRuleConfig from '../rules/index.js';
 import { DEFAULT_RULE_SEVERITIES } from '../rules/default-rule-severities.js';
 import { normalizeRuleRegistry } from '../utils/normalize-rule-registry.js';
+import { summarizeDiagnostics } from '../utils/lint-summary.js';
 import { RULE_SEVERITY } from '../types.js';
 import { runLint } from './run-lint.js';
 import { handleFixMode } from './handle-fix-mode.js';
@@ -60,21 +61,9 @@ const buildLintResult = (
 ): LintMdResult => {
   const { fixedResult, lintResult, executionErrors } = executionResult;
   const reportData = lintResult.reports;
-  let fixableErrorCount = 0;
-  let fixableWarningCount = 0;
 
   const reportDataWithSeverity: LintReportItem[] = reportData.map((item) => {
     const severity = item.severity as RULE_SEVERITY;
-
-    if (typeof item.fix === 'function') {
-      if (severity === RULE_SEVERITY.ERROR) {
-        fixableErrorCount++;
-      }
-      else if (severity === RULE_SEVERITY.WARN) {
-        fixableWarningCount++;
-      }
-    }
-
     const { loc, message, name, content } = item;
     return {
       loc,
@@ -99,12 +88,16 @@ const buildLintResult = (
     fixable: typeof item.fix === 'function'
   }));
 
+  // counts 唯一来源是 diagnostics（#190）；顶层字段只是兼容投影。
+  const summary = summarizeDiagnostics(diagnostics);
+
   return {
     lintResult: reportDataWithSeverity,
     diagnostics,
+    summary,
     fixedResult,
-    fixableErrorCount,
-    fixableWarningCount,
+    fixableErrorCount: summary.fixableErrorCount,
+    fixableWarningCount: summary.fixableWarningCount,
     executionErrors
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -341,9 +341,23 @@ export interface LintReportItem {
 }
 
 /** `lintMarkdown` 返回结果的公共部分 */
+/** 从 canonical diagnostics 派生的统计摘要（#190）；diagnostics 是唯一的 counts 来源 */
+export interface LintSummary {
+  /** severity === ERROR 的诊断数 */
+  errorCount: number
+  /** severity === WARN 的诊断数 */
+  warningCount: number
+  /** ERROR 且 fixable 的诊断数 */
+  fixableErrorCount: number
+  /** WARN 且 fixable 的诊断数 */
+  fixableWarningCount: number
+}
+
 export interface LintMdResultBase {
   lintResult: LintReportItem[]
   diagnostics: LintDiagnostic[]
+  /** 由 diagnostics 派生的统计摘要；顶层 fixable counts 是它的兼容投影 */
+  summary: LintSummary
   fixableErrorCount: number
   fixableWarningCount: number
   /**

--- a/src/utils/lint-summary.ts
+++ b/src/utils/lint-summary.ts
@@ -1,0 +1,42 @@
+import type { LintDiagnostic, LintSummary } from '../types.js';
+import { RULE_SEVERITY } from '../types.js';
+
+/**
+ * 从 canonical diagnostics 派生统计摘要（#190）。
+ *
+ * diagnostics 是 counts 的唯一来源：顶层 fixableErrorCount / fixableWarningCount
+ * 只是本函数结果的兼容投影，任何执行路径都不得独立累加 counts。
+ *
+ * invariant：正常诊断的 severity 不会是 OFF（OFF 的规则根本不会注册执行）。
+ * 防御起见，非 ERROR/WARN 的条目在这里被忽略而不是计入任何桶。
+ */
+export const summarizeDiagnostics = (
+  diagnostics: readonly LintDiagnostic[]
+): LintSummary => {
+  let errorCount = 0;
+  let warningCount = 0;
+  let fixableErrorCount = 0;
+  let fixableWarningCount = 0;
+
+  for (const diagnostic of diagnostics) {
+    if (diagnostic.severity === RULE_SEVERITY.ERROR) {
+      errorCount++;
+      if (diagnostic.fixable) {
+        fixableErrorCount++;
+      }
+    }
+    else if (diagnostic.severity === RULE_SEVERITY.WARN) {
+      warningCount++;
+      if (diagnostic.fixable) {
+        fixableWarningCount++;
+      }
+    }
+  }
+
+  return {
+    errorCount,
+    warningCount,
+    fixableErrorCount,
+    fixableWarningCount
+  };
+};


### PR DESCRIPTION
Part of #190（第三步：LintSummary + counts 从 diagnostics 派生）

## 改动

### 数据流变化

之前是双重真相：

```text
reports
 ├─→ diagnostics
 └─→ counts（独立累加循环）
```

现在是单向派生：

```text
reports
   ↓
diagnostics
   ↓
summarizeDiagnostics()
   ↓
summary → 顶层 fixableErrorCount / fixableWarningCount（兼容投影）
```

### 具体改动

| 文件 | 说明 |
|---|---|
| `src/types.ts` | 新增公共 `LintSummary { errorCount, warningCount, fixableErrorCount, fixableWarningCount }`；`LintMdResultBase.summary: LintSummary`（**必填**） |
| `src/utils/lint-summary.ts`（新增） | 纯函数 `summarizeDiagnostics(diagnostics)`，counts 的唯一计算点。invariant：诊断不会出现 OFF（OFF 规则不注册执行），防御性忽略非 ERROR/WARN 条目 |
| `src/core/lint-markdown.ts` | 删除 `buildLintResult()` 里独立的 counts 累加循环；顶层字段改为 `summary.fixableErrorCount / summary.fixableWarningCount` 的投影 |

### required vs optional

`summary` 采用 **required**：已确认仓库与官方 downstream 均只读取、不手工构造 `LintMdResult`（cli 的 `to-batch-lint-item.ts` 只消费字段），不存在构造方 break。

### 明确不做的事

- 不删除顶层 `fixableErrorCount` / `fixableWarningCount`
- 不迁移 CLI 到 `summary`
- 不动 `lintResult`
- 不做 initial/remaining diagnostics、messageId、severity enum 调整

## 测试

新增 `__tests__/unit/lint-summary.spec.ts`：

1. 精确组合场景（ERROR+fix / ERROR 无fix / WARN+fix / WARN 无fix 各一条）→ 四个桶计数全对
2. 非 fixable 不进任何 fixable 桶
3. `summary.fixableErrorCount === result.fixableErrorCount`、`summary.fixableWarningCount === result.fixableWarningCount`
4. 三种运行形态（混合自定义规则 / 全默认规则 / fix 模式）下 `summary` 恒等于 `summarizeDiagnostics(diagnostics)`
5. 空 diagnostics → 全 0
6. OFF severity 防御性忽略的直接单测

全量：49 suites / 418 tests 通过；lint / typecheck / typecheck:tests / package-contract（含 packed-install）通过；etc/core.api.md 已重新生成。
