### PR TITLE
refactor(types): deprecate legacy lint result fields

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -331,7 +331,10 @@ export interface FixedResult {
   metrics?: FixMetrics
 }
 
-/** `lintMarkdown` 返回的 lint 诊断项（带严重级别） */
+/**
+ * `lintMarkdown` 返回的 legacy 诊断项（带严重级别）。
+ * @deprecated Prefer LintDiagnostic for new integrations.
+ */
 export interface LintReportItem {
   loc: ReportOption['loc']
   message: string
@@ -354,11 +357,20 @@ export interface LintSummary {
 }
 
 export interface LintMdResultBase {
+  /**
+   * @deprecated Use diagnostics instead.
+   */
   lintResult: LintReportItem[]
   diagnostics: LintDiagnostic[]
   /** 由 diagnostics 派生的统计摘要；顶层 fixable counts 是它的兼容投影 */
   summary: LintSummary
+  /**
+   * @deprecated Use summary.fixableErrorCount.
+   */
   fixableErrorCount: number
+  /**
+   * @deprecated Use summary.fixableWarningCount.
+   */
   fixableWarningCount: number
   /**
    * 结构化根级规则执行错误数组（兼容所有返回模式：lint-only 与 fix 多轮）。


### PR DESCRIPTION
Part of #190（第四步：正式声明 legacy 字段的迁移方向）

## 改动

纯 JSDoc 标注，**零 runtime / 零签名变更**：

```ts
export interface LintMdResultBase {
  /**
   * @deprecated Use diagnostics instead.
   */
  lintResult: LintReportItem[]

  diagnostics: LintDiagnostic[]
  summary: LintSummary

  /**
   * @deprecated Use summary.fixableErrorCount.
   */
  fixableErrorCount: number

  /**
   * @deprecated Use summary.fixableWarningCount.
   */
  fixableWarningCount: number
}

/**
 * @deprecated Prefer LintDiagnostic for new integrations.
 */
export interface LintReportItem { ... }
```

IDE 中这些字段将显示删除线并提示替代项。

### 明确不做的事

- 不重建 `lintResult`（legacy 投影留给后续 PR）
- 不改 `loc` / `content`
- 不迁移 CLI
- 不删除任何字段、不改任何类型结构

`etc/core.api.md` 在本 PR 下零 diff——签名完全未动，只有文档注释变化，可据此复核"纯兼容声明"。

## 迁移路线

```text
#261 range      ✅
#262 fixable    ✅
#263 summary    ✅
#264 deprecate legacy fields   ← 本 PR
        ↓
#265 CLI migrate to diagnostics + summary
        ↓
确认官方 consumers 不再依赖 lintResult
        ↓
next major: 删除 lintResult 或改变 legacy projection 语义
```

先 deprecate 再迁 CLI 的原因：CLI 目前仍在自行从 `lintResult` 重算 counts 并重建 message 结构，与 core 的 `diagnostics + summary` 明显重复。等 #265 完成后，再考虑让 legacy 字段变成真正的投影或直接移除，比现在强行投影安全。

## 验证

418 tests / lint / typecheck / typecheck:tests 全绿；api-extractor 通过且 API report 无 diff。
