### PR TITLE
chore(release): prepare 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+## [2.4.0](https://github.com/lint-md/lint-md/compare/v2.3.2...v2.4.0) - 2026-08-22
+
+### Features
+
+- **diagnostics**: expose complete source ranges on `LintDiagnostic` (#261)
+- **diagnostics**: expose diagnostic fixability (#262)
+- **diagnostics**: add `LintSummary` derived from canonical diagnostics (#263)
+
+### Bug Fixes
+
+- **package**: make ESM build natively importable in Node.js (#260)
+
+### Refactoring
+
+- **api**: deprecate legacy lint result fields in favor of diagnostics and summary (#264)
+
 ## [2.3.2](https://github.com/lint-md/lint-md/compare/v2.3.1...v2.3.2) - 2026-08-10
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lint-md/core",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Core of lint-md which used to lint your markdown file for Chinese.",
   "main": "lib/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
Part of #190 系列。本 PR 严格只做两件事：版本号与 CHANGELOG。

## 版本判定

`2.4.0`（minor）而非 `2.3.3`：自 2.3.2 起合入的改动包含公开 API 增量，不只是 bugfix：

```text
#260 native ESM package importability
#261 LintDiagnostic.range + SourceRange（新公共类型）
#262 LintDiagnostic.fixable
#263 LintSummary + result.summary（新公共类型）
#264 legacy result 字段 @deprecated 标注
```

## 改动

- `package.json`: `"version": "2.4.0"`
- `CHANGELOG.md`: 补 2.4.0 段落（面向消费者视角，不写内部实现细节）

lockfile 在本仓库 gitignored，不随 release 提交（与 2.3.2 的 release commit 一致）。

## 验证

按既有 release contract：

```text
npm run prepublishOnly   ✅ lint / typecheck / typecheck:tests / build / package-contract / 49 suites · 418 tests
npm pack --dry-run --json ✅ @lint-md/core@2.4.0, 268 files
git diff --check          ✅
API report                ✅ 无意外变化（零 diff）
```

合并后即可发布 `@lint-md/core@2.4.0`；随后 CLI PR 以 `^2.4.0` 为真实消费基线做 diagnostics + summary 迁移。
