### PR TITLE
fix(benchmark): alias legacy core baseline dependency

### DIFF
--- a/__tests__/benchmark/lint-md.spec.ts
+++ b/__tests__/benchmark/lint-md.spec.ts
@@ -1,4 +1,6 @@
-import { fix, lint } from '@lint-md/core';
+// 0.2.2 基线经 npm alias 安装：#260 给包加了 exports 后，裸名 @lint-md/core
+// 触发 self-reference，只会解析到当前源码，benchmark 的“新旧对比”随之失效。
+import { fix, lint } from 'lint-md-core-legacy';
 import { benchMarkBetween, getExample } from '../utils/test-utils';
 import { lintMarkdown } from '../../src';
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@attachments/eslint-config": "^0.3.3",
-    "@lint-md/core": "0.2.2",
+    "lint-md-core-legacy": "npm:@lint-md/core@0.2.2",
     "@microsoft/api-extractor": "^7.58.12",
     "@types/benchmark": "^2.1.2",
     "@types/jest": "^29.2.0",


### PR DESCRIPTION
Part of #190 系列的测试基础设施修复。#260 遗留问题，master push 时 CI 暴露。

## 根因

benchmark 的“新旧对比”此前依赖一个隐藏假设：

```text
同名 devDependency @lint-md/core@0.2.2
+ 包自身没有 exports（无 self-reference）
→ import '@lint-md/core' 碰巧解析到 node_modules 里的 0.2.2
```

#260 给包加了 `exports` 之后，bare specifier 获得了 package self-reference 语义，
`import '@lint-md/core'` 只会解析到当前源码。旧 baseline 不再被加载——
如果简单在 benchmark 前加 `npm run build`，加载的也只是当前 2.4.0 自己，
对比同样失去意义（且 0.2.2 的 `fix` / `lint` API 在当前版本已不存在）。

## 修法：npm alias dependency

```jsonc
"devDependencies": {
-  "@lint-md/core": "0.2.2",
+  "lint-md-core-legacy": "npm:@lint-md/core@0.2.2",
}
```

```ts
-import { fix, lint } from '@lint-md/core';
+import { fix, lint } from 'lint-md-core-legacy';
```

语义从此明确：

```text
../../src               → 当前正在开发的 core
lint-md-core-legacy     → 固定 @lint-md/core@0.2.2 benchmark baseline
```

且不再与 self-reference 冲突。

## 验证

- `npm install` → `node_modules/lint-md-core-legacy` 为独立安装的 0.2.2，导出 `fix` / `lint`
- `npm run test:benchmark` ✅ 新旧双路径真实对比通过
- `npm run typecheck:tests` / lint / 全量 418 tests ✅

不需要回滚 2.4.0，不涉及 diagnostics 实现。
