### PR TITLE
docs(changelog): note benchmark alias fix in 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Bug Fixes
 
 - **package**: make ESM build natively importable in Node.js (#260)
+- **benchmark**: alias legacy core baseline dependency so the old-version comparison keeps working after exports were added (#266)
 
 ### Refactoring
 


### PR DESCRIPTION
Part of #190 系列。2.4.0 发版前补记 #266。

## 改动

`CHANGELOG.md` 的 2.4.0 段落 Bug Fixes 增加一行：

```md
- **benchmark**: alias legacy core baseline dependency so the old-version comparison keeps working after exports were added (#266)
```

仅文档，无代码变更；合并后即可按既有流程发布 `@lint-md/core@2.4.0`。
